### PR TITLE
Show the app's icon its image tile when there's no main image

### DIFF
--- a/src/gs-image-tile.c
+++ b/src/gs-image-tile.c
@@ -38,6 +38,8 @@ struct _GsImageTile
 	GtkWidget	*app_summary;
 	GtkWidget	*hover_app_name;
 	GtkWidget	*icon;
+	GtkWidget	*fallback_icon;
+	GtkWidget	*image_box;
 	GtkWidget	*eventbox;
 	GtkWidget	*stack;
 	GtkWidget	*stars;
@@ -132,10 +134,17 @@ gs_image_tile_set_app (GsAppTile *app_tile, GsApp *app)
 	app_state_changed (tile->app, NULL, tile);
 
 	/* perhaps set custom css */
-	gs_utils_widget_set_css_app (app, GTK_WIDGET (tile),
+	gs_utils_widget_set_css_app (app, GTK_WIDGET (tile->image_box),
 				     "GnomeSoftware::ImageTile-css");
 
 	gs_image_set_from_pixbuf (GTK_IMAGE (tile->icon),
+				  gs_app_get_pixbuf (tile->app));
+
+	/* The fallback icon should be covered by the main image but
+	 * is here for the cases where that image doesn't exist, as
+	 * without a graphical reference it is very difficult to spot
+	 * the applications */
+	gs_image_set_from_pixbuf (GTK_IMAGE (tile->fallback_icon),
 				  gs_app_get_pixbuf (tile->app));
 
 	gtk_label_set_label (GTK_LABEL (tile->app_name), gs_app_get_name (app));
@@ -214,6 +223,10 @@ gs_image_tile_class_init (GsImageTileClass *klass)
 	gtk_widget_class_bind_template_child (widget_class, GsImageTile, stars);
 	gtk_widget_class_bind_template_child (widget_class, GsImageTile,
 					      details_revealer);
+	gtk_widget_class_bind_template_child (widget_class, GsImageTile,
+					      fallback_icon);
+	gtk_widget_class_bind_template_child (widget_class, GsImageTile,
+					      image_box);
 }
 
 GtkWidget *

--- a/src/gs-image-tile.ui
+++ b/src/gs-image-tile.ui
@@ -33,6 +33,83 @@
             <property name="visible">True</property>
             <property name="halign">fill</property>
             <property name="valign">fill</property>
+	    <child type="overlay">
+	      <object class="GtkEventBox" id="image_box">
+                <property name="visible">True</property>
+		<property name="halign">fill</property>
+		<property name="valign">fill</property>
+		<style>
+		  <class name="main-image"/>
+		</style>
+	      </object>
+	    </child>
+	    <child type="overlay">
+	      <object class="GtkEventBox" id="eboxbox">
+                <property name="visible">True</property>
+		<property name="halign">fill</property>
+		<property name="valign">fill</property>
+                <child>
+                  <object class="GtkBox" id="box">
+		    <property name="visible">True</property>
+		    <property name="orientation">vertical</property>
+		    <property name="spacing">6</property>
+                    <property name="margin">12</property>
+                    <property name="margin-top">100</property>
+		    <property name="halign">start</property>
+		    <property name="valign">start</property>
+		    <child>
+		      <object class="GtkLabel" id="app_name">
+                        <property name="visible">True</property>
+                        <property name="valign">end</property>
+                        <property name="xalign">0</property>
+                        <property name="ellipsize">end</property>
+                        <property name="width_chars">12</property>
+                        <property name="max_width_chars">12</property>
+			<style>
+			  <class name="app-name"/>
+			</style>
+		      </object>
+		      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+		      </packing>
+		    </child>
+		    <child>
+		      <object class="GtkLabel" id="app_summary">
+                        <property name="visible">True</property>
+                        <property name="valign">end</property>
+                        <property name="xalign">0</property>
+                        <property name="ellipsize">end</property>
+                        <property name="lines">2</property>
+                        <property name="wrap">True</property>
+			<property name="width_chars">12</property>
+                        <property name="max_width_chars">12</property>
+			<style>
+			  <class name="app-summary"/>
+			</style>
+		      </object>
+		      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+		      </packing>
+		    </child>
+		    <child>
+		      <object class="GsStarWidget" id="stars">
+                        <property name="visible">True</property>
+                        <property name="halign">center</property>
+		      </object>
+		      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+		      </packing>
+		    </child>
+                  </object>
+                </child>
+		<style>
+		  <class name="app-info"/>
+		</style>
+	      </object>
+	    </child>
             <child type="overlay">
               <object class="GtkEventBox" id="eventbox">
                 <property name="no_show_all">True</property>
@@ -140,69 +217,16 @@
               </object>
 	    </child>
 	    <child>
-	      <object class="GtkEventBox" id="eboxbox">
-                <property name="visible">True</property>
-		<property name="halign">fill</property>
-		<property name="valign">fill</property>
-                <child>
-                  <object class="GtkBox" id="box">
-		    <property name="visible">True</property>
-		    <property name="orientation">vertical</property>
-		    <property name="spacing">6</property>
-                    <property name="margin">12</property>
-                    <property name="margin-top">100</property>
-		    <property name="halign">start</property>
-		    <property name="valign">start</property>
-		    <child>
-		      <object class="GtkLabel" id="app_name">
-                        <property name="visible">True</property>
-                        <property name="valign">end</property>
-                        <property name="xalign">0</property>
-                        <property name="ellipsize">end</property>
-                        <property name="width_chars">12</property>
-                        <property name="max_width_chars">12</property>
-			<style>
-			  <class name="app-name"/>
-			</style>
-		      </object>
-		      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-		      </packing>
-		    </child>
-		    <child>
-		      <object class="GtkLabel" id="app_summary">
-                        <property name="visible">True</property>
-                        <property name="valign">end</property>
-                        <property name="xalign">0</property>
-                        <property name="ellipsize">end</property>
-                        <property name="lines">2</property>
-                        <property name="wrap">True</property>
-			<property name="width_chars">12</property>
-                        <property name="max_width_chars">12</property>
-			<style>
-			  <class name="app-summary"/>
-			</style>
-		      </object>
-		      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-		      </packing>
-		    </child>
-		    <child>
-		      <object class="GsStarWidget" id="stars">
-                        <property name="visible">True</property>
-                        <property name="halign">center</property>
-		      </object>
-		      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-		      </packing>
-		    </child>
-                  </object>
-                </child>
+	      <object class="GtkImage" id="fallback_icon">
+		<property name="width-request">64</property>
+		<property name="height-request">64</property>
+		<property name="visible">True</property>
+		<property name="valign">center</property>
+		<property name="xalign">0</property>
+		<property name="margin-left">6</property>
+		<property name="margin-bottom">40</property>
 		<style>
-		  <class name="app-info"/>
+		  <class name="fallback-icon"/>
 		</style>
 	      </object>
 	    </child>

--- a/src/gtk-style.css
+++ b/src/gtk-style.css
@@ -304,7 +304,7 @@ button.star, .button.star {
 	box-shadow: none
 }
 
-.image-tile {
+.image-tile, .image-tile .main-image {
 	border-radius: 3%;
 	border: 0;
 	padding: 0;
@@ -322,12 +322,12 @@ button.star, .button.star {
 	transition-duration: 0;
 }
 
-.image-tile .app-info * {
+.image-tile .app-info *, .image-tile .fallback-icon {
 	opacity: 1;
 	transition-duration: 500ms;
 }
 
-.image-tile:hover .app-info * {
+.image-tile:hover .app-info *, .image-tile:hover .fallback-icon {
 	opacity: 0;
 	transition-duration: 0;
 }


### PR DESCRIPTION
This is accomplished by including the icon in the image tile's normal
view and changing how the main image is assigned to it: instead of
applying it as the background of the entire widget, it is applied as
the background of a widget that is layed over the mentioned icon. This
way, when there is a main image the icon is hidden behind it, but when
there is none, the icon is visible.

This allows the GsImageTile to display a graphical asset related to its
app even with apps that do not have that main image, which keeps a good
UX.

See https://phabricator.endlessm.com/T12144