### PR TITLE
Remove the "installed" label from search results

### DIFF
--- a/src/gs-app-row.c
+++ b/src/gs-app-row.c
@@ -364,20 +364,7 @@ gs_app_row_refresh (GsAppRow *app_row)
 	}
 
 	/* installed tag */
-	if (!priv->show_buttons) {
-		switch (gs_app_get_state (priv->app)) {
-		case AS_APP_STATE_UPDATABLE:
-		case AS_APP_STATE_UPDATABLE_LIVE:
-		case AS_APP_STATE_INSTALLED:
-			gtk_widget_set_visible (priv->label_installed, TRUE);
-			break;
-		default:
-			gtk_widget_set_visible (priv->label_installed, FALSE);
-			break;
-		}
-	} else {
-		gtk_widget_set_visible (priv->label_installed, FALSE);
-	}
+	gtk_widget_set_visible (priv->label_installed, FALSE);
 
 	gtk_label_set_label (GTK_LABEL (priv->name_label),
 			     gs_app_get_name (priv->app));


### PR DESCRIPTION
The label looks broken and brings little value that way.

https://phabricator.endlessm.com/T13819