### PR TITLE
Add the xdg-app dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -40,6 +40,7 @@ Depends: libappstream-glib8 (>= 0.5.12),
          gnome-software-common (= ${source:Version}),
          gsettings-desktop-schemas (>= 3.11.5),
          libxdg-app0 (>= 0.4.12),
+         xdg-app (>= 0.4.12)
          ${misc:Depends},
          ${shlibs:Depends}
 Replaces: gnome-packagekit-session (<< 3.16.0-2~)


### PR DESCRIPTION
This dependency is not really needed by the application but it's helpful
for the user since gnome-software doesn't have a way to configure
remotes at the moment.