### PR TITLE
Set minimum required version of flatpak to 0.6.13

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,7 @@ Build-Depends: appstream-util,
                libxml2-utils,
                pkg-config,
                xsltproc,
-               libflatpak-dev,
+               libflatpak-dev (>= 0.6.13),
                libsecret-1-dev,
                systemd
 Standards-Version: 3.9.6


### PR DESCRIPTION
This is required for flatpak_installation_update_remote_sync ()

https://phabricator.endlessm.com/T13403-debian