### PR TITLE
Warn and limit the progress set on a GsApp

### DIFF
--- a/src/gs-app.c
+++ b/src/gs-app.c
@@ -845,6 +845,12 @@ gs_app_set_progress (GsApp *app, guint percentage)
 	g_return_if_fail (GS_IS_APP (app));
 	if (app->progress == percentage)
 		return;
+	if (percentage > 100) {
+		g_warning ("Cannot set '%u' as the progress for app '%s'. "
+			   "Setting the maximum allowed value instead: 100.",
+			   percentage, gs_app_get_unique_id (app));
+		percentage = 100;
+	}
 	app->progress = percentage;
 	gs_app_queue_notify (app, "progress");
 }

--- a/src/gs-self-test.c
+++ b/src/gs-self-test.c
@@ -402,6 +402,14 @@ gs_app_func (void)
 	/* correctly parse URL */
 	gs_app_set_origin_hostname (app, "https://mirrors.fedoraproject.org/metalink");
 	g_assert_cmpstr (gs_app_get_origin_hostname (app), ==, "fedoraproject.org");
+
+	/* check setting the progress */
+	gs_app_set_progress (app, 42);
+	g_assert_cmpuint (gs_app_get_progress (app), ==, 42);
+	g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING,
+			       "Cannot set*as the progress for app*");
+	gs_app_set_progress (app, 142);
+	g_assert_cmpuint (gs_app_get_progress (app), ==, 100);
 }
 
 static guint _status_changed_cnt = 0;


### PR DESCRIPTION
If the progress being set is greater than 100 a warning should be
returned and the value be limited to 100.

https://phabricator.endlessm.com/T15131