### PR TITLE
Fix launching Flatpak apps

### DIFF
--- a/src/plugins/gs-flatpak.c
+++ b/src/plugins/gs-flatpak.c
@@ -2042,22 +2042,6 @@ gs_flatpak_launch (GsFlatpak *self,
 	if (branch == NULL)
 		branch = "master";
 
-	/* check the runtime is installed */
-	runtime = gs_app_get_runtime (app);
-	if (runtime != NULL) {
-		if (!gs_plugin_refine_item_state (self, runtime, cancellable, error))
-			return FALSE;
-		if (!gs_app_is_installed (runtime)) {
-			g_set_error_literal (error,
-					     GS_PLUGIN_ERROR,
-					     GS_PLUGIN_ERROR_NOT_SUPPORTED,
-					     "runtime is not installed");
-			gs_utils_error_add_unique_id (error, runtime);
-			gs_plugin_cache_add (self->plugin, NULL, runtime);
-			return FALSE;
-		}
-	}
-
 	/* launch the app */
 	if (!flatpak_installation_launch (self->installation,
 					  gs_app_get_flatpak_name (app),


### PR DESCRIPTION
The apps rely on the runtimes declaration in the repo's AppStream file.
This information however relates to the app's version that is given by
the server, which may need a different runtime (because of a update)
than what is installed; thus, these changes drop the check that verifies
whether the runtime is installed before launching the app, delegating
that responsibility to Flatpak itself which prevents mistakenly assuming
that the runtime is not installed.

https://phabricator.endlessm.com/T14905