### PR TITLE
Fix building the flatpak plugins

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,8 @@
 #!/usr/bin/make -f
 
+export DEB_LDFLAGS_MAINT_STRIP=-Wl,-Bsymbolic-functions
+include /usr/share/dpkg/buildflags.mk
+
 GS_CONFIGURE_FLAGS = --libdir=/usr/lib \
 		--disable-silent-rules \
 		--disable-reviews      \


### PR DESCRIPTION
They were not being correctly built and due to that it was failing when
initializing the GsFlatpak object in a second plugin.

https://phabricator.endlessm.com/T12068