### PR TITLE
Fix gs shell search provider

### DIFF
--- a/lib/gs-plugin-loader-sync.c
+++ b/lib/gs-plugin-loader-sync.c
@@ -23,25 +23,6 @@
 
 #include "gs-plugin-loader-sync.h"
 
-GsApp *
-gs_plugin_loader_get_app_by_id (GsPluginLoader *plugin_loader,
-				const gchar *id,
-				GsPluginRefineFlags refine_flags,
-				GCancellable *cancellable,
-				GError **error)
-{
-	GsApp *app;
-	gboolean ret;
-
-	app = gs_app_new (id);
-	ret = gs_plugin_loader_app_refine (plugin_loader, app, refine_flags,
-					   GS_PLUGIN_FAILURE_FLAGS_NONE,
-					   cancellable, error);
-	if (!ret)
-		g_clear_object (&app);
-	return app;
-}
-
 /* tiny helper to help us do the async operation */
 typedef struct {
 	GError		**error;

--- a/lib/gs-plugin-loader-sync.h
+++ b/lib/gs-plugin-loader-sync.h
@@ -106,11 +106,6 @@ gboolean	 gs_plugin_loader_refresh		(GsPluginLoader	*plugin_loader,
 							 GsPluginFailureFlags failure_flags,
 							 GCancellable	*cancellable,
 							 GError		**error);
-GsApp		*gs_plugin_loader_get_app_by_id		(GsPluginLoader	*plugin_loader,
-							 const gchar	*id,
-							 GsPluginRefineFlags refine_flags,
-							 GCancellable	*cancellable,
-							 GError		**error);
 GsApp		*gs_plugin_loader_file_to_app		(GsPluginLoader	*plugin_loader,
 							 GFile		*file,
 							 GsPluginRefineFlags refine_flags,

--- a/src/gs-search-page.c
+++ b/src/gs-search-page.c
@@ -152,7 +152,12 @@ gs_search_page_get_search_cb (GObject *source_object,
 
 	if (self->appid_to_show != NULL) {
 		g_autoptr (GsApp) a = NULL;
-		a = gs_app_new (self->appid_to_show);
+		if (as_utils_unique_id_valid (self->appid_to_show)) {
+			a = gs_plugin_loader_app_create (self->plugin_loader,
+							 self->appid_to_show);
+		} else {
+			a = gs_app_new (self->appid_to_show);
+		}
 		gs_shell_show_app (self->shell, a);
 		g_clear_pointer (&self->appid_to_show, g_free);
 	}

--- a/src/gs-shell-search-provider.c
+++ b/src/gs-shell-search-provider.c
@@ -93,7 +93,7 @@ search_done_cb (GObject *source,
 		GsApp *app = gs_app_list_index (list, i);
 		if (gs_app_get_state (app) != AS_APP_STATE_AVAILABLE)
 			continue;
-		g_variant_builder_add (&builder, "s", gs_app_get_id (app));
+		g_variant_builder_add (&builder, "s", gs_app_get_unique_id (app));
 	}
 	g_dbus_method_invocation_return_value (search->invocation, g_variant_new ("(as)", &builder));
 
@@ -177,39 +177,34 @@ handle_get_result_metas (GsShellSearchProvider2	*skeleton,
 	GdkPixbuf *pixbuf;
 	gint i;
 	GVariantBuilder builder;
-	GError *error = NULL;
 
 	g_debug ("****** GetResultMetas");
 
 	for (i = 0; results[i]; i++) {
 		g_autoptr(GsApp) app = NULL;
 
-		if (g_hash_table_lookup (self->metas_cache, results[i]))
+		/* already built */
+		if (g_hash_table_lookup (self->metas_cache, results[i]) != NULL)
 			continue;
 
 		/* find the application with this ID */
-		app = gs_plugin_loader_get_app_by_id (self->plugin_loader,
-						      results[i],
-						      GS_PLUGIN_REFINE_FLAGS_REQUIRE_ICON |
-						      GS_PLUGIN_REFINE_FLAGS_REQUIRE_DESCRIPTION,
-						      NULL,
-						      &error);
-		if (app == NULL) {
-			g_warning ("failed to refine %s: %s",
-				   results[i], error->message);
-			g_clear_error (&error);
+		app = gs_plugin_loader_app_create (self->plugin_loader, results[i]);
+		if (gs_app_get_summary (app) == NULL) {
+			g_warning ("failed to refine find app %s in global cache", results[i]);
 			continue;
 		}
 
 		g_variant_builder_init (&meta, G_VARIANT_TYPE ("a{sv}"));
-		g_variant_builder_add (&meta, "{sv}", "id", g_variant_new_string (gs_app_get_id (app)));
+		g_variant_builder_add (&meta, "{sv}", "id", g_variant_new_string (gs_app_get_unique_id (app)));
 		g_variant_builder_add (&meta, "{sv}", "name", g_variant_new_string (gs_app_get_name (app)));
 		pixbuf = gs_app_get_pixbuf (app);
 		if (pixbuf != NULL)
 			g_variant_builder_add (&meta, "{sv}", "icon", g_icon_serialize (G_ICON (pixbuf)));
 		g_variant_builder_add (&meta, "{sv}", "description", g_variant_new_string (gs_app_get_summary (app)));
 		meta_variant = g_variant_builder_end (&meta);
-		g_hash_table_insert (self->metas_cache, g_strdup (gs_app_get_id (app)), g_variant_ref_sink (meta_variant));
+		g_hash_table_insert (self->metas_cache,
+				     g_strdup (gs_app_get_unique_id (app)),
+				     g_variant_ref_sink (meta_variant));
 
 	}
 
@@ -303,8 +298,10 @@ search_provider_dispose (GObject *obj)
 static void
 gs_shell_search_provider_init (GsShellSearchProvider *self)
 {
-	self->metas_cache = g_hash_table_new_full (g_str_hash, g_str_equal,
-						   g_free, (GDestroyNotify) g_variant_unref);
+	self->metas_cache = g_hash_table_new_full ((GHashFunc) as_utils_unique_id_hash,
+						   (GEqualFunc) as_utils_unique_id_equal,
+						   g_free,
+						   (GDestroyNotify) g_variant_unref);
 
 	self->skeleton = gs_shell_search_provider2_skeleton_new ();
 


### PR DESCRIPTION
I did some testing and investigation I isolated two issues:

1) The ID used is not unique, causing the search to fail.
2) In `handle_get_result_metas`  the function `gs_plugin_loader_get_app_by_id` returns empty app structure therefore when the user type a search in the desktop search bar no app results are shown.

~Fixes:~
~1) Commit "search-provider: use the app unique id".~
~2) Commit "search-provider: cache app data in search_done_cb".~
~I could not find a way to fix that function, so I implanted a work around. Using a greedy approach, I save the app data in a cache in the `search_done_cb`, instead of in the `handle_get_result_metas`. The result is more data stored in the cache.~

~Also to make it work, I had to pass an empty string instead of the search terms. (see "search-provider: pass empty string to details action").~

~Side note if someone knows how to make `gs_plugin_loader_get_app_by_id` work, just revert the cache commit.~

~What it is still broken:
When you call the D-Bus method "GetResultMetas" the output is empty because `handle_get_result_metas` assumes that the data are in the cache.~

~I know it is not a perfect solution but it works, I am opened to feedback to improve it.~

UPDATE:
There is a patch upstream for this issue, I backported that. https://github.com/GNOME/gnome-software/commit/629cb4ffd7b891ff5abc519de768895ee5748e28


https://phabricator.endlessm.com/T10168