### PR TITLE
external-apps: Run after the "appstream" plugin

### DIFF
--- a/src/plugins/gs-plugin-external-apps.c
+++ b/src/plugins/gs-plugin-external-apps.c
@@ -76,6 +76,7 @@ gs_plugin_initialize (GsPlugin *plugin)
 	 * the app's headless part first */
 	gs_plugin_add_rule (plugin, GS_PLUGIN_RULE_RUN_BEFORE, "flatpak-system");
 	gs_plugin_add_rule (plugin, GS_PLUGIN_RULE_RUN_BEFORE, "flatpak-user");
+	gs_plugin_add_rule (plugin, GS_PLUGIN_RULE_RUN_AFTER, "appstream");
 }
 
 void


### PR DESCRIPTION
We need apps to have all the appstream data on them before we
eventually manage them as external apps.

This also solves an issue where broken external apps (an installed
external app without its external runtime installed) were showing
up in the installed list.

https://phabricator.endlessm.com/T13804