### PR TITLE
Perform Flatpak updates according the download-updates setting

### DIFF
--- a/src/plugins/gs-flatpak.h
+++ b/src/plugins/gs-flatpak.h
@@ -107,6 +107,8 @@ GPtrArray	*gs_flatpak_get_installed_runtimes (GsFlatpak		*self,
 						    GCancellable       	*cancellable,
 						    GError	       	**error);
 
+void		gs_flatpak_set_download_updates (GsFlatpak		*self,
+						 gboolean 		 download_updates);
 
 G_END_DECLS
 

--- a/src/plugins/gs-plugin-flatpak-system.c
+++ b/src/plugins/gs-plugin-flatpak-system.c
@@ -39,12 +39,32 @@ struct GsPluginData {
 	GSettings		*settings;
 };
 
+static void
+download_updates_setting_changed (GSettings *settings,
+				  const gchar *key,
+				  GsPlugin *self)
+{
+	GsPluginData *priv = gs_plugin_get_data (self);
+	gboolean download_updates = g_settings_get_boolean (settings,
+							    "download-updates");
+	gs_flatpak_set_download_updates (priv->flatpak, download_updates);
+}
+
 void
 gs_plugin_initialize (GsPlugin *plugin)
 {
 	GsPluginData *priv = gs_plugin_alloc_data (plugin, sizeof(GsPluginData));
+	gboolean download_updates;
+
 	priv->flatpak = gs_flatpak_new (plugin, GS_FLATPAK_SCOPE_SYSTEM);
 	priv->settings = g_settings_new ("org.gnome.software");
+	download_updates = g_settings_get_boolean (priv->settings,
+						   "download-updates");
+
+	gs_flatpak_set_download_updates (priv->flatpak, download_updates);
+	g_signal_connect (priv->settings, "changed::download-updates",
+			  G_CALLBACK (download_updates_setting_changed),
+			  plugin);
 
 	/* set plugin flags */
 	gs_plugin_add_flags (plugin, GS_PLUGIN_FLAGS_GLOBAL_CACHE);

--- a/src/plugins/gs-plugin-flatpak-user.c
+++ b/src/plugins/gs-plugin-flatpak-user.c
@@ -39,12 +39,32 @@ struct GsPluginData {
 	GSettings		*settings;
 };
 
+static void
+download_updates_setting_changed (GSettings *settings,
+				  const gchar *key,
+				  GsPlugin *self)
+{
+	GsPluginData *priv = gs_plugin_get_data (self);
+	gboolean download_updates = g_settings_get_boolean (settings,
+							    "download-updates");
+	gs_flatpak_set_download_updates (priv->flatpak, download_updates);
+}
+
 void
 gs_plugin_initialize (GsPlugin *plugin)
 {
 	GsPluginData *priv = gs_plugin_alloc_data (plugin, sizeof(GsPluginData));
+	gboolean download_updates;
+
 	priv->flatpak = gs_flatpak_new (plugin, GS_FLATPAK_SCOPE_USER);
 	priv->settings = g_settings_new ("org.gnome.software");
+	download_updates = g_settings_get_boolean (priv->settings,
+						   "download-updates");
+
+	gs_flatpak_set_download_updates (priv->flatpak, download_updates);
+	g_signal_connect (priv->settings, "changed::download-updates",
+			  G_CALLBACK (download_updates_setting_changed),
+			  plugin);
 
 	/* set plugin flags */
 	gs_plugin_add_flags (plugin, GS_PLUGIN_FLAGS_GLOBAL_CACHE);


### PR DESCRIPTION
Even if there is a download-updates setting, the Flatpak plugins are not
honoring it, meaning that Flatpak updates are always downloaded on
refresh time (and deployed later).

With these changes, the original behavior is still used if the mentioned
setting is true. Otherwise, it shows updates for refs that even if they
do not have downloaded updates and fetch those when the user
deliberately updates the apps.

https://phabricator.endlessm.com/T13407