### PR TITLE
Initialize progress to zero right before and after processing and action

### DIFF
--- a/src/gs-plugin-loader.c
+++ b/src/gs-plugin-loader.c
@@ -1168,6 +1168,9 @@ gs_plugin_loader_run_action (GsPluginLoaderJob *job,
 {
 	GsPluginLoaderPrivate *priv = gs_plugin_loader_get_instance_private (job->plugin_loader);
 
+	/* make sure the progress is properly initialized */
+	gs_app_set_progress (job->app, 0);
+
 	/* run each plugin */
 	for (guint i = 0; i < priv->plugins->len; i++) {
 		GsPlugin *plugin = g_ptr_array_index (priv->plugins, i);
@@ -2579,6 +2582,10 @@ gs_plugin_loader_app_action_thread_cb (GTask *task,
 	/* perform action */
 	if (gs_plugin_loader_run_action (job, cancellable, &error)) {
 		g_autoptr(GsPluginLoaderJob) job2 = NULL;
+
+		/* reset the progress after successful operations */
+		gs_app_set_progress (job->app, 0);
+
 		/* unstage addons */
 		addons = gs_app_get_addons (job->app);
 		for (i = 0; i < addons->len; i++) {


### PR DESCRIPTION
This will make sure that, even after a successful installation, the
progress bar is reset to zero, to prevent confusion in the unlikely
event of the user going for a install + uninstall + reinstall process.

Note: This patch is a backport from the one upstream without the unit
tests, that would cause lots of conflicts due to a different baseline.
See https://git.gnome.org/browse/gnome-software/commit/?id=89b5dcde

https://phabricator.endlessm.com/T15569