### PR TITLE
Temporarily added GNOME Weather to the list of blacklisted apps

### DIFF
--- a/src/plugins/gs-flatpak.c
+++ b/src/plugins/gs-flatpak.c
@@ -184,7 +184,7 @@ gs_flatpak_remove_prefixed_names (AsApp *app)
 static gboolean
 app_is_blacklisted_gnome_flatpak (AsApp *app, AsAppScope scope, FlatpakRemote *xremote)
 {
-	/* IDs of apps already provided by our core OS */
+	/* IDs of apps already provided by our core OS or our own flatpaks */
 	static const char *duplicated_apps[] = {
 		"org.gnome.Builder.desktop",
 		"org.gnome.Calculator.desktop",
@@ -192,6 +192,7 @@ app_is_blacklisted_gnome_flatpak (AsApp *app, AsAppScope scope, FlatpakRemote *x
 		"org.gnome.Nautilus.desktop",
 		"org.gnome.Rhythmbox3.desktop",
 		"org.gnome.Totem.desktop",
+		"org.gnome.Weather.desktop",
 		"org.gnome.clocks.desktop",
 		"org.gnome.eog.desktop",
 		"org.gnome.gedit.desktop",


### PR DESCRIPTION
The idea is to use GNOME Weather from the GNOME flatpak repository
but we can't do it now because we need it to be patched so that it
allows overriding its application ID (needed for Endless Coding).

See the upstream bug: https://bugzilla.gnome.org/show_bug.cgi?id=776315

In the meantime we are creating our own flatpak for GNOME Weather,
so we need to blacklist the one from GNOME to avoid duplicates.

https://phabricator.endlessm.com/T14720