### PR TITLE
app: Add an EOS Discovery Feed Content Provider

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -194,13 +194,13 @@ gnome_software_SOURCES =				\
 	gs-vendor.c					\
 	gs-vendor.h
 
-nodist_gnome_software_SOURCES =				\
-	gs-resources.c					\
-	gs-resources.h					\
-	gs-shell-search-provider-generated.c		\
-	gs-shell-search-provider-generated.h	\
+nodist_gnome_software_SOURCES =						\
 	gs-discovery-feed-content-provider-generated.c	\
-	gs-discovery-feed-content-provider-generated.h
+	gs-discovery-feed-content-provider-generated.h	\
+	gs-resources.c									\
+	gs-resources.h									\
+	gs-shell-search-provider-generated.c			\
+	gs-shell-search-provider-generated.h
 
 gnome_software_LDADD =					\
 	$(top_builddir)/lib/libgnomesoftware.a		\

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -78,6 +78,9 @@ org.gnome.Software.service: org.gnome.Software.service.in Makefile
 searchproviderdir = $(datadir)/gnome-shell/search-providers
 searchprovider_DATA = org.gnome.Software-search-provider.ini
 
+discoveryfeedcontentproviderdir = $(datadir)/eos-discovery-feed/content-providers
+discoveryfeedcontentprovider_DATA = org.gnome.Software-discovery-feed-content-provider.ini
+
 autostartdir = $(sysconfdir)/xdg/autostart
 autostart_DATA = gnome-software-service.desktop
 
@@ -113,6 +116,8 @@ gnome_software_SOURCES =				\
 	gs-content-rating.h				\
 	gs-details-page.c				\
 	gs-details-page.h				\
+	gs-discovery-feed-content-provider.c		\
+	gs-discovery-feed-content-provider.h		\
 	gs-extras-page.c				\
 	gs-extras-page.h				\
 	gs-feature-tile.c				\
@@ -193,7 +198,9 @@ nodist_gnome_software_SOURCES =				\
 	gs-resources.c					\
 	gs-resources.h					\
 	gs-shell-search-provider-generated.c		\
-	gs-shell-search-provider-generated.h
+	gs-shell-search-provider-generated.h	\
+	gs-discovery-feed-content-provider-generated.c	\
+	gs-discovery-feed-content-provider-generated.h
 
 gnome_software_LDADD =					\
 	$(top_builddir)/lib/libgnomesoftware.a		\
@@ -260,6 +267,13 @@ gs-shell-search-provider-generated.h gs-shell-search-provider-generated.c: Makef
 		--generate-c-code gs-shell-search-provider-generated \
 		$(srcdir)/shell-search-provider-dbus-interfaces.xml
 
+gs-discovery-feed-content-provider-generated.h gs-discovery-feed-content-provider-generated.c: Makefile.am $(srcdir)/discovery-feed-content-provider-dbus-interfaces.xml
+	$(AM_V_GEN) gdbus-codegen \
+	 	--interface-prefix com.endlessm. \
+		--c-namespace Gs \
+		--generate-c-code gs-discovery-feed-content-provider-generated \
+		$(srcdir)/discovery-feed-content-provider-dbus-interfaces.xml
+
 gs-resources.c: gnome-software.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --sourcedir="$(top_srcdir)/data/icons/categories" --generate-dependencies $(srcdir)/gnome-software.gresource.xml)
 	$(AM_V_GEN) $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --sourcedir="$(top_srcdir)/data/icons/categories" --target=$@ --generate-source --c-name gs $(srcdir)/gnome-software.gresource.xml
 
@@ -269,6 +283,8 @@ gs-resources.h: gnome-software.gresource.xml $(shell $(GLIB_COMPILE_RESOURCES) -
 BUILT_SOURCES =						\
 	$(packagekit_built_sources)			\
 	$(packagekit_modify2_built_sources)		\
+	gs-discovery-feed-content-provider-generated.h	\
+	gs-discovery-feed-content-provider-generated.c	\
 	gs-shell-search-provider-generated.c		\
 	gs-shell-search-provider-generated.h		\
 	gs-resources.c					\
@@ -276,6 +292,7 @@ BUILT_SOURCES =						\
 
 EXTRA_DIST =						\
 	shell-search-provider-dbus-interfaces.xml	\
+	discovery-feed-content-provider-dbus-interfaces.xml \
 	org.freedesktop.PackageKit.xml			\
 	org.freedesktop.PackageKit.Modify2.xml		\
 	gnome-software.gresource.xml			\
@@ -287,6 +304,7 @@ EXTRA_DIST =						\
 	org.gnome.Software.service.in			\
 	gnome-software-service.desktop.in		\
 	$(searchprovider_DATA)				\
+	$(discoveryfeedcontentprovider_DATA) \
 	$(UI_FILES)
 
 man_MANS =

--- a/src/discovery-feed-content-provider-dbus-interfaces.xml
+++ b/src/discovery-feed-content-provider-dbus-interfaces.xml
@@ -1,0 +1,25 @@
+<!DOCTYPE node PUBLIC
+"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
+<!--
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General
+ Public License along with this library; if not, see <http://www.gnu.org/licenses/>.
+-->
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <interface name="com.endlessm.DiscoveryFeedInstallableApps">
+    <method name="GetRelevantInstallableApps">
+      <arg type="aa{sv}" name="Results" direction="out" />
+    </method>
+  </interface>
+</node>

--- a/src/discovery-feed-content-provider-dbus-interfaces.xml
+++ b/src/discovery-feed-content-provider-dbus-interfaces.xml
@@ -18,7 +18,7 @@
 -->
 <node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
   <interface name="com.endlessm.DiscoveryFeedInstallableApps">
-    <method name="GetRelevantInstallableApps">
+    <method name="GetInstallableApps">
       <arg type="aa{sv}" name="Results" direction="out" />
     </method>
   </interface>

--- a/src/gs-application.c
+++ b/src/gs-application.c
@@ -43,6 +43,7 @@
 #include "gs-dbus-helper.h"
 #endif
 
+#include "gs-discovery-feed-content-provider.h"
 #include "gs-first-run-dialog.h"
 #include "gs-shell.h"
 #include "gs-update-monitor.h"
@@ -65,6 +66,7 @@ struct _GsApplication {
 	GsDbusHelper	*dbus_helper;
 #endif
 	GsShellSearchProvider *search_provider;
+	GsDiscoveryFeedContentProvider *discovery_feed_content_provider;
 	GSettings       *settings;
 };
 
@@ -174,7 +176,17 @@ gs_application_dbus_register (GApplication    *application,
 {
 	GsApplication *app = GS_APPLICATION (application);
 	app->search_provider = gs_shell_search_provider_new ();
-	return gs_shell_search_provider_register (app->search_provider, connection, error);
+	app->discovery_feed_content_provider = gs_discovery_feed_content_provider_new ();
+
+	if (!gs_shell_search_provider_register (app->search_provider, connection, error)) {
+		return FALSE;
+	}
+
+	if (!gs_discovery_feed_content_provider_register (app->discovery_feed_content_provider, connection, error)) {
+		return FALSE;
+	}
+
+	return TRUE;
 }
 
 static void
@@ -187,6 +199,11 @@ gs_application_dbus_unregister (GApplication    *application,
 	if (app->search_provider != NULL) {
 		gs_shell_search_provider_unregister (app->search_provider);
 		g_clear_object (&app->search_provider);
+	}
+
+	if (app->discovery_feed_content_provider != NULL) {
+		gs_discovery_feed_content_provider_unregister (app->discovery_feed_content_provider);
+		g_clear_object (&app->discovery_feed_content_provider);
 	}
 }
 
@@ -766,6 +783,7 @@ gs_application_setup_search_provider (GsApplication *app)
 {
 	gs_application_initialize_plugins (app);
 	gs_shell_search_provider_setup (app->search_provider, app->plugin_loader);
+	gs_discovery_feed_content_provider_setup (app->discovery_feed_content_provider, app->plugin_loader);
 }
 
 static void

--- a/src/gs-application.c
+++ b/src/gs-application.c
@@ -178,13 +178,11 @@ gs_application_dbus_register (GApplication    *application,
 	app->search_provider = gs_shell_search_provider_new ();
 	app->discovery_feed_content_provider = gs_discovery_feed_content_provider_new ();
 
-	if (!gs_shell_search_provider_register (app->search_provider, connection, error)) {
+	if (!gs_shell_search_provider_register (app->search_provider, connection, error))
 		return FALSE;
-	}
 
-	if (!gs_discovery_feed_content_provider_register (app->discovery_feed_content_provider, connection, error)) {
+	if (!gs_discovery_feed_content_provider_register (app->discovery_feed_content_provider, connection, error))
 		return FALSE;
-	}
 
 	return TRUE;
 }

--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -111,7 +111,7 @@ get_app_thumbnail_cached_filename (GsApp *app)
 	tile_cache_hash = g_compute_checksum_for_string (G_CHECKSUM_SHA256,
 	                                                 popular_background_url,
 	                                                 -1);
-	cache_identifier = g_strdup_printf("%s-%s", tile_cache_hash, url_basename);
+	cache_identifier = g_strdup_printf ("%s-%s", tile_cache_hash, url_basename);
 	cache_filename = gs_utils_get_cache_filename ("eos-popular-app-thumbnails",
 	                                              cache_identifier,
 	                                              GS_UTILS_CACHE_FLAG_NONE,

--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -67,7 +67,7 @@ static const DiscoveryFeedKudoWeight discovery_feed_app_kudos[] =
 	{ GS_APP_KUDO_FEATURED_RECOMMENDED, 5 },
 	{ GS_APP_KUDO_POPULAR, 3 }
 };
-static const guint discovery_feed_app_kudos_len = sizeof (discovery_feed_app_kudos) / sizeof (DiscoveryFeedKudoWeight);
+static const guint discovery_feed_app_kudos_len = G_N_ELEMENTS (discovery_feed_app_kudos);
 
 static guint
 get_discovery_feed_app_kudo_score (GsApp *app)

--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -119,7 +119,7 @@ get_app_thumbnail_cached_filename (GsApp *app)
 	 * since it will have a thumbnail */
 	if (g_file_test (cache_filename, G_FILE_TEST_EXISTS)) {
 		g_debug ("Hit cache for thumbnail when loading discovery feed %s: %s", popular_background_url, cache_filename);
-		return g_steal_pointer(&cache_filename);
+		return g_steal_pointer (&cache_filename);
 	}
 
 	return NULL;

--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -124,7 +124,7 @@ get_app_thumbnail_cached_filename (GsApp *app)
 		return cache_filename;
 	}
 
-    return cache_filename;
+	return cache_filename;
 }
 
 static const guint N_APPS_TO_INCLUDE_IN_RESULT = 5;
@@ -209,8 +209,8 @@ search_done_cb (GObject *source,
 
 static gboolean
 handle_get_discovery_feed_apps (GsDiscoveryFeedInstallableApps  *skeleton,
-                                GDBusMethodInvocation   *invocation,
-                                gpointer        user_data)
+				GDBusMethodInvocation   *invocation,
+				gpointer        user_data)
 {
 	GsDiscoveryFeedContentProvider *self = user_data;
 	PendingSearch *pending_search = g_slice_new0 (PendingSearch);

--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -1,0 +1,295 @@
+/*
+ * gs-discovery-feed-content-provider.c - Implementation of an EOS
+ * Discovery Feed Content Provider
+ *
+ * Copyright (c) 2017 Endless Mobile Inc.
+ *
+ * Licensed under the GNU General Public License Version 2
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <config.h>
+
+#include <gio/gio.h>
+#include <string.h>
+#include <glib/gi18n.h>
+
+#include "gs-app-list-private.h"
+#include "gs-plugin-loader-sync.h"
+#include "gs-utils.h"
+
+#include "gs-discovery-feed-content-provider-generated.h"
+#include "gs-discovery-feed-content-provider.h"
+
+typedef struct {
+	GsDiscoveryFeedContentProvider *provider;
+	GDBusMethodInvocation *invocation;
+} PendingSearch;
+
+struct _GsDiscoveryFeedContentProvider {
+	GObject parent;
+
+	GsDiscoveryFeedInstallableApps *skeleton;
+	GsPluginLoader *plugin_loader;
+	GCancellable *cancellable;
+};
+
+G_DEFINE_TYPE (GsDiscoveryFeedContentProvider, gs_discovery_feed_content_provider, G_TYPE_OBJECT)
+
+static void
+pending_search_free (PendingSearch *search)
+{
+	g_object_unref (search->invocation);
+	g_slice_free (PendingSearch, search);
+}
+
+typedef struct {
+	GsAppKudo kudo;
+	guint weight;
+} DiscoveryFeedKudoWeight ;
+
+static const DiscoveryFeedKudoWeight discovery_feed_app_kudos[] =
+{
+	{ GS_APP_KUDO_MY_LANGUAGE, 10 },
+	{ GS_APP_KUDO_FEATURED_RECOMMENDED, 5 },
+	{ GS_APP_KUDO_POPULAR, 3 }
+};
+static const guint discovery_feed_app_kudos_len = sizeof (discovery_feed_app_kudos) / sizeof (DiscoveryFeedKudoWeight);
+
+static guint
+get_discovery_feed_app_kudo_score (GsApp *app)
+{
+	guint i = 0;
+	guint score = 0;
+	guint64 kudos = gs_app_get_kudos (app);
+
+	for (; i < discovery_feed_app_kudos_len; ++i) {
+		if ((kudos & discovery_feed_app_kudos[i].kudo) != 0) {
+			score += discovery_feed_app_kudos[i].weight;
+		}
+	}
+
+	return score;
+}
+
+static gint
+search_sort_by_kudo_cb (GsApp *app1, GsApp *app2, gpointer user_data)
+{
+	guint pa, pb;
+	pa = get_discovery_feed_app_kudo_score (app1);
+	pb = get_discovery_feed_app_kudo_score (app2);
+	if (pa < pb)
+		return 1;
+	else if (pa > pb)
+		return -1;
+	return 0;
+}
+
+static gchar *
+get_app_thumbnail_cached_filename (GsApp *app)
+{
+	const gchar *popular_background_url = gs_app_get_metadata_item (app, "GnomeSoftware::popular-background");
+	g_autofree char *tile_cache_hash = NULL;
+	g_autofree char *cache_identifier = NULL;
+	g_autofree char *url_basename = NULL;
+	char *cache_filename = NULL;
+
+	url_basename = g_path_get_basename (popular_background_url);
+	tile_cache_hash = g_compute_checksum_for_string (G_CHECKSUM_SHA256,
+	                                                 popular_background_url,
+	                                                 -1);
+	cache_identifier = g_strdup_printf("%s-%s", tile_cache_hash, url_basename);
+	cache_filename = gs_utils_get_cache_filename ("eos-popular-app-thumbnails",
+	                                              cache_identifier,
+	                                              GS_UTILS_CACHE_FLAG_NONE,
+	                                              NULL);
+
+	/* Check to see if the file exists in the cache at the time we called this
+	 * function. If it does, then we can use this app in the results
+	 * since it will have a thumbnail */
+	if (g_file_test (cache_filename, G_FILE_TEST_EXISTS)) {
+		g_debug("Hit cache for thumbnail when loading discovery feed %s: %s", popular_background_url, cache_filename);
+		return cache_filename;
+	}
+
+    return cache_filename;
+}
+
+static const guint N_APPS_TO_INCLUDE_IN_RESULT = 5;
+
+static void
+search_done_cb (GObject *source,
+		GAsyncResult *res,
+		gpointer user_data)
+{
+	PendingSearch *search = user_data;
+	GsDiscoveryFeedContentProvider *self = search->provider;
+	guint i;
+	GVariantBuilder builder;
+	guint app_list_length;
+	guint count;
+	g_autoptr(GsAppList) list = NULL;
+
+	list = gs_plugin_loader_search_finish (self->plugin_loader, res, NULL);
+	if (list == NULL) {
+		g_dbus_method_invocation_return_value (search->invocation, g_variant_new ("(as)", NULL));
+		pending_search_free (search);
+		g_application_release (g_application_get_default ());
+		return;
+	}
+
+	app_list_length = gs_app_list_length (list);
+	count = 0;
+
+	/* sort by kudos, as there is no ratings data by default */
+	gs_app_list_sort (list, search_sort_by_kudo_cb, NULL);
+
+	g_variant_builder_init (&builder, G_VARIANT_TYPE ("aa{sv}"));
+	for (i = 0; i < app_list_length; i++) {
+	        gchar *app_thumbnail_filename;
+	        GdkPixbuf *pixbuf;
+	        GVariant *icon_serialized = NULL;
+		GsApp *app = gs_app_list_index (list, i);
+
+		if (gs_app_get_state (app) != AS_APP_STATE_AVAILABLE)
+			continue;
+
+		/* This app must have an icon which is serializable */
+		pixbuf = gs_app_get_pixbuf (app);
+		if (pixbuf != NULL)
+			icon_serialized = g_icon_serialize (G_ICON (pixbuf));
+
+		if (!icon_serialized)
+			continue;
+
+		/* Check to make sure that the app has an available thumbnail
+		 * otherwise, we need to skip it completely */
+		app_thumbnail_filename = get_app_thumbnail_cached_filename (app);
+
+		if (!app_thumbnail_filename)
+			continue;
+
+		g_variant_builder_open (&builder, G_VARIANT_TYPE("a{sv}"));
+		g_variant_builder_add (&builder, "{sv}", "app_id", g_variant_new_string (gs_app_get_id (app)));
+		g_variant_builder_add (&builder, "{sv}", "id", g_variant_new_string (gs_app_get_id (app)));
+		g_variant_builder_add (&builder, "{sv}", "name", g_variant_new_string (gs_app_get_name (app)));
+		g_variant_builder_add (&builder, "{sv}", "synopsis", g_variant_new_string (gs_app_get_summary (app)));
+		g_variant_builder_add (&builder, "{sv}", "thumbnail_uri", g_variant_new_string (app_thumbnail_filename));
+		g_variant_builder_add (&builder, "{sv}", "icon", icon_serialized);
+		g_free (app_thumbnail_filename);
+		g_variant_unref (icon_serialized);
+
+		g_variant_builder_close (&builder);
+
+		if (++count > N_APPS_TO_INCLUDE_IN_RESULT)
+			break;
+	}
+	g_dbus_method_invocation_return_value (search->invocation,
+	                                       g_variant_new ("(aa{sv})", &builder));
+
+	pending_search_free (search);
+	g_application_release (g_application_get_default ());
+}
+
+static gboolean
+handle_get_discovery_feed_apps (GsDiscoveryFeedInstallableApps  *skeleton,
+                                GDBusMethodInvocation   *invocation,
+                                gpointer        user_data)
+{
+	GsDiscoveryFeedContentProvider *self = user_data;
+	PendingSearch *pending_search = g_slice_new (PendingSearch);
+	pending_search->provider = self;
+	pending_search->invocation = g_object_ref (invocation);
+
+	if (self->cancellable != NULL) {
+		g_cancellable_cancel (self->cancellable);
+		g_clear_object (&self->cancellable);
+	}
+
+	g_application_hold (g_application_get_default ());
+	self->cancellable = g_cancellable_new ();
+	gs_plugin_loader_search_async(self->plugin_loader,
+				      "com.endlessm",
+				      GS_PLUGIN_REFINE_FLAGS_REQUIRE_ICON,
+				      GS_PLUGIN_FAILURE_FLAGS_NONE,
+				      self->cancellable,
+				      search_done_cb,
+				      pending_search);
+
+	return TRUE;
+}
+
+gboolean
+gs_discovery_feed_content_provider_register (GsDiscoveryFeedContentProvider *self,
+                                             GDBusConnection       *connection,
+                                             GError               **error)
+{
+	return g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (self->skeleton),
+	                                         connection,
+	                                         "/org/gnome/Software/DiscoveryFeedContentProvider", error);
+}
+
+void
+gs_discovery_feed_content_provider_unregister (GsDiscoveryFeedContentProvider *self)
+{
+	g_dbus_interface_skeleton_unexport (G_DBUS_INTERFACE_SKELETON (self->skeleton));
+}
+
+static void
+discovery_feed_content_provider_dispose (GObject *obj)
+{
+	GsDiscoveryFeedContentProvider *self = GS_DISCOVERY_FEED_CONTENT_PROVIDER (obj);
+
+	if (self->cancellable != NULL) {
+		g_cancellable_cancel (self->cancellable);
+		g_clear_object (&self->cancellable);
+	}
+
+	g_clear_object (&self->plugin_loader);
+	g_clear_object (&self->skeleton);
+
+	G_OBJECT_CLASS (gs_discovery_feed_content_provider_parent_class)->dispose (obj);
+}
+
+static void
+gs_discovery_feed_content_provider_init (GsDiscoveryFeedContentProvider *self)
+{
+	self->skeleton = gs_discovery_feed_installable_apps_skeleton_new ();
+
+	g_signal_connect (self->skeleton, "handle-get-relevant-installable-apps",
+			  G_CALLBACK (handle_get_discovery_feed_apps), self);
+}
+
+static void
+gs_discovery_feed_content_provider_class_init (GsDiscoveryFeedContentProviderClass *klass)
+{
+	GObjectClass *oclass = G_OBJECT_CLASS (klass);
+
+	oclass->dispose = discovery_feed_content_provider_dispose;
+}
+
+GsDiscoveryFeedContentProvider *
+gs_discovery_feed_content_provider_new (void)
+{
+	return g_object_new (gs_discovery_feed_content_provider_get_type (), NULL);
+}
+
+void
+gs_discovery_feed_content_provider_setup (GsDiscoveryFeedContentProvider *provider,
+				          GsPluginLoader *loader)
+{
+	provider->plugin_loader = g_object_ref (loader);
+}

--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -159,9 +159,9 @@ search_done_cb (GObject *source,
 
 	g_variant_builder_init (&builder, G_VARIANT_TYPE ("aa{sv}"));
 	for (i = 0; i < app_list_length; i++) {
-	        gchar *app_thumbnail_filename;
-	        GdkPixbuf *pixbuf;
-	        GVariant *icon_serialized = NULL;
+		gchar *app_thumbnail_filename;
+		GdkPixbuf *pixbuf;
+		GVariant *icon_serialized = NULL;
 		GsApp *app = gs_app_list_index (list, i);
 
 		if (gs_app_get_state (app) != AS_APP_STATE_AVAILABLE)

--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -214,7 +214,7 @@ handle_get_discovery_feed_apps (GsDiscoveryFeedInstallableApps  *skeleton,
                                 gpointer        user_data)
 {
 	GsDiscoveryFeedContentProvider *self = user_data;
-	PendingSearch *pending_search = g_slice_new (PendingSearch);
+	PendingSearch *pending_search = g_slice_new0 (PendingSearch);
 	pending_search->provider = self;
 	pending_search->invocation = g_object_ref (invocation);
 

--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -218,13 +218,13 @@ handle_get_discovery_feed_apps (GsDiscoveryFeedInstallableApps  *skeleton,
 	pending_search->invocation = g_object_ref (invocation);
 
 	g_application_hold (g_application_get_default ());
-	gs_plugin_loader_search_async(self->plugin_loader,
-				      "com.endlessm",
-				      GS_PLUGIN_REFINE_FLAGS_REQUIRE_ICON,
-				      GS_PLUGIN_FAILURE_FLAGS_NONE,
-				      NULL,
-				      search_done_cb,
-				      pending_search);
+	gs_plugin_loader_search_async (self->plugin_loader,
+				       "com.endlessm",
+				       GS_PLUGIN_REFINE_FLAGS_REQUIRE_ICON,
+				       GS_PLUGIN_FAILURE_FLAGS_NONE,
+				       NULL,
+				       search_done_cb,
+				       pending_search);
 
 	return TRUE;
 }

--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -269,7 +269,7 @@ gs_discovery_feed_content_provider_init (GsDiscoveryFeedContentProvider *self)
 {
 	self->skeleton = gs_discovery_feed_installable_apps_skeleton_new ();
 
-	g_signal_connect (self->skeleton, "handle-get-relevant-installable-apps",
+	g_signal_connect (self->skeleton, "handle-get-installable-apps",
 			  G_CALLBACK (handle_get_discovery_feed_apps), self);
 }
 

--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -145,7 +145,9 @@ search_done_cb (GObject *source,
 
 	list = gs_plugin_loader_search_finish (self->plugin_loader, res, NULL);
 	if (list == NULL) {
-		g_dbus_method_invocation_return_value (search->invocation, g_variant_new ("(as)", NULL));
+		gs_discovery_feed_installable_apps_complete_get_installable_apps (self->skeleton,
+										  search->invocation,
+										  NULL);
 		pending_search_free (search);
 		g_application_release (g_application_get_default ());
 		return;
@@ -197,8 +199,10 @@ search_done_cb (GObject *source,
 		if (++count > N_APPS_TO_INCLUDE_IN_RESULT)
 			break;
 	}
-	g_dbus_method_invocation_return_value (search->invocation,
-	                                       g_variant_new ("(aa{sv})", &builder));
+
+	gs_discovery_feed_installable_apps_complete_get_installable_apps (self->skeleton,
+									  search->invocation,
+									  g_variant_builder_end (&builder));
 
 	pending_search_free (search);
 	g_application_release (g_application_get_default ());

--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -121,7 +121,7 @@ get_app_thumbnail_cached_filename (GsApp *app)
 	 * function. If it does, then we can use this app in the results
 	 * since it will have a thumbnail */
 	if (g_file_test (cache_filename, G_FILE_TEST_EXISTS)) {
-		g_debug("Hit cache for thumbnail when loading discovery feed %s: %s", popular_background_url, cache_filename);
+		g_debug ("Hit cache for thumbnail when loading discovery feed %s: %s", popular_background_url, cache_filename);
 		return cache_filename;
 	}
 

--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -75,11 +75,9 @@ get_discovery_feed_app_kudo_score (GsApp *app)
 	guint score = 0;
 	guint64 kudos = gs_app_get_kudos (app);
 
-	for (; i < discovery_feed_app_kudos_len; ++i) {
-		if ((kudos & discovery_feed_app_kudos[i].kudo) != 0) {
+	for (; i < discovery_feed_app_kudos_len; ++i)
+		if ((kudos & discovery_feed_app_kudos[i].kudo) != 0)
 			score += discovery_feed_app_kudos[i].weight;
-		}
-	}
 
 	return score;
 }

--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -127,8 +127,6 @@ get_app_thumbnail_cached_filename (GsApp *app)
 	return NULL;
 }
 
-static const guint N_APPS_TO_INCLUDE_IN_RESULT = 5;
-
 static void
 search_done_cb (GObject *source,
 		GAsyncResult *res,
@@ -194,9 +192,6 @@ search_done_cb (GObject *source,
 		g_variant_unref (icon_serialized);
 
 		g_variant_builder_close (&builder);
-
-		if (++count > N_APPS_TO_INCLUDE_IN_RESULT)
-			break;
 	}
 
 	gs_discovery_feed_installable_apps_complete_get_installable_apps (self->skeleton,

--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -104,7 +104,7 @@ get_app_thumbnail_cached_filename (GsApp *app)
 	g_autofree char *tile_cache_hash = NULL;
 	g_autofree char *cache_identifier = NULL;
 	g_autofree char *url_basename = NULL;
-	char *cache_filename = NULL;
+	g_autofree char *cache_filename = NULL;
 
 	url_basename = g_path_get_basename (popular_background_url);
 	tile_cache_hash = g_compute_checksum_for_string (G_CHECKSUM_SHA256,
@@ -121,10 +121,10 @@ get_app_thumbnail_cached_filename (GsApp *app)
 	 * since it will have a thumbnail */
 	if (g_file_test (cache_filename, G_FILE_TEST_EXISTS)) {
 		g_debug ("Hit cache for thumbnail when loading discovery feed %s: %s", popular_background_url, cache_filename);
-		return cache_filename;
+		return g_steal_pointer(&cache_filename);
 	}
 
-	return cache_filename;
+	return NULL;
 }
 
 static const guint N_APPS_TO_INCLUDE_IN_RESULT = 5;

--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -44,7 +44,6 @@ struct _GsDiscoveryFeedContentProvider {
 
 	GsDiscoveryFeedInstallableApps *skeleton;
 	GsPluginLoader *plugin_loader;
-	GCancellable *cancellable;
 };
 
 G_DEFINE_TYPE (GsDiscoveryFeedContentProvider, gs_discovery_feed_content_provider, G_TYPE_OBJECT)
@@ -218,18 +217,12 @@ handle_get_discovery_feed_apps (GsDiscoveryFeedInstallableApps  *skeleton,
 	pending_search->provider = self;
 	pending_search->invocation = g_object_ref (invocation);
 
-	if (self->cancellable != NULL) {
-		g_cancellable_cancel (self->cancellable);
-		g_clear_object (&self->cancellable);
-	}
-
 	g_application_hold (g_application_get_default ());
-	self->cancellable = g_cancellable_new ();
 	gs_plugin_loader_search_async(self->plugin_loader,
 				      "com.endlessm",
 				      GS_PLUGIN_REFINE_FLAGS_REQUIRE_ICON,
 				      GS_PLUGIN_FAILURE_FLAGS_NONE,
-				      self->cancellable,
+				      NULL,
 				      search_done_cb,
 				      pending_search);
 
@@ -256,11 +249,6 @@ static void
 discovery_feed_content_provider_dispose (GObject *obj)
 {
 	GsDiscoveryFeedContentProvider *self = GS_DISCOVERY_FEED_CONTENT_PROVIDER (obj);
-
-	if (self->cancellable != NULL) {
-		g_cancellable_cancel (self->cancellable);
-		g_clear_object (&self->cancellable);
-	}
 
 	g_clear_object (&self->plugin_loader);
 	g_clear_object (&self->skeleton);

--- a/src/gs-discovery-feed-content-provider.h
+++ b/src/gs-discovery-feed-content-provider.h
@@ -1,0 +1,41 @@
+/*
+ * gs-discovery-feed-content-provider.h - Implementation of an EOS
+ * Discovery Feed Content Provider
+ *
+ * Copyright (c) 2017 Endless Mobile Inc.
+ *
+ * Licensed under the GNU General Public License Version 2
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef __GS_DISCOVERY_FEED_CONTENT_PROVIDER_H
+#define __GS_DISCOVERY_FEED_CONTENT_PROVIDER_H
+
+#include "gs-plugin-loader.h"
+
+#define GS_TYPE_DISCOVERY_FEED_CONTENT_PROVIDER gs_discovery_feed_content_provider_get_type()
+
+G_DECLARE_FINAL_TYPE (GsDiscoveryFeedContentProvider, gs_discovery_feed_content_provider, GS, DISCOVERY_FEED_CONTENT_PROVIDER, GObject)
+
+gboolean		 gs_discovery_feed_content_provider_register	(GsDiscoveryFeedContentProvider	 *self,
+									 GDBusConnection	 *connection,
+									 GError			**error);
+void			 gs_discovery_feed_content_provider_unregister	(GsDiscoveryFeedContentProvider	 *self);
+GsDiscoveryFeedContentProvider	*gs_discovery_feed_content_provider_new		(void);
+void			 gs_discovery_feed_content_provider_setup		(GsDiscoveryFeedContentProvider	 *provider,
+										 GsPluginLoader		 *loader);
+
+#endif /* __GS_DISCOVERY_FEED_CONTENT_PROVIDER_H */

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,9 +9,16 @@ resources_src = gnome.compile_resources(
   c_name : 'gs'
 )
 
-gdbus_src = gnome.gdbus_codegen(
+gdbus_shell_search_provider_src = gnome.gdbus_codegen(
   'gs-shell-search-provider-generated',
   'shell-search-provider-dbus-interfaces.xml',
+  interface_prefix : 'org.gnome.',
+  namespace : 'Gs'
+)
+
+gdbus_discovery_feed_content_provider_src = gnome.gdbus_codegen(
+  'gs-discovery-feed-content-provider-generated',
+  'discovery-feed-content-provider-dbus-interfaces.xml',
   interface_prefix : 'org.gnome.',
   namespace : 'Gs'
 )
@@ -33,6 +40,7 @@ gnome_software_sources = [
   'gs-content-rating.c',
   'gs-debug.c',
   'gs-details-page.c',
+  'gs-discovery-feed-content-provider.c',
   'gs-extras-page.c',
   'gs-feature-tile.c',
   'gs-first-run-dialog.c',
@@ -110,7 +118,8 @@ endif
 executable(
   'gnome-software',
   resources_src,
-  gdbus_src,
+  gdbus_shell_search_provider_src,
+  gdbus_discovery_feed_content_provider_src,
   sources : gnome_software_sources,
   include_directories : [
     include_directories('..'),
@@ -245,6 +254,9 @@ i18n.merge_file(
 
 install_data('org.gnome.Software-search-provider.ini',
              install_dir : 'share/gnome-shell/search-providers')
+
+install_data('org.gnome.Software-discovery-feed-content-provider.ini',
+             install_dir : 'share/eos-discovery-feed/content-providers')
 
 if get_option('enable-man')
   xsltproc = find_program('xsltproc')

--- a/src/org.gnome.Software-discovery-feed-content-provider.ini
+++ b/src/org.gnome.Software-discovery-feed-content-provider.ini
@@ -1,0 +1,7 @@
+[Discovery Feed Content Provider]
+DesktopId=org.gnome.Software.desktop
+BusName=org.gnome.Software
+ObjectPath=/org/gnome/Software/DiscoveryFeedContentProvider
+AppID=org.gnome.Software
+SupportedInterfaces=com.endlessm.DiscoveryFeedInstallableApps
+Version=1


### PR DESCRIPTION
Similar to the included Shell Search Provider, this provider
will include the top five apps to install to populate the
discovery feed with content.

https://phabricator.endlessm.com/T16977