### PR TITLE
T12725

### DIFF
--- a/src/gs-plugin-loader.c
+++ b/src/gs-plugin-loader.c
@@ -858,12 +858,6 @@ gs_plugin_loader_filter_qt_for_gtk (GsApp *app, gpointer user_data)
 }
 
 static gboolean
-gs_plugin_loader_app_is_non_compulsory (GsApp *app, gpointer user_data)
-{
-	return !gs_app_has_quirk (app, AS_APP_QUIRK_COMPULSORY);
-}
-
-static gboolean
 gs_plugin_loader_app_is_non_installed (GsApp *app, gpointer user_data)
 {
 	if (gs_app_get_state (app) == AS_APP_STATE_INSTALLED)
@@ -2513,7 +2507,6 @@ gs_plugin_loader_get_category_apps_thread_cb (GTask *task,
 	}
 
 	/* filter package list */
-	gs_app_list_filter (state->list, gs_plugin_loader_app_is_non_compulsory, NULL);
 	gs_app_list_filter (state->list, gs_plugin_loader_app_is_valid, state);
 	gs_app_list_filter (state->list, gs_plugin_loader_filter_qt_for_gtk, NULL);
 	gs_app_list_filter (state->list, gs_plugin_loader_get_app_is_compatible, plugin_loader);


### PR DESCRIPTION
This PR make GNOME Software:
 - Show compulsory (aka core) apps with 'eos-' suffixed icon
 - Show apps with low score on appstream (ie Writer, Presentation, Evolution, etc)

https://phabricator.endlessm.com/T12725