### PR TITLE
eos: Link with libflatpak

### DIFF
--- a/plugins/eos/Makefile.am
+++ b/plugins/eos/Makefile.am
@@ -20,7 +20,7 @@ libgs_plugin_eos_la_SOURCES =	\
 	gs-flatpak-symlinks.h	\
 	gs-plugin-eos.c
 libgs_plugin_eos_la_LIBADD =				\
-	$(GS_PLUGIN_LIBS)
+	$(GS_PLUGIN_LIBS) $(FLATPAK_LIBS)
 libgs_plugin_eos_la_LDFLAGS = -module -avoid-version
 libgs_plugin_eos_la_CFLAGS =				\
 	$(GS_PLUGIN_CFLAGS) $(FLATPAK_CFLAGS)


### PR DESCRIPTION
The EOS plugin was not being linked with libflatpak and this somehow
didn't show up as a problem except on 3.2 images.

https://phabricator.endlessm.com/T18119