### PR TITLE
Hide the license details in the details page

### DIFF
--- a/src/gs-shell-details.c
+++ b/src/gs-shell-details.c
@@ -109,6 +109,7 @@ struct _GsShellDetails
 	GtkWidget		*label_pending;
 	GtkWidget		*label_license_nonfree_details;
 	GtkWidget		*label_licenses_intro;
+	GtkWidget		*label_details_license_title;
 	GtkWidget		*list_box_addons;
 	GtkWidget		*box_reviews;
 	GtkWidget		*box_details_screenshot_fallback;
@@ -798,6 +799,13 @@ gs_shell_details_refresh_all (GsShellDetails *self)
 		gtk_widget_set_visible (self->button_details_license_nonfree, TRUE);
 		gtk_widget_set_visible (self->button_details_license_unknown, FALSE);
 	}
+
+	/* XXX: until we decide what to do regarding the styling and until we
+	 * fix the license generation in the flatpak apps, we hide the license */
+	gtk_widget_hide (self->label_details_license_title);
+	gtk_widget_hide (self->button_details_license_free);
+	gtk_widget_hide (self->button_details_license_nonfree);
+	gtk_widget_hide (self->button_details_license_unknown);
 
 	/* set version */
 	tmp = gs_app_get_version (self->app);
@@ -2003,6 +2011,7 @@ gs_shell_details_class_init (GsShellDetailsClass *klass)
 	gtk_widget_class_bind_template_child (widget_class, GsShellDetails, popover_license_unknown);
 	gtk_widget_class_bind_template_child (widget_class, GsShellDetails, label_license_nonfree_details);
 	gtk_widget_class_bind_template_child (widget_class, GsShellDetails, label_licenses_intro);
+	gtk_widget_class_bind_template_child (widget_class, GsShellDetails, label_details_license_title);
 }
 
 static void


### PR DESCRIPTION
This is in order to avoid the user seeing the wrong license that we have
in our Flatpak apps but should be properly fixed later.

https://phabricator.endlessm.com/T12854