### PR TITLE
Block encyclopedia apps in China

### DIFF
--- a/src/plugins/gs-plugin-eos.c
+++ b/src/plugins/gs-plugin-eos.c
@@ -520,8 +520,10 @@ app_is_banned_for_personality (GsPlugin *plugin, GsApp *app)
 	    gs_app_get_state (app) == AS_APP_STATE_UPDATABLE_LIVE)
 		return FALSE;
 
-	return (g_strcmp0 (priv->personality, "es_GT") == 0) &&
-		(g_strcmp0 (id, "org.openarena.Openarena.desktop") == 0);
+	return ((g_strcmp0 (priv->personality, "es_GT") == 0) &&
+	        (g_strcmp0 (id, "org.openarena.Openarena.desktop") == 0)) ||
+	       ((g_strcmp0 (priv->personality, "zh_CN") == 0) &&
+	        g_str_has_prefix (id, "com.endlessm.encyclopedia"));
 }
 
 static gboolean


### PR DESCRIPTION
Regardless of the user's current language, we've been asked
to not show the encyclopedia apps in the app center for users
of the zh_CN image personality.

Note that we check for the "com.endlessm.encyclopedia" prefix
rather than a specific ID in order to block any localized
version of the encyclopedia.

https://phabricator.endlessm.com/T13291