### PR TITLE
Don't try to validate the eos-extra.xml file by parsing it with AsStore

### DIFF
--- a/src/plugins/gs-install-appstream.c
+++ b/src/plugins/gs-install-appstream.c
@@ -85,18 +85,6 @@ gs_install_appstream_check_content_type (GFile *file, GError **error)
 		return FALSE;
 	}
 
-	/* check is an AppStream file */
-	store = as_store_new ();
-	if (!as_store_from_file (store, file, NULL, NULL, error))
-		return FALSE;
-	if (as_store_get_size (store) == 0) {
-		g_set_error_literal (error,
-				     G_IO_ERROR,
-				     G_IO_ERROR_INVALID_DATA,
-				     "No applications found in the AppStream XML");
-		return FALSE;
-	}
-
 	return TRUE;
 }
 


### PR DESCRIPTION
After the change in gnome-software-data@c7028eee, the eos-extra.xml file
will no longer contain full <components> but partial ones, as they are
meant to be merged with the full versions of them (provided by the distro
wide AppStream collection XML), and therefore declare the merge='append'
attribute as described in the Appstream specification [1].

Because of this, it is no longer possible to validate this file by using
use as_store_from_file() to load the XML and then checking that it has
at least some elements, because that will never be the case as now that
file does not contain any complete component by itself, just extended
information for the already present ones.

Thus, we have to drop this validation step and believe that the file
is valid as long as it's a valid gzipped-XML, leaving the proper step
of validation for later on, when GNOME Software loads all the data and
tries to merge it to get the final result.

[1] https://www.freedesktop.org/software/appstream/docs/chap-DistroData.html

https://phabricator.endlessm.com/T15646