### PR TITLE
eos: Fix displaying the custom app tile in KApps of different locales

### DIFF
--- a/src/plugins/gs-plugin-eos.c
+++ b/src/plugins/gs-plugin-eos.c
@@ -474,11 +474,12 @@ gs_plugin_eos_blacklist_kapp_if_needed (GsPlugin *plugin, GsApp *app)
 	last_token = tokens[num_tokens - 1];
 
 	if (!gs_plugin_locale_is_compatible (plugin, last_token)) {
-		if (!gs_app_is_installed (app)) {
-			g_debug ("Blacklisting '%s': incompatible with the "
-				 "current locale", gs_app_get_unique_id (app));
-			gs_app_add_category (app, "Blacklisted");
-		}
+		if (gs_app_is_installed (app))
+			return FALSE;
+
+		g_debug ("Blacklisting '%s': incompatible with the current "
+			 "locale", gs_app_get_unique_id (app));
+		gs_app_add_category (app, "Blacklisted");
 
 		return TRUE;
 	}


### PR DESCRIPTION
Installed knowledge apps of different locales are not being blacklisted
but the blacklisting function is mistakenly returning TRUE which
prevents any further refining of those apps, thus resulting in not
having a custom tile set. This patch fixes that return value.

https://phabricator.endlessm.com/T13306