### PR TITLE
trivial: Use the "update" label in the updates page's buttons

### DIFF
--- a/src/gs-app-row.c
+++ b/src/gs-app-row.c
@@ -197,7 +197,7 @@ gs_app_row_refresh_button (GsAppRow *app_row, gboolean missing_search_result)
 		if (priv->show_update) {
 			/* TRANSLATORS: this is a button in the updates panel
 			 * that allows the app to be easily updated live */
-			gtk_button_set_label (GTK_BUTTON (priv->button), _("Install"));
+			gtk_button_set_label (GTK_BUTTON (priv->button), _("Update"));
 		} else {
 			/* TRANSLATORS: this is a button next to the search results that
 			 * allows the application to be easily removed */

--- a/src/gs-shell-updates.c
+++ b/src/gs-shell-updates.c
@@ -494,11 +494,11 @@ gs_shell_updates_get_updates_cb (GsPluginLoader *plugin_loader,
 	if (self->all_updates_are_live) {
 		gtk_button_set_label (GTK_BUTTON (self->button_update_all),
 				      /* TRANSLATORS: all updates will be installed */
-				      _("_Install All"));
+				      _("U_pdate All"));
 	} else {
 		gtk_button_set_label (GTK_BUTTON (self->button_update_all),
 				      /* TRANSLATORS: this is an offline update */
-				      _("Restart & _Install"));
+				      _("_Restart & Update"));
 	}
 
 	/* update the counter */


### PR DESCRIPTION
The "update" label is used instead of "install" to better support
users' expectations.

https://phabricator.endlessm.com/T13593