### PR TITLE
external-apps: Update repo after deleting app

### DIFF
--- a/src/plugins/eos-external-apps-build-install
+++ b/src/plugins/eos-external-apps-build-install
@@ -116,4 +116,4 @@ echo "$APPNAME is now installed"
 
 # Remove installed app from system repo
 ostree refs --delete "runtime/$APPNAME" --repo="$REPO"
-ostree prune --refs-only --repo="$REPO"
+flatpak build-update-repo --prune "$REPO"

--- a/src/plugins/gs-flatpak.c
+++ b/src/plugins/gs-flatpak.c
@@ -635,11 +635,6 @@ gs_flatpak_refresh (GsFlatpak *self,
 	/* give all the repos a second chance */
 	g_hash_table_remove_all (self->broken_remotes);
 
-	/* temporarily blacklist the external apps repo */
-	g_hash_table_insert (self->broken_remotes,
-			     g_strdup ("eos-external-apps"),
-			     GUINT_TO_POINTER (1));
-
 	/* update AppStream metadata */
 	if (flags & GS_PLUGIN_REFRESH_FLAGS_METADATA) {
 		if (!gs_flatpak_refresh_appstream (self,
@@ -1846,11 +1841,6 @@ gs_flatpak_init (GsFlatpak *self)
 {
 	self->broken_remotes = g_hash_table_new_full (g_str_hash, g_str_equal,
 						      g_free, NULL);
-
-	/* temporarily blacklist the external apps repo */
-	g_hash_table_insert (self->broken_remotes,
-			     g_strdup ("eos-external-apps"),
-			     GUINT_TO_POINTER (1));
 }
 
 GsFlatpak *


### PR DESCRIPTION
This regenerates the summary and appstream data to keep gnome-software
happy when it updates flatpak remotes.

https://phabricator.endlessm.com/T11731