### PR TITLE
Add client side of thumbnails downloading

### DIFF
--- a/src/gs-app.c
+++ b/src/gs-app.c
@@ -131,6 +131,13 @@ enum {
 	PROP_LAST
 };
 
+enum {
+	SIGNAL_METADATA_CHANGED,
+	SIGNAL_LAST
+};
+
+static guint signals [SIGNAL_LAST] = { 0 };
+
 G_DEFINE_TYPE (GsApp, gs_app, G_TYPE_OBJECT)
 
 static void
@@ -2075,6 +2082,10 @@ gs_app_set_metadata (GsApp *app, const gchar *key, const gchar *value)
 
 	/* if no value, then remove the key */
 	if (value == NULL) {
+		g_signal_emit (app,
+	        	       signals[SIGNAL_METADATA_CHANGED],
+			       g_quark_from_string (key),
+			       key);
 		g_hash_table_remove (app->metadata, key);
 		return;
 	}
@@ -2093,6 +2104,11 @@ gs_app_set_metadata (GsApp *app, const gchar *key, const gchar *value)
 	g_hash_table_insert (app->metadata,
 			     g_strdup (key),
 			     g_string_free (str, FALSE));
+
+	g_signal_emit (app,
+	               signals[SIGNAL_METADATA_CHANGED],
+	               g_quark_from_string (key),
+	               key);
 }
 
 /**
@@ -2905,6 +2921,24 @@ gs_app_class_init (GsAppClass *klass)
 				     0, G_MAXUINT64, 0,
 				     G_PARAM_READWRITE | G_PARAM_CONSTRUCT);
 	g_object_class_install_property (object_class, PROP_QUIRK, pspec);
+
+        /**
+         * GsApp:metadata-changed:
+         * Fired when a plugin either adds or removes metadata for this
+         * GsApp. Mutating existing metadata is not a valid operation
+         * and the signal will not be fired in that case.
+         *
+         * The detail of this signal will be the key that was either
+         * added or removed from this GsApp's metadata.
+         */
+	signals [SIGNAL_METADATA_CHANGED] =
+	        g_signal_new ("metadata-changed",
+	                      G_TYPE_FROM_CLASS (object_class),
+	                      G_SIGNAL_RUN_LAST | G_SIGNAL_DETAILED,
+	                      0,
+	                      NULL, NULL, g_cclosure_marshal_VOID__STRING,
+	                      G_TYPE_NONE, 1,
+	                      G_TYPE_STRING);
 }
 
 static void

--- a/src/gs-image-tile.c
+++ b/src/gs-image-tile.c
@@ -106,15 +106,29 @@ app_state_changed (GsApp *app, GParamSpec *pspec, GsImageTile *tile)
 }
 
 static void
+app_image_tile_css_added (GsApp *app, const char *metadata, GsAppTile *tile)
+{
+	if (g_strcmp0 (metadata, "GnomeSoftware::ImageTile-css") == 0) {
+		gs_utils_widget_set_css_app (app, GTK_WIDGET (tile),
+		                             "GnomeSoftware::ImageTile-css");
+	} else {
+		g_assert_not_reached ();
+	}
+}
+
+static void
 gs_image_tile_set_app (GsAppTile *app_tile, GsApp *app)
 {
 	GsImageTile *tile = GS_IMAGE_TILE (app_tile);
 
 	g_return_if_fail (GS_IS_APP (app) || app == NULL);
 
-	if (tile->app)
+	if (tile->app) {
 		g_signal_handlers_disconnect_by_func (tile->app,
 						      app_state_changed, tile);
+		g_signal_handlers_disconnect_by_func (tile->app,
+		                                      app_image_tile_css_added, tile);
+	}
 
 	g_set_object (&tile->app, app);
 	if (!app)
@@ -131,6 +145,8 @@ gs_image_tile_set_app (GsAppTile *app_tile, GsApp *app)
 
 	g_signal_connect (tile->app, "notify::state",
 		 	  G_CALLBACK (app_state_changed), tile);
+	g_signal_connect (tile->app, "metadata-changed::GnomeSoftware::ImageTile-css",
+	                  G_CALLBACK (app_image_tile_css_added), tile);
 	app_state_changed (tile->app, NULL, tile);
 
 	/* perhaps set custom css */

--- a/src/plugins/gs-plugin-eos.c
+++ b/src/plugins/gs-plugin-eos.c
@@ -22,9 +22,12 @@
 #include <config.h>
 
 #include <gio/gdesktopappinfo.h>
+#include <libsoup/soup.h>
 #include <gnome-software.h>
 #include <glib/gi18n.h>
+#include <gs-common.h>
 #include <gs-plugin.h>
+#include <gs-utils.h>
 
 #include "gs-flatpak.h"
 
@@ -38,6 +41,7 @@ struct GsPluginData
 	GDBusConnection *session_bus;
 	GHashTable *desktop_apps;
 	int applications_changed_id;
+	SoupSession *soup_session;
 };
 
 static GHashTable *
@@ -106,6 +110,9 @@ gs_plugin_initialize (GsPlugin *plugin)
 						    G_DBUS_SIGNAL_FLAGS_NONE,
 						    (GDBusSignalCallback) on_desktop_apps_changed,
 						    plugin, NULL);
+	priv->soup_session = soup_session_new_with_options (SOUP_SESSION_USER_AGENT,
+	                                                    gs_user_agent (),
+	                                                    NULL);
 }
 
 /**
@@ -123,6 +130,7 @@ gs_plugin_destroy (GsPlugin *plugin)
 	}
 
 	g_clear_object (&priv->session_bus);
+	g_clear_object (&priv->soup_session);
 	g_hash_table_destroy (priv->desktop_apps);
 }
 
@@ -220,12 +228,77 @@ gs_plugin_eos_refine_core_app (GsApp *app)
 	}
 }
 
+typedef struct _PopularBackgroundImageTileRequestData
+{
+	GsApp *app;
+	GsPlugin *plugin;
+	char *cache_filename;
+} PopularBackgroundImageTileRequestData;
+
+static void
+popular_background_image_tile_request_data_destroy (PopularBackgroundImageTileRequestData *data)
+{
+	g_free (data->cache_filename);
+	g_free (data);
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(PopularBackgroundImageTileRequestData,
+                              popular_background_image_tile_request_data_destroy);
+
+static void
+gs_plugin_eos_update_tile_image_from_filename (GsApp      *app,
+                                               const char *filename)
+{
+	g_autofree char *css = g_strdup_printf ("background-image: url('%s')",
+	                                       filename);
+	gs_app_set_metadata (app, "GnomeSoftware::ImageTile-css", css);
+}
+
+static void
+gs_plugin_eos_tile_image_downloaded_cb (SoupSession *session,
+                                        SoupMessage *msg,
+                                        gpointer user_data)
+{
+	g_autoptr(PopularBackgroundImageTileRequestData) data = user_data;
+	g_autoptr(GError) error = NULL;
+
+	if (msg->status_code == SOUP_STATUS_CANCELLED)
+		return;
+
+	if (msg->status_code != SOUP_STATUS_OK) {
+		g_debug ("Failed to download tile image corresponding to cache entry %s: %s",
+		         data->cache_filename,
+		         msg->reason_phrase);
+		return;
+	}
+
+	/* Write out the cache image to disk */
+	if (!g_file_set_contents (data->cache_filename,
+	                          msg->response_body->data,
+	                          msg->response_body->length,
+	                          &error)) {
+		g_debug ("Failed to write cache image %s, %s",
+		         data->cache_filename,
+		         error->message);
+		return;
+	}
+
+	gs_plugin_eos_update_tile_image_from_filename (data->app, data->cache_filename);
+}
+
 static void
 gs_plugin_eos_refine_popular_app (GsPlugin *plugin,
 				  GsApp *app)
 {
 	const char *popular_bg = NULL;
-	g_autofree char *css = NULL;
+	g_autofree char *tile_cache_hash = NULL;
+	g_autofree char *cache_filename = NULL;
+	g_autofree char *url_basename = NULL;
+	g_autofree char *cache_identifier = NULL;
+	GsPluginData *priv = gs_plugin_get_data (plugin);
+	PopularBackgroundImageTileRequestData *request_data = NULL;
+	g_autoptr(SoupURI) soup_uri = NULL;
+	g_autoptr(SoupMessage) message = NULL;
 
 	popular_bg =
 	   gs_app_get_metadata_item (app, "GnomeSoftware::popular-background");
@@ -234,8 +307,51 @@ gs_plugin_eos_refine_popular_app (GsPlugin *plugin,
 	    gs_app_get_metadata_item (app, "GnomeSoftware::ImageTile-css"))
 		return;
 
-	css = g_strdup_printf ("background-image: url('%s');", popular_bg);
-	gs_app_set_metadata (app, "GnomeSoftware::ImageTile-css", css);
+	url_basename = g_path_get_basename (popular_bg);
+
+	/* First take a hash of this URL and see if it is in our cache */
+	tile_cache_hash = g_compute_checksum_for_string (G_CHECKSUM_SHA256,
+	                                                 popular_bg,
+	                                                 -1);
+	cache_identifier = g_strdup_printf("%s-%s", tile_cache_hash, url_basename);
+	cache_filename = gs_utils_get_cache_filename ("eos-popular-app-thumbnails",
+	                                              cache_identifier,
+	                                              GS_UTILS_CACHE_FLAG_NONE,
+	                                              NULL);
+
+	/* Check to see if the file exists in the cache at the time we called this
+	 * function. If it does, then change the css so that the tile loads. Otherwise,
+	 * we'll need to asynchronously fetch the image from the server and write it
+	 * to the cache */
+	if (g_file_test (cache_filename, G_FILE_TEST_EXISTS)) {
+		gs_plugin_eos_update_tile_image_from_filename (app, cache_filename);
+		return;
+	}
+
+	soup_uri = soup_uri_new (popular_bg);
+	g_debug("Downloading thumbnail %s to %s", popular_bg, cache_filename);
+	if (!soup_uri || !SOUP_URI_VALID_FOR_HTTP (soup_uri)) {
+		g_debug ("Couldn't download %s, URL is not valid", popular_bg);
+		return;
+	}
+
+	/* XXX: Note that we might have multiple downloads in progress here. We
+	 * don't make any attempt to keep track of this. */
+	message = soup_message_new_from_uri (SOUP_METHOD_GET, soup_uri);
+	if (!message) {
+		g_debug ("Couldn't download %s, network not available", popular_bg);
+		return;
+	}
+
+	request_data = g_new0 (PopularBackgroundImageTileRequestData, 1);
+	request_data->app = app;
+	request_data->plugin = plugin;
+	request_data->cache_filename = g_steal_pointer (&cache_filename);
+
+	soup_session_queue_message (priv->soup_session,
+	                            g_steal_pointer (&message),
+	                            gs_plugin_eos_tile_image_downloaded_cb,
+	                            request_data);
 }
 
 /**


### PR DESCRIPTION
Currently we pass the URL of the thumbnail directly to GtkCSS - this will create a lot of unnecessary load and network traffic every time gnome-software is booted up. It also doesn't work offline.

We want to cache these thumbnails. To do that, we need to download and save them to the cache directory using libsoup and then pass the filesystem location to GtkCSS.

In some cases, we might end up downloading files after the `_refine` functions on plugins have been run. A signal was added to GsApp to indicate that new metadata has been added after the fact so that interested views can refresh themselves appropriately.

https://phabricator.endlessm.com/T12142