### PR TITLE
eos: Blacklist app if incompatible with the OS version

### DIFF
--- a/src/gs-app.c
+++ b/src/gs-app.c
@@ -2840,6 +2840,35 @@ gs_app_add_category (GsApp *app, const gchar *category)
 }
 
 /**
+ * gs_app_remove_category:
+ * @app: a #GsApp
+ * @category: a category ID, e.g. "AudioVideo"
+ *
+ * Removes an category ID from an application, it exists.
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 3.24
+ **/
+gboolean
+gs_app_remove_category (GsApp *app, const gchar *category)
+{
+	const gchar *tmp;
+	guint i;
+
+	g_return_val_if_fail (GS_IS_APP (app), FALSE);
+
+	for (i = 0; i < app->categories->len; i++) {
+		tmp = g_ptr_array_index (app->categories, i);
+		if (g_strcmp0 (tmp, category) != 0)
+			continue;
+		g_ptr_array_remove_index_fast (app->categories, i);
+		return TRUE;
+	}
+	return FALSE;
+}
+
+/**
  * gs_app_get_key_colors:
  * @app: a #GsApp
  *

--- a/src/gs-app.h
+++ b/src/gs-app.h
@@ -259,6 +259,8 @@ gboolean	 gs_app_has_category		(GsApp		*app,
 						 const gchar	*category);
 void		 gs_app_add_category		(GsApp		*app,
 						 const gchar	*category);
+gboolean	 gs_app_remove_category		(GsApp		*app,
+						 const gchar	*category);
 GPtrArray	*gs_app_get_keywords		(GsApp		*app);
 void		 gs_app_set_keywords		(GsApp		*app,
 						 GPtrArray	*keywords);

--- a/src/plugins/gs-plugin-external-apps.c
+++ b/src/plugins/gs-plugin-external-apps.c
@@ -530,6 +530,11 @@ gs_plugin_refine_app (GsPlugin *plugin,
 
 	flatpak = gs_plugin_get_gs_flatpak_for_app (plugin, app);
 
+	/* We need to unblacklist all external apps (because they can be
+	 * blacklisted by default) and let the code sort out whether it should
+	 * be blacklisted later */
+	gs_app_remove_category (app, "Blacklisted");
+
 	if (!gs_flatpak_refine_app (flatpak, app, flags, cancellable, error)) {
 		g_debug ("Refining app %s failed!", gs_app_get_unique_id (app));
 		return FALSE;


### PR DESCRIPTION
Even though we use Flatpak for managing our applications and that
is independent from the OS version, there are some applications that
may use in a hybrid way: we use Flatpak for the distribution but we
launch them from outside which means that perhaps the OS in question
doesn't have the app helper that launched it. For that reason we want
to be able to blacklist apps if they are not compatible with the OS.

https://phabricator.endlessm.com/T14235