### PR TITLE
Add plugins for cleaning up the legacy external runtimes

### DIFF
--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -101,6 +101,8 @@ endif
 
 if HAVE_FLATPAK
 plugin_LTLIBRARIES += libgs_plugin_flatpak.la
+plugin_LTLIBRARIES += libgs_plugin_legacy-external-apps.la
+plugin_LTLIBRARIES += libgs_plugin_external-runtimes-cleaner.la
 endif
 
 if HAVE_OSTREE
@@ -227,7 +229,33 @@ libgs_plugin_flatpak_la_SOURCES =			\
 libgs_plugin_flatpak_la_LIBADD = $(GS_PLUGIN_LIBS) $(FLATPAK_LIBS)
 libgs_plugin_flatpak_la_LDFLAGS = -module -avoid-version
 libgs_plugin_flatpak_la_CFLAGS = $(GS_PLUGIN_CFLAGS) $(WARN_CFLAGS)
-endif
+
+libgs_plugin_legacy_external_apps_la_SOURCES =	\
+	gs-appstream.c				\
+	gs-appstream.h				\
+	gs-flatpak.c				\
+	gs-flatpak.h				\
+	gs-flatpak-symlinks.c			\
+	gs-flatpak-symlinks.h			\
+	gs-legacy-external-apps.h		\
+	gs-plugin-legacy-external-apps.c
+libgs_plugin_legacy_external_apps_la_LIBADD = $(GS_PLUGIN_LIBS) $(FLATPAK_LIBS) $(JSON_GLIB_LIBS)
+libgs_plugin_legacy_external_apps_la_LDFLAGS = -module -avoid-version
+libgs_plugin_legacy_external_apps_la_CFLAGS = $(GS_PLUGIN_CFLAGS) $(JSON_GLIB_CFLAGS) $(WARN_CFLAGS)
+
+libgs_plugin_external_runtimes_cleaner_la_SOURCES =		\
+	gs-appstream.c				\
+	gs-appstream.h				\
+	gs-flatpak.c				\
+	gs-flatpak.h				\
+	gs-flatpak-symlinks.c			\
+	gs-flatpak-symlinks.h			\
+	gs-legacy-external-apps.h		\
+	gs-plugin-external-runtimes-cleaner.c
+libgs_plugin_external_runtimes_cleaner_la_LIBADD = $(GS_PLUGIN_LIBS) $(FLATPAK_LIBS) $(JSON_GLIB_LIBS)
+libgs_plugin_external_runtimes_cleaner_la_LDFLAGS = -module -avoid-version
+libgs_plugin_external_runtimes_cleaner_la_CFLAGS = $(GS_PLUGIN_CFLAGS) $(JSON_GLIB_CFLAGS) $(WARN_CFLAGS)
+endif # HAVE_FLATPAK
 
 if HAVE_OSTREE
 libgs_plugin_ostree_la_SOURCES = gs-plugin-ostree.c

--- a/src/plugins/gs-legacy-external-apps.h
+++ b/src/plugins/gs-legacy-external-apps.h
@@ -1,0 +1,29 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2016 Endless Mobile, Inc
+ *
+ * Author: Joaquim Rocha <jrocha@endlessm.com>
+ *
+ * Licensed under the GNU General Public License Version 2
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef __GS_LEGACY_EXTERNAL_APPS_H__
+#define __GS_LEGACY_EXTERNAL_APPS_H__
+
+#define LEGACY_RUNTIME_INSTALLED_MTD_KEY "EndlessOS::legacy-ext-runtime-installed"
+
+#endif /* __GS_LEGACY_EXTERNAL_APPS_H__ */

--- a/src/plugins/gs-plugin-external-runtimes-cleaner.c
+++ b/src/plugins/gs-plugin-external-runtimes-cleaner.c
@@ -1,0 +1,240 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * gs-plugin-external-runtimes-cleaner: This plugin handles the removal of no
+ * longer needed external apps' "external runtimes".
+ * It should be removed once the transition path to the Flatpak implementation
+ * of external apps is complete.
+ *
+ * Copyright (C) 2016 Endless Mobile, Inc
+ *
+ * Author: Joaquim Rocha <jrocha@endlessm.com>
+ *
+ * Licensed under the GNU General Public License Version 2
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <config.h>
+#include <flatpak.h>
+#include <glib.h>
+#include <gnome-software.h>
+#include <string.h>
+
+#include "gs-appstream.h"
+#include "gs-flatpak.h"
+#include "gs-legacy-external-apps.h"
+
+struct GsPluginData {
+	FlatpakInstallation	*installation;
+};
+
+void
+gs_plugin_initialize (GsPlugin *plugin)
+{
+	GsPluginData *priv = gs_plugin_alloc_data (plugin, sizeof(GsPluginData));
+
+	/* Run plugin after the flatpak plugin because we need to complement its
+	 * update/removal implementations */
+	gs_plugin_add_rule (plugin, GS_PLUGIN_RULE_RUN_AFTER, "flatpak");
+}
+
+gboolean
+gs_plugin_setup (GsPlugin *plugin,
+		 GCancellable *cancellable,
+		 GError **error)
+{
+	GsPluginData *priv = gs_plugin_get_data (plugin);
+	priv->installation = flatpak_installation_new_system (cancellable,
+							      error);
+
+	if (!priv->installation)
+		return FALSE;
+
+	return TRUE;
+}
+
+void
+gs_plugin_destroy (GsPlugin *plugin)
+{
+	GsPluginData *priv = gs_plugin_get_data (plugin);
+	g_object_unref (priv->installation);
+}
+
+static void
+command_cancelled_cb (GCancellable *cancellable,
+		      GSubprocess *subprocess)
+{
+	g_debug ("Killing process '%s' after a cancellation!",
+		 g_subprocess_get_identifier (subprocess));
+	g_subprocess_force_exit (subprocess);
+}
+
+static gboolean
+run_command (const char **argv,
+	     GCancellable *cancellable,
+	     GError **error)
+{
+	g_autofree char *cmd = NULL;
+	int exit_val = -1;
+	g_autoptr(GSubprocess) subprocess = NULL;
+	gboolean result = FALSE;
+
+	subprocess = g_subprocess_newv (argv,
+					G_SUBPROCESS_FLAGS_STDOUT_PIPE |
+					G_SUBPROCESS_FLAGS_STDIN_PIPE,
+					error);
+
+	if (!subprocess)
+		return FALSE;
+
+	if (cancellable)
+		g_cancellable_connect (cancellable,
+				       G_CALLBACK (command_cancelled_cb),
+				       subprocess, NULL);
+
+	result = g_subprocess_wait_check (subprocess, NULL, error);
+	exit_val = g_subprocess_get_exit_status (subprocess);
+	cmd = g_strjoinv (" ", (char **) argv);
+
+	g_debug ("Result of running '%s': retcode=%d", cmd, exit_val);
+
+	return result;
+}
+
+static gboolean
+remove_legacy_ext_runtime (GsApp *app,
+			   const char *version,
+			   GCancellable *cancellable,
+			   GError **error)
+{
+	g_autofree char *name = g_strdup_printf ("%s.external",
+						 gs_app_get_flatpak_name (app));
+
+	/* run the external apps removal script as the configured helper user */
+	const char *argv[] = {"flatpak", "uninstall", "--runtime",
+			      name, version,
+			      NULL};
+
+	g_debug ("Removing runtime extension '%s' with branch '%s'...", name,
+		 version);
+
+	return run_command (argv, cancellable, error);
+}
+
+gboolean
+gs_plugin_app_remove (GsPlugin *plugin,
+		      GsApp *app,
+		      GCancellable *cancellable,
+		      GError **error)
+{
+	const char *version;
+	g_autoptr(GError) local_error = NULL;
+
+	/* only try to remove runtimes if the app has been or is being updated;
+	 * this prevents any removal if the app update has failed */
+	if (gs_app_is_installed (app) &&
+	    gs_app_get_state (app) != AS_APP_STATE_REMOVING)
+		return TRUE;
+
+	/* if the external runtime version is not installed, it is not a
+	 * legacy external app */
+	version = gs_app_get_metadata_item (app,
+					    LEGACY_RUNTIME_INSTALLED_MTD_KEY);
+	if (!version)
+		return TRUE;
+
+	if (!remove_legacy_ext_runtime (app, version, cancellable,
+					&local_error)) {
+		g_debug ("Could not remove legacy external runtime for app "
+			 "%s when updating it: %s", gs_app_get_unique_id (app),
+			 local_error->message);
+	}
+	return TRUE;
+}
+
+static gboolean
+app_is_new_external_app (GsPlugin *plugin,
+			 GsApp *app,
+			 GCancellable *cancellable)
+{
+	GsPluginData *priv = gs_plugin_get_data (plugin);
+	const char *deploy_dir;
+	g_autoptr(FlatpakInstalledRef) ref = NULL;
+	g_autofree char *extra_dir = NULL;
+	g_autoptr(GError) error = NULL;
+
+	ref = flatpak_installation_get_installed_ref (priv->installation,
+						      FLATPAK_REF_KIND_APP,
+						      gs_app_get_flatpak_name (app),
+						      gs_app_get_flatpak_arch (app),
+						      gs_app_get_flatpak_branch (app),
+						      cancellable,
+						      &error);
+
+	if (!ref) {
+		g_debug ("Failed to get ref for app '%s': %s",
+			 gs_app_get_unique_id (app), error->message);
+		return FALSE;
+	}
+
+	deploy_dir = flatpak_installed_ref_get_deploy_dir (ref);
+
+	/* new external apps (implemented in Flatpak) have their external assets
+	 * downloaded into an "extra" directory on install/update time; this
+	 * proves that the app is a new external app */
+	extra_dir = g_build_filename (deploy_dir, "files", "extra", NULL);
+	return g_file_test (extra_dir, G_FILE_TEST_IS_DIR | G_FILE_TEST_EXISTS);
+}
+
+gboolean
+gs_plugin_update_app (GsPlugin *plugin,
+		      GsApp *app,
+		      GCancellable *cancellable,
+		      GError **error)
+{
+	const char *version;
+	g_autoptr(GError) local_error = NULL;
+
+	/* only try to remove runtimes if the app has been or is being updated;
+	 * this prevents any removal if the app update has failed */
+	if (!gs_app_is_installed (app) ||
+	    gs_app_get_state (app) != AS_APP_STATE_INSTALLING)
+		return TRUE;
+
+	/* if the external runtime version is not installed, it is not a
+	 * legacy external app */
+	version = gs_app_get_metadata_item (app,
+					    LEGACY_RUNTIME_INSTALLED_MTD_KEY);
+	if (!version)
+		return TRUE;
+
+	/* making sure that the updated app is a new external app is another
+	 * safety check to ensure we don't break apps for users */
+	if (!app_is_new_external_app (plugin, app, cancellable)) {
+		g_warning ("Will not remove external runtime after upgrading "
+			   "app '%s': there is no 'extra' dir, so removing the "
+			   "runtime could break the app for the user.",
+			   gs_app_get_unique_id (app));
+		return TRUE;
+	}
+
+	if (!remove_legacy_ext_runtime (app, version, cancellable,
+					&local_error)) {
+		g_debug ("Could not remove legacy external runtime for app "
+			 "%s when updating it: %s", gs_app_get_unique_id (app),
+			 local_error->message);
+	}
+	return TRUE;
+}

--- a/src/plugins/gs-plugin-legacy-external-apps.c
+++ b/src/plugins/gs-plugin-legacy-external-apps.c
@@ -1,0 +1,220 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * gs-plugin-legacy-external-apps: This plugin handles the transition from
+ * Endless' custom implementation of external apps to the Flatpak's one.
+ * It should be removed once the transition path is complete for Endless OS
+ * users.
+ *
+ * Copyright (C) 2016 Endless Mobile, Inc
+ *
+ * Author: Joaquim Rocha <jrocha@endlessm.com>
+ *
+ * Licensed under the GNU General Public License Version 2
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <config.h>
+#include <flatpak.h>
+#include <glib.h>
+#include <gnome-software.h>
+#include <string.h>
+
+#include "gs-appstream.h"
+#include "gs-flatpak.h"
+#include "gs-legacy-external-apps.h"
+
+#define LEGACY_RUNTIME_MTD_KEY "EndlessOS::legacy-ext-runtime"
+
+static const char *LEGACY_EXTERNAL_APPS[] = {"com.dropbox.Client.desktop",
+					     "com.google.Chrome.desktop",
+					     "com.microsoft.Skype.desktop",
+					     "com.spotify.Client.desktop",
+					     NULL};
+
+struct GsPluginData {
+	FlatpakInstallation	*installation;
+};
+
+void
+gs_plugin_initialize (GsPlugin *plugin)
+{
+	GsPluginData *priv = gs_plugin_alloc_data (plugin, sizeof(GsPluginData));
+
+	/* Run plugin before the flatpak plugin because we need to setup the
+	 * external runtime version in the apps before they are actually
+	 * removed/updated */
+	gs_plugin_add_rule (plugin, GS_PLUGIN_RULE_RUN_BEFORE, "flatpak");
+}
+
+gboolean
+gs_plugin_setup (GsPlugin *plugin,
+		 GCancellable *cancellable,
+		 GError **error)
+{
+	GsPluginData *priv = gs_plugin_get_data (plugin);
+	priv->installation = flatpak_installation_new_system (cancellable,
+							      error);
+
+	if (!priv->installation)
+		return FALSE;
+
+	return TRUE;
+}
+
+void
+gs_plugin_destroy (GsPlugin *plugin)
+{
+	GsPluginData *priv = gs_plugin_get_data (plugin);
+	g_object_unref (priv->installation);
+}
+
+static gboolean
+app_is_legacy_external_app (GsApp *app)
+{
+	guint i;
+	for (i = 0; LEGACY_EXTERNAL_APPS[i] != NULL; ++i) {
+		const char *current_id = LEGACY_EXTERNAL_APPS[i];
+		if (g_strcmp0 (gs_app_get_id (app), current_id) == 0)
+			return TRUE;
+	}
+
+	return FALSE;
+}
+
+static AsApp *
+get_installed_appstream_app (GsPlugin *plugin,
+			     GsApp *app,
+			     GCancellable *cancellable,
+			     GError **error)
+{
+	AsApp *as_app;
+	GsPluginData *priv = gs_plugin_get_data (plugin);
+	const char *deploy_dir;
+	g_autoptr(AsStore) store = NULL;
+	g_autoptr(FlatpakInstalledRef) ref = NULL;
+	g_autoptr(GFile) appstream_file = NULL;
+	g_autofree char *appstream_xml = NULL;
+	g_autofree char *appstream_path = NULL;
+
+	ref = flatpak_installation_get_installed_ref (priv->installation,
+						      FLATPAK_REF_KIND_APP,
+						      gs_app_get_flatpak_name (app),
+						      gs_app_get_flatpak_arch (app),
+						      gs_app_get_flatpak_branch (app),
+						      cancellable,
+						      error);
+
+	if (!ref)
+		return NULL;
+
+	deploy_dir = flatpak_installed_ref_get_deploy_dir (ref);
+
+	appstream_xml = g_strdup_printf ("%s.appdata.xml",
+					  gs_app_get_flatpak_name (app));
+	appstream_path = g_build_filename (deploy_dir, "files", "share",
+					   "app-info", "xmls", appstream_xml,
+					   NULL);
+	appstream_file = g_file_new_for_path (appstream_path);
+
+	store = as_store_new ();
+	as_store_set_add_flags (store,
+				AS_STORE_ADD_FLAG_USE_UNIQUE_ID |
+				AS_STORE_ADD_FLAG_USE_MERGE_HEURISTIC);
+	if (!as_store_from_file (store, appstream_file, NULL, cancellable,
+				 error))
+		return NULL;
+
+	as_app = as_store_get_app_by_id (store, gs_app_get_id (app));
+	if (!as_app)
+		g_set_error (error, AS_STORE_ERROR, AS_STORE_ERROR_FAILED,
+			     "Failed to get app %s from its own installation "
+			     "AppStream file.", gs_app_get_unique_id (app));
+
+	return g_object_ref (as_app);
+}
+
+static gboolean
+setup_ext_runtime_version (GsPlugin *plugin,
+			   GsApp *app,
+			   GCancellable *cancellable,
+			   GError **error)
+{
+	const char *runtime_version;
+	g_autoptr(GError) local_error = NULL;
+	g_autoptr(AsApp) as_app = NULL;
+
+	if (!app_is_legacy_external_app (app))
+		return TRUE;
+
+	as_app = get_installed_appstream_app (plugin, app, cancellable,
+					      &local_error);
+
+	if (!as_app) {
+		g_warning ("Failed to get AsApp from installed AppStream "
+			   "data of app '%s': %s", gs_app_get_unique_id (app),
+			   local_error->message);
+		g_propagate_error (error, g_steal_pointer (&local_error));
+		return FALSE;
+	}
+
+	/* get the runtime version that is set in the installed AppStream data */
+	runtime_version = as_app_get_metadata_item (as_app,
+						    LEGACY_RUNTIME_MTD_KEY);
+
+	/* we setup the version of the external runtime used by this external
+	 * app so it is later used by "external-apps-cleaner" plugin when
+	 * removing those runtimes; we use a new key and not the one that is
+	 * already set in the metadata so we verify that this key has been
+	 * set by this plugin (and thus, by what was installed) and not by
+	 * the general AppStream data */
+	gs_app_set_metadata (app, LEGACY_RUNTIME_INSTALLED_MTD_KEY, NULL);
+	gs_app_set_metadata (app, LEGACY_RUNTIME_INSTALLED_MTD_KEY,
+			     runtime_version);
+
+	return TRUE;
+}
+
+gboolean
+gs_plugin_refine_app (GsPlugin *plugin,
+		      GsApp *app,
+		      GsPluginRefineFlags flags,
+		      GCancellable *cancellable,
+		      GError **error)
+{
+	/* we have to whitelist Chrome which has been blacklisted so previous
+	 * versions of the OS (without the helper app) would not see it */
+	if (g_strcmp0 (gs_app_get_id (app), "com.google.Chrome.desktop") == 0)
+		gs_app_remove_category (app, "Blacklisted");
+	return TRUE;
+}
+
+gboolean
+gs_plugin_app_remove (GsPlugin *plugin,
+		      GsApp *app,
+		      GCancellable *cancellable,
+		      GError **error)
+{
+	return setup_ext_runtime_version (plugin, app, cancellable, error);
+}
+
+gboolean
+gs_plugin_update_app (GsPlugin *plugin,
+		      GsApp *app,
+		      GCancellable *cancellable,
+		      GError **error)
+{
+	return setup_ext_runtime_version (plugin, app, cancellable, error);
+}


### PR DESCRIPTION
The plugin "legacy-external-apps" gets the info about the external
runtime from the installed AppStream data and runs before the "flatpak"
plugin so we can get this info before the app is changed
(removed/updated). That info is set as a metadata item in the GsApp
object.

The plugin "external-runtimes-cleaner" uses the info mentioned above
to remove the external runtimes once an app is updated or removed. It
runs after the Flatpak plugin and ensures that such runtimes are only
removed if the app has been successfully updated/removed.

https://phabricator.endlessm.com/T14442