### PR TITLE
Do not set a cache age on manual refresh

### DIFF
--- a/src/gs-shell-updates.c
+++ b/src/gs-shell-updates.c
@@ -741,7 +741,7 @@ gs_shell_updates_get_new_updates (GsShellUpdates *self)
 	self->cancellable_refresh = g_cancellable_new ();
 
 	gs_plugin_loader_refresh_async (self->plugin_loader,
-					10 * 60,
+					0,
 					GS_PLUGIN_REFRESH_FLAGS_INTERACTIVE |
 					GS_PLUGIN_REFRESH_FLAGS_METADATA |
 					GS_PLUGIN_REFRESH_FLAGS_PAYLOAD,


### PR DESCRIPTION
We need things to always happen immediately when pressing the refresh
button and not only if the cache is older than 10 minutes.

https://phabricator.endlessm.com/T12998