### PR TITLE
Do not fail when updating an app if the update is already installed

### DIFF
--- a/src/plugins/gs-flatpak.c
+++ b/src/plugins/gs-flatpak.c
@@ -2399,6 +2399,7 @@ gs_flatpak_update_app (GsFlatpak *self,
 		       GCancellable *cancellable,
 		       GError **error)
 {
+	GError *local_error = NULL;
 	g_autoptr(FlatpakInstalledRef) xref = NULL;
 
 	/* install */
@@ -2416,11 +2417,23 @@ gs_flatpak_update_app (GsFlatpak *self,
 					    gs_app_get_flatpak_arch (app),
 					    gs_app_get_flatpak_branch (app),
 					    gs_flatpak_progress_cb, app,
-					    cancellable, error);
+					    cancellable, &local_error);
 	if (xref == NULL) {
-		gs_plugin_flatpak_error_convert (error);
-		gs_app_set_state_recover (app);
-		return FALSE;
+		gboolean already_installed =
+			g_error_matches (local_error,
+					 FLATPAK_ERROR,
+					 FLATPAK_ERROR_ALREADY_INSTALLED);
+		if (!already_installed) {
+			g_propagate_error (error, local_error);
+			gs_plugin_flatpak_error_convert (error);
+			gs_app_set_state_recover (app);
+			return FALSE;
+		}
+
+		g_clear_error (&local_error);
+		g_debug ("Error: update for %s is already installed; "
+			 "marking the GsApp as installed and continuing...",
+			 gs_app_get_unique_id (app));
 	}
 
 	/* update UI */


### PR DESCRIPTION
Due to some bug or concurrent use of Flatpak, sometimes an update that
the user is installing happens to be already installed. In that case,
upon failing to update the app via GNOME Software, it should check the
error and just mark the app as installed if the update is already
installed: thus behaving has if the update had succeeded which is what
has the minimum impact in the UX.

https://phabricator.endlessm.com/T16370