### PR TITLE
eos: Do not blacklist apps before they are assigned a state

### DIFF
--- a/src/plugins/gs-plugin-eos.c
+++ b/src/plugins/gs-plugin-eos.c
@@ -844,6 +844,11 @@ gs_plugin_refine (GsPlugin		*plugin,
 
 		gs_plugin_eos_refine_core_app (app);
 
+		/* if we don't know yet the state of an app then we shouldn't
+		 * do any further operations on it */
+		if (gs_app_get_state (app) == AS_APP_STATE_UNKNOWN)
+			continue;
+
 		if (gs_plugin_eos_blacklist_if_needed (plugin, app))
 			continue;
 


### PR DESCRIPTION
This prevents prematurely blacklisting apps before knowing if they're
are installed or not.

https://phabricator.endlessm.com/T14266