### PR TITLE
Do not show an update for apps whose latest flatpak commit is NULL

### DIFF
--- a/src/plugins/gs-flatpak.c
+++ b/src/plugins/gs-flatpak.c
@@ -645,7 +645,8 @@ gs_flatpak_add_updates (GsFlatpak *self, GsAppList *list,
 		/* check the application has already been downloaded */
 		commit = flatpak_ref_get_commit (FLATPAK_REF (xref));
 		latest_commit = flatpak_installed_ref_get_latest_commit (xref);
-		if (g_strcmp0 (commit, latest_commit) == 0) {
+		if (latest_commit == NULL ||
+		    g_strcmp0 (commit, latest_commit) == 0) {
 			g_debug ("no downloaded update for %s",
 				 flatpak_ref_get_name (FLATPAK_REF (xref)));
 			continue;


### PR DESCRIPTION
The logic for setting an app as updatable works by comparing the current
commit of an app with the latest one available.
However, if an app no longer exists in its remote, then the latest
commit is being set as NULL, thus resulting in a wrong update for the
app in GNOME Software.

This patch simply checks if the latest commit of an app is not NULL
before comparing the commits in question.

https://phabricator.endlessm.com/T13371