### PR TITLE
eos: consider kde4 prefix when adding the app to the desktop

### DIFF
--- a/src/plugins/gs-plugin-eos.c
+++ b/src/plugins/gs-plugin-eos.c
@@ -765,7 +765,10 @@ remove_app_from_shell (GsPlugin		*plugin,
 {
 	GError *error = NULL;
 	GsPluginData *priv = gs_plugin_get_data (plugin);
-	const char *shortcut_id = get_desktop_file_id (app);
+	const char *desktop_file_id = get_desktop_file_id (app);
+	g_autoptr(GDesktopAppInfo) app_info =
+		gs_utils_get_desktop_app_info (desktop_file_id);
+	const char *shortcut_id = g_app_info_get_id (G_APP_INFO (app_info));
 
 	g_dbus_connection_call_sync (priv->session_bus,
 				     "org.gnome.Shell",
@@ -796,7 +799,10 @@ add_app_to_shell (GsPlugin	*plugin,
 {
 	GError *error = NULL;
 	GsPluginData *priv = gs_plugin_get_data (plugin);
-	const char *shortcut_id = get_desktop_file_id (app);
+	const char *desktop_file_id = get_desktop_file_id (app);
+	g_autoptr(GDesktopAppInfo) app_info =
+		gs_utils_get_desktop_app_info (desktop_file_id);
+	const char *shortcut_id = g_app_info_get_id (G_APP_INFO (app_info));
 
 	g_dbus_connection_call_sync (priv->session_bus,
 				     "org.gnome.Shell",


### PR DESCRIPTION
Roundtrip through gs_utils_get_desktop_app_info(), which will allow us
to use the correct app ID even in the case of apps using the kde4
prefix.

https://phabricator.endlessm.com/T16469