### PR TITLE
Show the search button in the category and installed views

### DIFF
--- a/src/gs-shell.c
+++ b/src/gs-shell.c
@@ -289,7 +289,9 @@ gs_shell_change_mode (GsShell *shell,
 	/* only show the search button in overview and search pages */
 	widget = GTK_WIDGET (gtk_builder_get_object (priv->builder, "search_button"));
 	gtk_widget_set_visible (widget, mode == GS_SHELL_MODE_OVERVIEW ||
-					mode == GS_SHELL_MODE_SEARCH);
+					mode == GS_SHELL_MODE_SEARCH ||
+					mode == GS_SHELL_MODE_CATEGORY ||
+					mode == GS_SHELL_MODE_INSTALLED);
 	/* hide unless we're going to search */
 	widget = GTK_WIDGET (gtk_builder_get_object (priv->builder, "search_bar"));
 	gtk_search_bar_set_search_mode (GTK_SEARCH_BAR (widget),


### PR DESCRIPTION
Upstream has chosen not to show this button in the mentioned views for
different reasons but we need this in order for the UI to be coherent.

https://phabricator.endlessm.com/T13211