### PR TITLE
Blacklist GNOME Games: flatpak from stable channel is buggy and crashes

### DIFF
--- a/src/plugins/gs-flatpak.c
+++ b/src/plugins/gs-flatpak.c
@@ -206,6 +206,8 @@ app_is_blacklisted_gnome_flatpak (AsApp *app, AsAppScope scope, FlatpakRemote *x
 		"org.gnome.Documents.desktop",
 		/* Rendering issues in YouTube */
 		"org.gnome.Epiphany.desktop",
+		/* Crashes retrieving covers, wrong libretro installation*/
+		"org.gnome.Games.desktop",
 		/* Doesn't work due to network related problems */
 		"org.gnome.Maps.desktop",
 		/* Requires Telepathy daemons running in the host */


### PR DESCRIPTION
The org.gnome.Games flatpak in the stable channel is buggy and easily
crashes when retrieving covers, as well as when trying to run some
ROMS that rely on libretro-specific plugins, as those are not installed
in the right path under /app.

This is currently fixed in the nightly channel, so we will hopefully be
able to un-blacklist once those versions make it to the stable channel.

https://phabricator.endlessm.com/T15446