### PR TITLE
Update xdg-app dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,7 @@ Build-Depends: appstream-util,
                libxml2-utils,
                pkg-config,
                xsltproc,
-               libxdgapp-dev (>= 0.4.12)
+               libxdg-app-dev (>= 0.4.12)
 Standards-Version: 3.9.6
 Homepage: https://wiki.gnome.org/Apps/Software
 Vcs-Svn: svn://anonscm.debian.org/pkg-gnome/packages/unstable/gnome-software/
@@ -39,7 +39,7 @@ Architecture: any
 Depends: libappstream-glib8 (>= 0.5.12),
          gnome-software-common (= ${source:Version}),
          gsettings-desktop-schemas (>= 3.11.5),
-         libxdgapp (>= 0.4.12),
+         libxdg-app0 (>= 0.4.12),
          ${misc:Depends},
          ${shlibs:Depends}
 Replaces: gnome-packagekit-session (<< 3.16.0-2~)


### PR DESCRIPTION
The names of the xdg-app dependencies have changed: from libxdgapp to
libxdg-app.