### PR TITLE
details: enable horizontal scroll when needed

### DIFF
--- a/src/gs-shell-details.ui
+++ b/src/gs-shell-details.ui
@@ -43,7 +43,7 @@
             <property name="visible">True</property>
             <property name="shadow_type">none</property>
             <property name="can_focus">True</property>
-            <property name="hscrollbar_policy">never</property>
+            <property name="hscrollbar_policy">automatic</property>
             <property name="vscrollbar_policy">automatic</property>
             <child>
               <object class="GtkViewport" id="viewport1">


### PR DESCRIPTION
The Details page uses a fixed size frame, which doesn't
scale down when running on low resolution devices. This
renders the main window way too big on low resolution
displays.

Fix that by making the Details page scroll horizontally
when needed.

https://phabricator.endlessm.com/T11698