### PR TITLE
eos: Do not add a shortcut to the desktop if it's already there

### DIFF
--- a/src/plugins/gs-plugin-eos.c
+++ b/src/plugins/gs-plugin-eos.c
@@ -799,10 +799,19 @@ add_app_to_shell (GsPlugin	*plugin,
 		  GCancellable	*cancellable,
 		  GError	**error_out)
 {
+	GHashTable *apps_with_shortcuts;
 	GError *error = NULL;
 	GsPluginData *priv = gs_plugin_get_data (plugin);
 	g_autoptr (GDesktopAppInfo) app_info = get_desktop_app_info (app);
 	const char *app_id = g_app_info_get_id (G_APP_INFO (app_info));
+
+	apps_with_shortcuts = get_applications_with_shortcuts (plugin, NULL, NULL);
+	if (g_hash_table_lookup (apps_with_shortcuts, app_id)) {
+		g_debug ("App '%s' already has its shortcut (%s) in the desktop; "
+			 "skipping adding it.", gs_app_get_unique_id (app),
+			 app_id);
+		return TRUE;
+	}
 
 	g_dbus_connection_call_sync (priv->session_bus,
 				     "org.gnome.Shell",


### PR DESCRIPTION
The EOS plugin adds a shortcut in the desktop to the apps after they
are installed and this was being done without checking if that shortcut
was already present.
This has not been a problem because applications (usually) do not get
their shortcut in the desktop when they are not installed but this
changed for Google Chrome where we ship some images already with a
special shortcut to it. The problem is that when a shortcut is added
to the desktop while it is already present in there it gets moved to
the end of the list of shortcuts which is not the desired behavior
in this use-case.

These changes fix the mentioned problem by simply avoiding to add a
shortcut to the desktop if it is already there.

https://phabricator.endlessm.com/T15185