### PR TITLE
Continue refresh even if it's not possible to update a remote's appst…

### DIFF
--- a/src/plugins/gs-flatpak.c
+++ b/src/plugins/gs-flatpak.c
@@ -179,23 +179,13 @@ gs_flatpak_refresh_appstream (GsFlatpak *self, guint cache_age,
 								  cancellable,
 								  &error_local);
 		if (!ret) {
-			if (g_error_matches (error_local,
-					     G_IO_ERROR,
-					     G_IO_ERROR_FAILED)) {
-				g_debug ("Failed to get AppStream metadata: %s",
-					 error_local->message);
-				/* don't try to fetch this again until refresh() */
-				g_hash_table_insert (self->broken_remotes,
-						     g_strdup (remote_name),
-						     GUINT_TO_POINTER (1));
-				continue;
-			}
-			g_set_error (error,
-				     GS_PLUGIN_ERROR,
-				     GS_PLUGIN_ERROR_NOT_SUPPORTED,
-				     "Failed to get AppStream metadata: %s",
-				     error_local->message);
-			return FALSE;
+			g_warning ("Failed to get AppStream metadata: %s",
+				   error_local->message);
+			/* don't try to fetch this again until refresh() */
+			g_hash_table_insert (self->broken_remotes,
+					     g_strdup (remote_name),
+					     GUINT_TO_POINTER (1));
+			continue;
 		}
 
 		/* add the new AppStream repo to the shared store */


### PR DESCRIPTION
…ream

Otherwise it leads to cases where, e.g. having one remote with a broken gpg
key (or with a user without permissions to pull from an untrusted
source) may prevent updating other valid remotes.

These changes do not quit the refresh operation when updating one remote
fails and promote a debug message to a warning so it is more visible.

https://phabricator.endlessm.com/T13243