### PR TITLE
Fallback to using the 'eos3' branch as the default for the eos-apps remote

### DIFF
--- a/src/plugins/gs-plugin-eos.c
+++ b/src/plugins/gs-plugin-eos.c
@@ -733,6 +733,10 @@ gs_plugin_eos_blacklist_by_branch_if_needed (GsPlugin *plugin, GsApp *app)
 	else
 		default_branch = g_hash_table_lookup (priv->usr_default_branches, origin);
 
+	/* Temporary fallback for users upgrading from EOS < 3.1 */
+	if (!default_branch && g_strcmp0(origin, "eos-apps") == 0)
+		default_branch = "eos3";
+
 	/* if we do not have a configured default branch for this repo then
 	 * do nothing */
 	if (!default_branch)


### PR DESCRIPTION
This is a small patch to make sure users upgrading from EOS < 3.1 don't ever
see multiple versions of the apps if, for any reason, they run then new App
Center while being offline and before having successfully pulled the default
branch extended attribute from the summary file, in the OSTree server.

NOTE: This must be removed at some point before releasing EOS 4, of course.

https://phabricator.endlessm.com/T14167