### PR TITLE
Fix launching apps after updating

### DIFF
--- a/src/plugins/gs-flatpak.c
+++ b/src/plugins/gs-flatpak.c
@@ -1597,6 +1597,29 @@ gs_plugin_refine_item_state (GsFlatpak *self,
 	return TRUE;
 }
 
+static GsApp *
+gs_flatpak_create_runtime_from_metadata (GsFlatpak *self,
+					 const GsApp *app,
+					 const gchar *data,
+					 const gsize length,
+					 GError **error)
+{
+	g_autofree gchar *runtime = NULL;
+	g_autoptr(GKeyFile) kf = NULL;
+
+	kf = g_key_file_new ();
+	if (!g_key_file_load_from_data (kf, data, length, G_KEY_FILE_NONE, error)) {
+		gs_utils_error_convert_gio (error);
+		return FALSE;
+	}
+	runtime = g_key_file_get_string (kf, "Application", "runtime", error);
+	if (runtime == NULL) {
+		gs_utils_error_convert_gio (error);
+		return FALSE;
+	}
+	return gs_appstream_create_runtime (self->plugin, app, runtime);
+}
+
 static gboolean
 gs_flatpak_set_app_metadata (GsFlatpak *self,
 			     GsApp *app,
@@ -1669,6 +1692,41 @@ gs_flatpak_set_app_metadata (GsFlatpak *self,
 	return TRUE;
 }
 
+static GBytes *
+gs_flatpak_fetch_remote_metadata (GsFlatpak *self,
+				  GsApp *app,
+				  GCancellable *cancellable,
+				  GError **error)
+{
+	g_autoptr(GBytes) data = NULL;
+	g_autoptr(FlatpakRef) xref = NULL;
+
+	/* no origin */
+	if (gs_app_get_origin (app) == NULL) {
+		g_set_error (error,
+			     GS_PLUGIN_ERROR,
+			     GS_PLUGIN_ERROR_NOT_SUPPORTED,
+			     "no origin set for %s",
+			     gs_app_get_unique_id (app));
+		return NULL;
+	}
+
+	/* fetch from the server */
+	xref = gs_flatpak_create_fake_ref (app, error);
+	if (xref == NULL)
+		return NULL;
+	data = flatpak_installation_fetch_remote_metadata_sync (self->installation,
+								gs_app_get_origin (app),
+								xref,
+								cancellable,
+								error);
+	if (data == NULL) {
+		gs_plugin_flatpak_error_convert (error);
+		return NULL;
+	}
+	return g_steal_pointer (&data);
+}
+
 static gboolean
 gs_plugin_refine_item_metadata (GsFlatpak *self,
 				GsApp *app,
@@ -1716,31 +1774,8 @@ gs_plugin_refine_item_metadata (GsFlatpak *self,
 			return FALSE;
 		str = contents;
 	} else {
-		g_autoptr(FlatpakRef) xref = NULL;
-
-		/* no origin */
-		if (gs_app_get_origin (app) == NULL) {
-			g_set_error (error,
-				     GS_PLUGIN_ERROR,
-				     GS_PLUGIN_ERROR_NOT_SUPPORTED,
-				     "no origin set for %s",
-				     gs_app_get_unique_id (app));
-			return FALSE;
-		}
-
-		/* fetch from the server */
-		xref = gs_flatpak_create_fake_ref (app, error);
-		if (xref == NULL)
-			return FALSE;
-		data = flatpak_installation_fetch_remote_metadata_sync (self->installation,
-									gs_app_get_origin (app),
-									xref,
-									cancellable,
-									error);
-		if (data == NULL) {
-			gs_plugin_flatpak_error_convert (error);
-			return FALSE;
-		}
+		data = gs_flatpak_fetch_remote_metadata (self, app, cancellable,
+							 error);
 		str = g_bytes_get_data (data, &len);
 	}
 
@@ -2143,7 +2178,29 @@ install_runtime_for_app (GsFlatpak *self,
 			 GError **error)
 {
 	GsApp *runtime;
-	runtime = gs_app_get_runtime (app);
+	gsize len;
+	const gchar *str;
+	g_autoptr(GBytes) data = gs_flatpak_fetch_remote_metadata (self, app,
+								   cancellable,
+								   error);
+
+	if (data == NULL) {
+		gs_utils_error_add_unique_id (error, app);
+		gs_app_set_state_recover (app);
+		return FALSE;
+	}
+
+	str = g_bytes_get_data (data, &len);
+	runtime = gs_flatpak_create_runtime_from_metadata (self, app, str, len,
+							   error);
+
+	if (runtime != NULL) {
+		gs_app_set_runtime (app, runtime);
+	} else {
+		gs_utils_error_add_unique_id (error, app);
+		gs_app_set_state_recover (app);
+		return FALSE;
+	}
 
 	/* the runtime could come from a different remote to the app */
 	if (!gs_refine_item_metadata (self, runtime, cancellable, error)) {


### PR DESCRIPTION
When an app has an update and the new updated app needs a different
runtime, unless the AppStream of the repo has been very recently
updated, the app not realize that it needs to eventually install a
new runtime.

These changes get the runtime information from the remote ref (meaning
the real runtime for the app) before deciding whether the runtime
needs to be installed which prevents the problem above.

https://phabricator.endlessm.com/T15062