### PR TITLE
Depend on a new enough json-glib to drop the compat defines

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,7 @@ dnl ---------------------------------------------------------------------------
 PKG_CHECK_MODULES(GTK, gtk+-3.0 >= 3.18.2 gio-unix-2.0 gtkspell3-3.0)
 PKG_CHECK_MODULES(APPSTREAM, appstream-glib >= 0.5.5)
 PKG_CHECK_MODULES(GDK_PIXBUF, gdk-pixbuf-2.0 >= 2.31.5)
-PKG_CHECK_MODULES(JSON_GLIB, json-glib-1.0)
+PKG_CHECK_MODULES(JSON_GLIB, json-glib-1.0 >= 1.1.1)
 PKG_CHECK_MODULES(SQLITE, sqlite3)
 PKG_CHECK_MODULES(SOUP, libsoup-2.4 >= 2.51.92)
 PKG_CHECK_MODULES(GSETTINGS_DESKTOP_SCHEMAS, gsettings-desktop-schemas >= 3.11.5)

--- a/src/plugins/gs-plugin-fedora-distro-upgrades.c
+++ b/src/plugins/gs-plugin-fedora-distro-upgrades.c
@@ -30,10 +30,6 @@
 
 #define FEDORA_PKGDB_COLLECTIONS_API_URI "https://admin.fedoraproject.org/pkgdb/api/collections/"
 
-#ifndef JsonParser_autoptr
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(JsonParser, g_object_unref)
-#endif
-
 struct GsPluginPrivate {
 	GPtrArray	*distros;
 };

--- a/src/plugins/gs-plugin-xdg-app-reviews.c
+++ b/src/plugins/gs-plugin-xdg-app-reviews.c
@@ -39,13 +39,6 @@
 #define XDG_APP_REVIEW_CACHE_AGE_MAX		237000 /* 1 week */
 #define XDG_APP_REVIEW_NUMBER_RESULTS_MAX	5
 
-#ifndef JsonParser_autoptr
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(JsonParser, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(JsonBuilder, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(JsonNode, json_node_free)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(JsonGenerator, g_object_unref)
-#endif
-
 struct GsPluginPrivate {
 	GSettings		*settings;
 	gchar			*distro;


### PR DESCRIPTION
Cherry-pick from upstream so g-s compiles with json-glib >= 1.1.2.