### PR TITLE
Pull the default branches from the server's summary file when needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -258,7 +258,7 @@ AC_ARG_ENABLE(flatpak,
               enable_flatpak=maybe)
 AS_IF([test "x$enable_flatpak" != "xno"], [
     PKG_CHECK_MODULES(FLATPAK,
-                      [flatpak >= 0.6.12],
+                      [flatpak >= 0.6.13],
                       [have_flatpak=yes],
                       [have_flatpak=no])
 ], [


### PR DESCRIPTION
Ensure that the default-branch attribute is pulled from the server's
summary file on refresh time.

This is based on a patch by Mario Sanchez related to T13403.

https://phabricator.endlessm.com/T14596