### PR TITLE
overview: wrap "No Application Data Found" label

### DIFF
--- a/src/gs-shell-overview.ui
+++ b/src/gs-shell-overview.ui
@@ -305,6 +305,7 @@
                 <property name="label" translatable="yes">No Application Data Found</property>
                 <property name="halign">start</property>
                 <property name="valign">center</property>
+                <property name="wrap">True</property>
                 <attributes>
                   <attribute name="scale" value="1.4"/>
                 </attributes>


### PR DESCRIPTION
When a category is empty, GNOME Software displays the
"No Application Data Found" message. This message, by
design, has a bigger font size which - combined with
the Large Text accessibility setting - renders GNOME
Software unshrinkable to an acceptable low resolution
size.

To fix that, make the "No Application Data Found" wrap
the words when needed.

https://phabricator.endlessm.com/T11698