### PR TITLE
external-apps: Really run enable service

### DIFF
--- a/data/eos-external-apps-enable.service.in
+++ b/data/eos-external-apps-enable.service.in
@@ -1,6 +1,5 @@
 [Unit]
 Description=Initialize flatpak-external-apps repository
-ConditionNeedsUpdate=/var
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
ConditionNeedsUpdate only works if the service runs before
systemd-update-done.service. Unfortunately, this also means running with
DefaultDependencies=no in sysinit.target. Since this operation is so
lightweight (it just run flatpak remote-add and flatpak remote-modify),
just have it run on every boot.

https://phabricator.endlessm.com/T12949