### PR TITLE
shell: don't set an empty featured category name

### DIFF
--- a/src/gs-shell.c
+++ b/src/gs-shell.c
@@ -2033,7 +2033,7 @@ gs_shell_set_featured_category_name (GsShell *shell,
 	GsShellPrivate *priv = gs_shell_get_instance_private (shell);
 	const char *featured_name = gs_category_get_name (priv->featured_category);
 
-	if (name == NULL)
+	if (name == NULL || name[0] == '\0')
 		name = _("Featured");
 
 	if (g_strcmp0 (featured_name, name) != 0)


### PR DESCRIPTION
We can't just check for the override being non-NULL; we also need to
check that it's not an empty string and fall back to the default in that
case.

https://phabricator.endlessm.com/T16302