### PR TITLE
Reset GsApp's progress to zero when recovering a non-transient state

### DIFF
--- a/src/gs-app.c
+++ b/src/gs-app.c
@@ -700,6 +700,10 @@ gs_app_set_state_recover (GsApp *app)
 		 as_app_state_to_string (app->state),
 		 as_app_state_to_string (app->state_recover));
 
+	/* make sure progress gets reset when recovering state, to prevent
+	 * confusing initial states when going through more than one attempt */
+	gs_app_set_progress (app, 0);
+
 	app->state = app->state_recover;
 	gs_app_queue_notify (app, "state");
 }


### PR DESCRIPTION
Make sure progress gets reset when recovering state, to prevent
confusing initial states when going through more than one attempt.

https://phabricator.endlessm.com/T15569