### PR TITLE
external-apps: Fix crash while app is being uninstalled

### DIFF
--- a/src/plugins/gs-flatpak.c
+++ b/src/plugins/gs-flatpak.c
@@ -2319,6 +2319,10 @@ gs_flatpak_refine_metadata_from_installation (GsFlatpak *self,
 	const char *commit = NULL;
 
 	ref = gs_flatpak_get_installed_ref (self, app, cancellable, error);
+
+	if (!ref)
+		return FALSE;
+
 	commit = flatpak_ref_get_commit (FLATPAK_REF (ref));
 
 	if (!commit)


### PR DESCRIPTION
This patch fixes a crash that was happening when an external app was
being uninstalled and the user entered its details view.
The problem was that upon entering the details view while the app was
being uninstalled, the app would be refined and there was a race
between what the GsApp's state was and what the Flatpak state was,
so when calling a method that assumed the app to be installed, a seg
fault would occur.

https://phabricator.endlessm.com/T14237