### PR TITLE
external-apps: Remove apps' assets when they're no longer needed

### DIFF
--- a/src/plugins/eos-external-apps-build-install
+++ b/src/plugins/eos-external-apps-build-install
@@ -114,9 +114,12 @@ mkdir -p "$EXPORTDIR"
 
 if [ "$ASSETTYPE" = "deb" ]; then
     ar x "$assetfile"
+    rm "$assetfile"
     tar xf data.tar.* -C "$EXPORTDIR"
+    rm data.tar.*
 elif [ "$ASSETTYPE" = "tar" ]; then
     tar xf "$assetfile" -C "$EXPORTDIR"
+    rm "$assetfile"
 else
     echo "$0: Cannot support asset type $ASSETTYPE"
     exit 1


### PR DESCRIPTION
This should save twice the size of the external apps' Debian packages
and one time the size of tarball external apps' tarballs.

https://phabricator.endlessm.com/T14145