### PR TITLE
eos: Prevent blacklisting apps that represent the same app

### DIFF
--- a/src/plugins/gs-plugin-eos.c
+++ b/src/plugins/gs-plugin-eos.c
@@ -432,15 +432,16 @@ gs_plugin_update_locale_cache_app (GsPlugin *plugin,
 				   GsApp *app)
 {
 	GsApp *cached_app = gs_plugin_cache_lookup (plugin, locale_cache_key);
+	const char *cached_app_id = gs_app_get_unique_id (cached_app);
+	const char *app_id = gs_app_get_unique_id (app);
 
 	/* avoid blacklisting the same app that's already cached */
-	if (cached_app == app)
+	if (cached_app == app || g_strcmp0 (cached_app_id, app_id) == 0)
 		return;
 
 	if (cached_app && !gs_app_is_installed (cached_app)) {
 		g_debug ("Blacklisting '%s': using '%s' due to its locale",
-			 gs_app_get_unique_id (cached_app),
-			 gs_app_get_unique_id (app));
+			 cached_app_id, app_id);
 		gs_app_add_category (cached_app, "Blacklisted");
 	}
 


### PR DESCRIPTION
When different GsApp objects exist for the same application, then
they will become blacklisted because in the
gs_plugin_eos_blacklist_kapp_if_needed method one object will replace
and blacklist the other. Since they refer to the same app, then that
app would end up blacklisted.

This patch verifies not only the object that has been cached but also
compares the IDs to see if they refer to the same app, in order to
avoid the issue mentioned above.

https://phabricator.endlessm.com/T13396