### PR TITLE
eos: Remove shortcuts directly when applications are removed

### DIFF
--- a/src/plugins/gs-plugin-eos.c
+++ b/src/plugins/gs-plugin-eos.c
@@ -870,6 +870,23 @@ gs_plugin_app_install (GsPlugin *plugin,
 	return TRUE;
 }
 
+gboolean
+gs_plugin_app_remove (GsPlugin *plugin,
+		      GsApp *app,
+		      GCancellable *cancellable,
+		      GError **error)
+{
+	if (!gs_app_is_flatpak (app))
+		return TRUE;
+
+	/* We're only interested in apps that have been successfully uninstalled */
+	if (gs_app_is_installed (app))
+		return TRUE;
+
+	remove_app_from_shell (plugin, app, cancellable, error);
+	return TRUE;
+}
+
 static gboolean
 launch_with_sys_desktop_file (GsApp *app,
                               GError **error)


### PR DESCRIPTION
This is done automatically by the Shell for all applications except
Chrome as it uses a special desktop file instead of the one provided
by Flatpak. Nonetheless, instead of using a different logic only for
Chrome, this patch always attempts to remove the shortcut for any
Flatpak app that is removed (as it's future proof in case more apps
have special desktop files in the future).

https://phabricator.endlessm.com/T15130