### PR TITLE
Add gs-plugin-flatpak-appstream

### DIFF
--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -88,6 +88,7 @@ plugin_LTLIBRARIES += libgs_plugin_fwupd.la
 endif
 
 if HAVE_FLATPAK
+plugin_LTLIBRARIES += libgs_plugin_flatpak-appstream.la
 plugin_LTLIBRARIES += libgs_plugin_flatpak-system.la
 plugin_LTLIBRARIES += libgs_plugin_flatpak-user.la
 plugin_LTLIBRARIES += libgs_plugin_external-apps.la
@@ -198,6 +199,18 @@ libgs_plugin_limba_la_CFLAGS = $(GS_PLUGIN_CFLAGS) $(WARN_CFLAGS)
 endif
 
 if HAVE_FLATPAK
+libgs_plugin_flatpak_appstream_la_SOURCES =		\
+	gs-appstream.c					\
+	gs-appstream.h					\
+	gs-flatpak.c					\
+	gs-flatpak.h					\
+	gs-flatpak-symlinks.c				\
+	gs-flatpak-symlinks.h				\
+	gs-plugin-flatpak-appstream.c
+libgs_plugin_flatpak_appstream_la_LIBADD = $(GS_PLUGIN_LIBS) $(FLATPAK_LIBS)
+libgs_plugin_flatpak_appstream_la_LDFLAGS = -module -avoid-version
+libgs_plugin_flatpak_appstream_la_CFLAGS = $(GS_PLUGIN_CFLAGS) $(WARN_CFLAGS)
+
 libgs_plugin_flatpak_system_la_SOURCES =		\
 	gs-appstream.c					\
 	gs-appstream.h					\

--- a/src/plugins/gs-plugin-flatpak-appstream.c
+++ b/src/plugins/gs-plugin-flatpak-appstream.c
@@ -1,0 +1,75 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2016 Endless Mobile, Inc
+ *
+ * Author: Joaquim Rocha <jrocha@endlessm.com>
+ *
+ * Licensed under the GNU General Public License Version 2
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <config.h>
+#include <flatpak.h>
+#include <gnome-software.h>
+
+#include "gs-flatpak.h"
+
+struct GsPluginData {
+	GsFlatpak	*usr_flatpak;
+	GsFlatpak	*sys_flatpak;
+};
+
+void
+gs_plugin_initialize (GsPlugin *plugin)
+{
+	/* XXX: This plugin is needed temporarily to fix the issue that the
+	 * Flatpak plugins, which also handle their remote's appstream files,
+	 * need to run after the appstream plugin but the this one needs to
+	 * have also the flatpak appstream symlinks in place; this was causing
+	 * an empty overview when GNOME Software was launched without the
+	 * symlinks */
+	GsPluginData *priv = gs_plugin_alloc_data (plugin, sizeof(GsPluginData));
+
+	priv->usr_flatpak = gs_flatpak_new (plugin, GS_FLATPAK_SCOPE_USER);
+	priv->sys_flatpak = gs_flatpak_new (plugin, GS_FLATPAK_SCOPE_SYSTEM);
+
+	/* Run plugin before the appstream one so we set up the flatpak's
+	 * appstream files for it */
+	gs_plugin_add_rule (plugin, GS_PLUGIN_RULE_RUN_BEFORE, "appstream");
+}
+
+void
+gs_plugin_destroy (GsPlugin *plugin)
+{
+	GsPluginData *priv = gs_plugin_get_data (plugin);
+
+	g_clear_object (&priv->usr_flatpak);
+	g_clear_object (&priv->sys_flatpak);
+}
+
+gboolean
+gs_plugin_setup (GsPlugin *plugin,
+		 GCancellable *cancellable,
+		 GError **error)
+{
+	GsPluginData *priv = gs_plugin_get_data (plugin);
+
+	if (!gs_flatpak_setup (priv->usr_flatpak, cancellable, error) ||
+	    !gs_flatpak_setup (priv->sys_flatpak, cancellable, error))
+		return FALSE;
+
+	return TRUE;
+}


### PR DESCRIPTION
This plugin is needed temporarily to fix the issue that the Flatpak
plugins (which also handle their remote's appstream files) need to run
after the appstream plugin but the this one needs to have also the
flatpak appstream symlinks in place. This was causing an empty overview
when GNOME Software was launched without the symlinks.

https://phabricator.endlessm.com/T13855