### PR TITLE
Handle default branches using flatpak's API only

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -242,7 +242,7 @@ AC_ARG_ENABLE(flatpak,
               enable_flatpak=maybe)
 AS_IF([test "x$enable_flatpak" != "xno"], [
     PKG_CHECK_MODULES(FLATPAK,
-                      [flatpak >= 0.4.14],
+                      [flatpak >= 0.6.12],
                       [have_flatpak=yes],
                       [have_flatpak=no])
 ], [

--- a/configure.ac
+++ b/configure.ac
@@ -242,7 +242,7 @@ AC_ARG_ENABLE(flatpak,
               enable_flatpak=maybe)
 AS_IF([test "x$enable_flatpak" != "xno"], [
     PKG_CHECK_MODULES(FLATPAK,
-                      [flatpak >= 0.6.12],
+                      [flatpak >= 0.6.13],
                       [have_flatpak=yes],
                       [have_flatpak=no])
 ], [

--- a/src/plugins/gs-flatpak.c
+++ b/src/plugins/gs-flatpak.c
@@ -2332,3 +2332,32 @@ gs_flatpak_refine_metadata_from_installation (GsFlatpak *self,
 	gs_appstream_copy_metadata (app, as_app, TRUE);
 	return TRUE;
 }
+
+void
+gs_flatpak_fill_default_branches (GsFlatpak *self, GHashTable *table)
+{
+	g_autoptr(GPtrArray) xremotes = NULL;
+	guint i;
+
+	if (self->installation == NULL)
+		return;
+
+	xremotes = flatpak_installation_list_remotes (self->installation, NULL, NULL);
+	if (xremotes == NULL || xremotes->len == 0)
+		return;
+
+	for (i = 0; i < xremotes->len; i++) {
+		FlatpakRemote *xremote = g_ptr_array_index (xremotes, i);
+		char *default_branch = flatpak_remote_get_default_branch (xremote);
+		gchar *remote_name = NULL;
+
+		/* filter by branch */
+		if (default_branch == NULL)
+			continue;
+
+		remote_name = g_strdup (flatpak_remote_get_name (xremote));
+		g_hash_table_insert (table, remote_name, default_branch);
+		g_debug ("Found default branch '%s' for remote '%s'",
+			 default_branch, remote_name);
+	}
+}

--- a/src/plugins/gs-flatpak.h
+++ b/src/plugins/gs-flatpak.h
@@ -24,6 +24,7 @@
 #define __GS_FLATPAK_H
 
 #include <gnome-software.h>
+#include <flatpak.h>
 
 G_BEGIN_DECLS
 
@@ -141,6 +142,8 @@ gboolean	gs_flatpak_refine_metadata_from_installation (GsFlatpak		*self,
 							      GsApp		*app,
 							      GCancellable	*cancellable,
 							      GError		**error);
+
+void            gs_flatpak_fill_default_branches (GsFlatpak *self, GHashTable *table);
 
 G_END_DECLS
 


### PR DESCRIPTION
Drop the need on our custom system based on the `/etc/gnome-software/flatpak-extra.conf` file and use flatpak's new APIs instead to check the default-branch attribute for a remote, pulling it from the server's summary file when needed.

https://phabricator.endlessm.com/T13403