### PR TITLE
T14960

### DIFF
--- a/src/gnome-software.ui
+++ b/src/gnome-software.ui
@@ -452,6 +452,7 @@
                 <child>
                   <object class="GtkStack" id="stack_main">
                     <property name="visible">True</property>
+                    <property name="hhomogeneous">False</property>
                     <child>
                       <object class="GsShellOverview" id="shell_overview">
                         <property name="visible">True</property>

--- a/src/gnome-software.ui
+++ b/src/gnome-software.ui
@@ -420,7 +420,6 @@
 
                 <child>
                   <object class="GtkScrolledWindow" id="scrolledwindow_sidefilter">
-                    <property name="width-request">220</property>
                     <property name="visible">False</property>
                     <property name="margin-top">0</property>
                     <property name="margin-bottom">0</property>
@@ -431,6 +430,8 @@
                     <property name="vscrollbar_policy">automatic</property>
                     <property name="shadow_type">in</property>
                     <property name="valign">fill</property>
+                    <property name="min-content-width">200</property>
+                    <property name="propagate-natural-width">True</property>
                     <style>
                       <class name="sidefilter_scrolledwindow"/>
                     </style>

--- a/src/gs-shell.c
+++ b/src/gs-shell.c
@@ -40,6 +40,7 @@
 #include "gs-sources-dialog.h"
 #include "gs-update-dialog.h"
 #include "gs-update-monitor.h"
+#include "gs-utils.h"
 
 static const gchar *page_name[] = {
 	"unknown",
@@ -1736,6 +1737,24 @@ gs_shell_setup (GsShell *shell, GsPluginLoader *plugin_loader, GCancellable *can
 
 	/* coldplug */
 	gs_shell_rescan_events (shell);
+
+	/* adapt the window for low resolution screens */
+	if (gs_utils_is_low_resolution ()) {
+		    GtkWidget *buttonbox = GTK_WIDGET (gtk_builder_get_object (priv->builder, "buttonbox_main"));
+
+		    gtk_container_child_set (GTK_CONTAINER (buttonbox),
+					     GTK_WIDGET (gtk_builder_get_object (priv->builder, "button_all")),
+					     "non-homogeneous", TRUE,
+					     NULL);
+		    gtk_container_child_set (GTK_CONTAINER (buttonbox),
+					     GTK_WIDGET (gtk_builder_get_object (priv->builder, "button_installed")),
+					     "non-homogeneous", TRUE,
+					     NULL);
+		    gtk_container_child_set (GTK_CONTAINER (buttonbox),
+					     GTK_WIDGET (gtk_builder_get_object (priv->builder, "button_updates")),
+					     "non-homogeneous", TRUE,
+					     NULL);
+	    }
 }
 
 void

--- a/src/gs-side-filter-row.ui
+++ b/src/gs-side-filter-row.ui
@@ -44,6 +44,7 @@
               <object class="GtkLabel" id="label">
 		<property name="visible">True</property>
 		<property name="xalign">0</property>
+                <property name="wrap">True</property>
 		<attributes>
 		  <attribute name="weight" value="bold"/>
 		</attributes>

--- a/src/gs-utils.c
+++ b/src/gs-utils.c
@@ -46,6 +46,9 @@
 #include "gs-utils.h"
 #include "gs-plugin.h"
 
+#define LOW_RESOLUTION_WIDTH  800
+#define LOW_RESOLUTION_HEIGHT 600
+
 /**
  * gs_mkdir_parent:
  * @path: A full pathname
@@ -828,6 +831,26 @@ gs_utils_error_convert_appstream (GError **perror)
 	}
 	error->domain = GS_PLUGIN_ERROR;
 	return TRUE;
+}
+
+/**
+ * gs_utils_is_low_resolution:
+ *
+ * Retrieves whether the primary monitor has a low resolution.
+ *
+ * Returns: %TRUE if the monitor has low resolution
+ **/
+gboolean
+gs_utils_is_low_resolution (void)
+{
+	GdkRectangle geometry;
+	GdkMonitor *monitor;
+
+	monitor = gdk_display_get_primary_monitor (gdk_display_get_default ());
+
+	gdk_monitor_get_geometry (monitor, &geometry);
+
+	return geometry.width < LOW_RESOLUTION_WIDTH || geometry.height < LOW_RESOLUTION_HEIGHT;
 }
 
 /* vim: set noexpandtab: */

--- a/src/gs-utils.h
+++ b/src/gs-utils.h
@@ -78,6 +78,7 @@ gboolean	 gs_utils_error_convert_gdbus	(GError		**perror);
 gboolean	 gs_utils_error_convert_gdk_pixbuf(GError	**perror);
 gboolean	 gs_utils_error_convert_json_glib (GError	**perror);
 gboolean	 gs_utils_error_convert_appstream (GError	**perror);
+gboolean	 gs_utils_is_low_resolution	  (void);
 
 G_END_DECLS
 


### PR DESCRIPTION
This PR makes GNOME Software usable on low resolution displays through the following changes:
 * Make the main stack non-homogeneous
 * Make the header buttons non-homogeneous on low resolution displays
 * Allow the sidebar to reduce its width when needed

https://phabricator.endlessm.com/T14960