### PR TITLE
eos: Make a note of when we got a cache hit

### DIFF
--- a/src/plugins/gs-plugin-eos.c
+++ b/src/plugins/gs-plugin-eos.c
@@ -324,6 +324,7 @@ gs_plugin_eos_refine_popular_app (GsPlugin *plugin,
 	 * we'll need to asynchronously fetch the image from the server and write it
 	 * to the cache */
 	if (g_file_test (cache_filename, G_FILE_TEST_EXISTS)) {
+		g_debug("Hit cache for thumbnail %s: %s", popular_bg, cache_filename);
 		gs_plugin_eos_update_tile_image_from_filename (app, cache_filename);
 		return;
 	}


### PR DESCRIPTION
This is useful for QA to test that the cache is working as expected.

https://phabricator.endlessm.com/T12142