### PR TITLE
Fix updating the app desktop shortcuts when apps are updatable

### DIFF
--- a/src/plugins/gs-plugin-eos.c
+++ b/src/plugins/gs-plugin-eos.c
@@ -533,8 +533,7 @@ gs_plugin_eos_update_app_shortcuts_info (GsPlugin *plugin,
 	const char *app_id = NULL;
 	g_autoptr (GDesktopAppInfo) app_info = NULL;
 
-	if (gs_app_get_state (app) != AS_APP_STATE_INSTALLED &&
-	    gs_app_get_state (app) != AS_APP_STATE_UPDATABLE) {
+	if (!gs_app_is_installed (app)) {
 		gs_app_remove_quirk (app, AS_APP_QUIRK_HAS_SHORTCUT);
 		return;
 	}


### PR DESCRIPTION
The logic was not checking all the updatable states (there's
"updatable" and "updatable live"). This patch uses the convenience
function gs_app_is_installed instead of checking the statuses
directly.

https://phabricator.endlessm.com/T15010