### PR TITLE
Disable reviews and shell-extensions when building

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gnome-software (3.19.92-0) master; urgency=medium
+
+  * New upstream release
+
+ -- Joaquim Rocha <jrocha@endlessm.com>  Thu, 17 Mar 2016 18:57:11 +0100
+
 gnome-software (3.19.90-0) master; urgency=medium
 
   * New upstream version as of Feb 25

--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,9 @@
 #!/usr/bin/make -f
 
 GS_CONFIGURE_FLAGS = --libdir=/usr/lib \
-		--disable-silent-rules
+		--disable-silent-rules \
+		--disable-reviews      \
+		--disable-shell-extensions
 
 # Install target dir
 INSTALLDIR = $(CURDIR)/debian/tmp


### PR DESCRIPTION
Reviews and GNOME Shell Extensions should not be part of the UI in Endless's use of GNOME Software.