### PR TITLE
Fix missing name for GNOME Software

### DIFF
--- a/src/org.gnome.Software.desktop.in
+++ b/src/org.gnome.Software.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
-_Name=App Center
-_Comment=Add, remove or update software on this computer
+Name=App Center
+Comment=Add, remove or update software on this computer
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=org.gnome.Software
 Exec=gnome-software %U


### PR DESCRIPTION
https://phabricator.endlessm.com/T14837