### PR TITLE
build: Set arch to 32 bit directly when the Debian architecture match…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -304,6 +304,14 @@ AM_CONDITIONAL(HAVE_EAM, test x$have_eam = xyes)
 GDBUS_CODEGEN=`$PKG_CONFIG --variable gdbus_codegen gio-2.0`
 AC_SUBST(GDBUS_CODEGEN)
 
+# hack to override the result of the arch that 'uname' gives.
+# this is needed when using a 64bit kernel with a 32bit user space
+DPKG_ARCH=`dpkg --print-architecture`
+AS_IF([ test "$DPKG_ARCH" = "i386" ],
+  ARCH_OVERRIDE="${prefix}/bin/setarch $DPKG_ARCH "
+  AC_SUBST(ARCH_OVERRIDE)
+)
+
 GLIB_TESTS
 
 dnl ---------------------------------------------------------------------------

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -71,7 +71,7 @@ org.freedesktop.PackageKit.service: org.freedesktop.PackageKit.service.in Makefi
 endif
 
 org.gnome.Software.service: org.gnome.Software.service.in Makefile
-	$(AM_V_GEN) sed -e "s|\@bindir\@|$(bindir)|" $<> $@
+	$(AM_V_GEN) sed -e "s|\@bindir\@|@ARCH_OVERRIDE@$(bindir)|" $<> $@
 
 searchproviderdir = $(datadir)/gnome-shell/search-providers
 searchprovider_DATA = org.gnome.Software-search-provider.ini


### PR DESCRIPTION
Fix xdg-app and appstream-glib getting the arch of the kernel which results in problems when the system has a 32 bit user space on top of a 64 bit kernel.