### PR TITLE
postinst: Ensure external apps repo initialized

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -30,6 +30,14 @@ else
     install -d -m0755 -o ${g_s_helper_user} -g ${g_s_helper_user} "${ext_apps_repo}"
 fi
 
+# initialize the repo if necessary
+if [ ! -f "${ext_apps_repo}/config" ]; then
+    ostree --repo="${ext_apps_repo}" init --mode=bare-user
+fi
+
+# ensure appstream and summary data exist for gnome-software update
+flatpak build-update-repo "${ext_apps_repo}"
+
 # add or modify external apps repo if needed
 ext_apps_repo_name=eos-external-apps
 


### PR DESCRIPTION
gnome-software will expect the repo to contain a summary and appstream
branch when updating. Otherwise, it marks the repo as broken. Initialize
the ostree repository if necessary and regenerate the metadata with
`flatpak build-update-repo`.

https://phabricator.endlessm.com/T11731