### PR TITLE
Fix launching app's details from the "installed" notification

### DIFF
--- a/src/gs-app.c
+++ b/src/gs-app.c
@@ -3534,4 +3534,47 @@ gs_app_new (const gchar *id)
 	return GS_APP (app);
 }
 
+/**
+ * gs_app_new_from_unique_id:
+ * @unique_id: an application unique ID, e.g.
+ *	`system/flatpak/gnome/desktop/org.gnome.Software.desktop/master`
+ *
+ * Creates a new application object.
+ *
+ * The unique ID will be parsed to set some information in the application such
+ * as the scope, bundle kind, id, etc. Unlike gs_app_new(), it cannot take a
+ * %NULL argument.
+ *
+ * Returns: a new #GsApp
+ *
+ * Since: 3.22
+ **/
+GsApp *
+gs_app_new_from_unique_id (const gchar *unique_id)
+{
+	GsApp *app;
+	g_auto(GStrv) split = NULL;
+
+	g_return_val_if_fail (unique_id != NULL, NULL);
+
+	split = g_strsplit (unique_id, "/", -1);
+	if (g_strv_length (split) != 6)
+		return NULL;
+
+	app = gs_app_new (NULL);
+	if (g_strcmp0 (split[0], "*") != 0)
+		gs_app_set_scope (app, as_app_scope_from_string (split[0]));
+	if (g_strcmp0 (split[1], "*") != 0)
+		gs_app_set_bundle_kind (app, as_bundle_kind_from_string (split[1]));
+	if (g_strcmp0 (split[2], "*") != 0)
+		gs_app_set_origin (app, split[2]);
+	if (g_strcmp0 (split[3], "*") != 0)
+		gs_app_set_kind (app, as_app_kind_from_string (split[3]));
+	if (g_strcmp0 (split[4], "*") != 0)
+		gs_app_set_id (app, split[4]);
+	if (g_strcmp0 (split[5], "*") != 0)
+		gs_app_set_branch (app, split[5]);
+	return app;
+}
+
 /* vim: set noexpandtab: */

--- a/src/gs-app.h
+++ b/src/gs-app.h
@@ -102,6 +102,7 @@ typedef enum {
 #endif
 
 GsApp		*gs_app_new			(const gchar	*id);
+GsApp		*gs_app_new_from_unique_id	(const gchar	*unique_id);
 gchar		*gs_app_to_string		(GsApp		*app);
 
 const gchar	*gs_app_get_id			(GsApp		*app);

--- a/src/gs-application.c
+++ b/src/gs-application.c
@@ -598,7 +598,12 @@ details_activated (GSimpleAction *action,
 		gs_shell_show_search_result (app->shell, id, search);
 	else {
 		g_autoptr (GsApp) a = NULL;
-		a = gs_app_new (id);
+
+		if (as_utils_unique_id_valid (id))
+			a = gs_app_new_from_unique_id (id);
+		else
+			a = gs_app_new (id);
+
 		gs_shell_show_app (app->shell, a);
 	}
 }

--- a/src/gs-common.c
+++ b/src/gs-common.c
@@ -143,7 +143,7 @@ gs_app_notify_installed (GsApp *app)
 						       gs_app_get_id (app));
 	}
 	g_notification_set_default_action_and_target  (n, "app.details", "(ss)",
-						       gs_app_get_id (app), "");
+						       gs_app_get_unique_id (app), "");
 	g_application_send_notification (g_application_get_default (), "installed", n);
 }
 

--- a/src/gs-self-test.c
+++ b/src/gs-self-test.c
@@ -239,6 +239,23 @@ gs_plugin_func (void)
 }
 
 static void
+gs_app_unique_id_func (void)
+{
+	g_autoptr(GsApp) app = NULL;
+	const gchar *unique_id;
+
+	unique_id = "system/flatpak/gnome/desktop/org.gnome.Software.desktop/master";
+	app = gs_app_new_from_unique_id (unique_id);
+	g_assert (GS_IS_APP (app));
+	g_assert_cmpint (gs_app_get_scope (app), ==, AS_APP_SCOPE_SYSTEM);
+	g_assert_cmpint (gs_app_get_bundle_kind (app), ==, AS_BUNDLE_KIND_FLATPAK);
+	g_assert_cmpstr (gs_app_get_origin (app), ==, "gnome");
+	g_assert_cmpint (gs_app_get_kind (app), ==, AS_APP_KIND_DESKTOP);
+	g_assert_cmpstr (gs_app_get_id (app), ==, "org.gnome.Software.desktop");
+	g_assert_cmpstr (gs_app_get_branch (app), ==, "master");
+}
+
+static void
 gs_app_func (void)
 {
 	g_autoptr(GsApp) app = NULL;
@@ -1287,6 +1304,7 @@ main (int argc, char **argv)
 	g_test_add_func ("/gnome-software/utils{wilson}", gs_utils_wilson_func);
 	g_test_add_func ("/gnome-software/os-release", gs_os_release_func);
 	g_test_add_func ("/gnome-software/app", gs_app_func);
+	g_test_add_func ("/gnome-software/app{unique-id}", gs_app_unique_id_func);
 	g_test_add_func ("/gnome-software/plugin", gs_plugin_func);
 	g_test_add_func ("/gnome-software/plugin{global-cache}", gs_plugin_global_cache_func);
 	g_test_add_func ("/gnome-software/auth{secret}", gs_auth_secret_func);


### PR DESCRIPTION
It was not finding a plugin for the app that had just been installed
when the user clicked the notification to go into the app's details
page.

This patch adds a new method to create a GsApp out of a unique ID,
setting as much info as it can from the ID, and thus increasing the
chances of the app getting adopted by some plugin.

https://phabricator.endlessm.com/T13244