### PR TITLE
eos: Do not blacklist apps based on locale if they're installed

### DIFF
--- a/src/plugins/gs-plugin-eos.c
+++ b/src/plugins/gs-plugin-eos.c
@@ -407,6 +407,15 @@ gs_plugin_app_is_locale_best_match (GsPlugin *plugin,
 }
 
 static void
+blacklist_if_not_installed (GsApp *app)
+{
+	if (gs_app_is_installed (app))
+		return;
+
+	gs_app_add_category (app, "Blacklisted");
+}
+
+static void
 gs_plugin_update_locale_cache_app (GsPlugin *plugin,
 				   const char *locale_cache_key,
 				   GsApp *app)
@@ -421,7 +430,7 @@ gs_plugin_update_locale_cache_app (GsPlugin *plugin,
 		g_debug ("Blacklisting '%s': using '%s' due to its locale",
 			 gs_app_get_unique_id (cached_app),
 			 gs_app_get_unique_id (app));
-		gs_app_add_category (cached_app, "Blacklisted");
+		blacklist_if_not_installed (cached_app);
 	}
 
 	gs_plugin_cache_add (plugin, locale_cache_key, app);
@@ -456,7 +465,8 @@ gs_plugin_eos_blacklist_kapp_if_needed (GsPlugin *plugin, GsApp *app)
 	if (!gs_plugin_locale_is_compatible (plugin, last_token)) {
 		g_debug ("Blacklisting '%s': incompatible with the current "
 			 "locale", gs_app_get_unique_id (app));
-		gs_app_add_category (app, "Blacklisted");
+		blacklist_if_not_installed (app);
+
 		return TRUE;
 	}
 
@@ -472,7 +482,8 @@ gs_plugin_eos_blacklist_kapp_if_needed (GsPlugin *plugin, GsApp *app)
 		g_debug ("Blacklisting '%s': cached app '%s' is best match",
 			 gs_app_get_unique_id (app),
 			 gs_app_get_unique_id (cached_app));
-		gs_app_add_category (app, "Blacklisted");
+		blacklist_if_not_installed (app);
+
 		return TRUE;
 	}
 


### PR DESCRIPTION
A user that installs an app that's available in a certain locale by
having switched to it temporarily should still see it when they switch
back.

https://phabricator.endlessm.com/T12910