### PR TITLE
Fix built plugins when generating the Debian package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,7 @@ GS_CONFIGURE_FLAGS = --libdir=/usr/lib \
 		--disable-silent-rules \
 		--disable-reviews      \
 		--disable-shell-extensions 	\
+		--disable-odrs			\
 		--enable-xdg-app
 
 # Install target dir

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,8 @@
 GS_CONFIGURE_FLAGS = --libdir=/usr/lib \
 		--disable-silent-rules \
 		--disable-reviews      \
-		--disable-shell-extensions
+		--disable-shell-extensions 	\
+		--enable-xdg-app
 
 # Install target dir
 INSTALLDIR = $(CURDIR)/debian/tmp


### PR DESCRIPTION
I have noticed that the xdg-app plugin is not shipped in the deb so I have enabled in debian/rules to see if that makes a difference (it should be built if xdg-app is available, which is a deb build dependency).

I have also disabled the ODRS plugin as we do not want to worry about ratings ATM.

https://phabricator.endlessm.com/T11467