### PR TITLE
Switch to the light theme

### DIFF
--- a/src/gnome-software.ui
+++ b/src/gnome-software.ui
@@ -421,28 +421,24 @@
                 <child>
                   <object class="GtkScrolledWindow" id="scrolledwindow_sidefilter">
                     <property name="visible">False</property>
-                    <property name="margin-top">0</property>
-                    <property name="margin-bottom">0</property>
-                    <property name="margin-start">0</property>
-                    <property name="margin-end">12</property>
+                    <property name="margin">0</property>
                     <property name="can_focus">True</property>
                     <property name="hscrollbar_policy">never</property>
                     <property name="vscrollbar_policy">automatic</property>
-                    <property name="shadow_type">in</property>
                     <property name="valign">fill</property>
                     <property name="min-content-width">200</property>
                     <property name="propagate-natural-width">True</property>
                     <style>
-                      <class name="sidefilter_scrolledwindow"/>
+                      <class name="background"/>
                     </style>
                     <child>
                       <object class="GtkListBox" id="listbox_sidefilter">
                         <property name="visible">True</property>
-                        <property name="margin-top">4</property>
                         <property name="selection_mode">browse</property>
                         <property name="halign">fill</property>
                         <style>
                           <class name="sidefilter"/>
+                          <class name="background"/>
                         </style>
                       </object>
                     </child>

--- a/src/gs-application.c
+++ b/src/gs-application.c
@@ -236,10 +236,6 @@ gs_application_initialize_ui (GsApplication *app)
 
 	initialized = TRUE;
 
-	/* prefer the dark theme */
-	g_object_set (gtk_settings_get_default (),
-		      "gtk-application-prefer-dark-theme", TRUE, NULL);
-
 	/* add custom icons */
 	gtk_icon_theme_add_resource_path (gtk_icon_theme_get_default (),
 					  "/org/gnome/Software/icons");

--- a/src/gs-shell-category.ui
+++ b/src/gs-shell-category.ui
@@ -5,6 +5,11 @@
     <child>
       <object class="GtkBox" id="box_category">
         <property name="visible">True</property>
+
+        <style>
+          <class name="view" />
+        </style>
+
         <child>
           <object class="GtkScrolledWindow" id="scrolledwindow_filter">
             <property name="width-request">220</property>

--- a/src/gs-shell-overview.ui
+++ b/src/gs-shell-overview.ui
@@ -10,6 +10,11 @@
     <child>
       <object class="GtkStack" id="stack_overview">
         <property name="visible">True</property>
+
+        <style>
+          <class name="view" />
+        </style>
+
         <child>
           <object class="GtkBox">
             <property name="visible">True</property>

--- a/src/gs-side-filter-row.ui
+++ b/src/gs-side-filter-row.ui
@@ -35,9 +35,6 @@
 		<property name="can_focus">False</property>
 		<property name="icon_name">folder-music-symbolic</property>
 		<property name="icon_size">3</property>
-		<style>
-		  <class name="dim-label"/>
-		</style>
 	      </object>
             </child>
             <child>
@@ -48,9 +45,6 @@
 		<attributes>
 		  <attribute name="weight" value="bold"/>
 		</attributes>
-		<style>
-		  <class name="dim-label"/>
-		</style>
               </object>
             </child>
 	  </object>

--- a/src/gtk-style.css
+++ b/src/gtk-style.css
@@ -412,12 +412,29 @@ flowboxchild {
 }
 
 .sidefilter row:hover {
-	background-color: @theme_bg_color;
+	background-color: alpha(#f3f3f3, 0.66);
+}
+
+/* The selected row always have 1px borders... */
+.sidefilter row:selected,
+.sidefilter:backdrop row:selected {
+	border: solid #cfcfcf;
+	border-width: 1px 0 1px 0;
+}
+
+/* ... except the first row */
+.sidefilter row:first-child:selected,
+.sidefilter:backdrop row:first-child:selected {
+	border: solid #cfcfcf;
+	border-width: 0 0 1px 0;
+}
+
+.sidefilter:backdrop row:selected {
+	background-color: #f3f3f3;
 }
 
 .sidefilter row:selected {
-	background-color: @theme_bg_color;
-	border-bottom: 1px #000;
+	background-color: #f6f6f6;
 }
 
 .sidefilter row {
@@ -441,12 +458,21 @@ flowboxchild {
 	opacity: 1;
 }
 
-.sidefilter_scrolledwindow {
+.sidefilter row label,
+.sidefilter row image {
+	color: #4d4d4d;
+}
+
+
+.image-tile stack {
+	background-color: #646464;
+	border-radius: 8px;
 	border: 0;
+	padding: 0;
 }
 
 .image-tile, .image-tile .main-image {
-	border-radius: 3%;
+	border-radius: 8px;
 	border: 0;
 	padding: 0;
 }
@@ -454,12 +480,12 @@ flowboxchild {
 .image-tile .app-info {
 	background: linear-gradient(to bottom, transparent 50%, rgba(0, 0, 0, 0.6));
 	transition-duration: 500ms;
-	border-radius: 3%;
+	border-radius: 8px;
 	border: 0;
 }
 
 .image-tile:hover .app-info {
-	background: rgba(255, 255, 255, 0.8);
+	background: rgba(0, 0, 0, 0.75);
 	transition-duration: 0;
 }
 
@@ -474,6 +500,8 @@ flowboxchild {
 }
 
 .image-tile .app-name {
+	text-shadow: 0px 1px 2px black;
+	color: white;
 	font-size: 20px;
 }
 
@@ -493,16 +521,16 @@ flowboxchild {
 
 .image-tile .app-installed-indicator {
 	font-size: 80%;
-	background-color: @theme_bg_color;
+	background-color: #f6f6f6;
 	border-radius: 0;
-	color: @theme_selected_fg_color;
 	text-shadow: none;
 	opacity: 0;
 	transition-duration: 300ms;
 }
 
+.image-tile .app-installed-indicator:backdrop,
 .image-tile .app-installed-indicator:backdrop label {
-	color: @theme_selected_fg_color;
+	background-color: #f3f3f3;
 }
 
 .image-tile:hover .app-installed-indicator {
@@ -511,9 +539,20 @@ flowboxchild {
 }
 
 .image-tile .app-summary {
+	text-shadow: 0px 1px 2px black;
+	color: white;
 	font-size: 80%;
 }
 
 .application-details-website {
 	padding: 0;
+}
+
+/* Override the theme's .view class */
+.view {
+	background-color: #f6f6f6;
+}
+
+.view:backdrop {
+	background-color: #f3f3f3;
 }


### PR DESCRIPTION
This PR changes GNOME Software to use the light theme variant. This is how it looks:

![captura de tela de 2017-03-21 15-50-04](https://cloud.githubusercontent.com/assets/3518204/24165025/1e783814-0e4e-11e7-8b9a-f20a0d7e18a4.png)

Per the mockups at https://endlessm.invisionapp.com/d/main#/projects/prototypes/10298019

https://phabricator.endlessm.com/T16197