### PR TITLE
Don't blacklist GNOME Builder

### DIFF
--- a/src/plugins/gs-flatpak.c
+++ b/src/plugins/gs-flatpak.c
@@ -186,7 +186,6 @@ app_is_blacklisted_gnome_flatpak (AsApp *app, AsAppScope scope, FlatpakRemote *x
 {
 	/* IDs of apps already provided by our core OS or our own flatpaks */
 	static const char *duplicated_apps[] = {
-		"org.gnome.Builder.desktop",
 		"org.gnome.Calculator.desktop",
 		"org.gnome.Evince.desktop",
 		"org.gnome.Nautilus.desktop",


### PR DESCRIPTION
In the past, GNOME Builder didn't properly installed
the appstream data, and GNOME Software wouldn't show
it. Sometime later, we blacklisted Builder and, even
after the appstream issue was fixed, Software wouldn't
show it.

Fix that by not blacklisting GNOME Builder.

https://phabricator.endlessm.com/T14858