### PR TITLE
Disable the featured banner

### DIFF
--- a/src/gs-shell-overview.c
+++ b/src/gs-shell-overview.c
@@ -558,7 +558,8 @@ gs_shell_overview_load (GsShellOverview *self)
 
 	priv->empty = TRUE;
 
-	if (!priv->loading_featured) {
+	/* disable the featured app for now until we have a plan for it */
+	if (FALSE && !priv->loading_featured) {
 		priv->loading_featured = TRUE;
 		gs_plugin_loader_get_featured_async (priv->plugin_loader,
 						     GS_PLUGIN_REFINE_FLAGS_REQUIRE_ICON,

--- a/src/gs-shell-overview.ui
+++ b/src/gs-shell-overview.ui
@@ -111,7 +111,7 @@
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkLabel" id="featured_heading">
-                            <property name="visible">True</property>
+                            <property name="visible">False</property>
                             <property name="can_focus">False</property>
                             <property name="xalign">0</property>
                             <property name="label" translatable="yes">Featured Application</property>
@@ -132,7 +132,7 @@
                         </child>
                         <child>
                           <object class="GtkAlignment" id="bin_featured">
-                            <property name="visible">True</property>
+                            <property name="visible">False</property>
                             <property name="halign">fill</property>
                           </object>
                           <packing>


### PR DESCRIPTION
The reason is that we still do not have a defined plan for how to use
this section, so it's better to disable it until then.

https://phabricator.endlessm.com/T14706