### PR TITLE
group EknServices together with apps runtime, rather than the old EOS runtime

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -1046,7 +1046,7 @@ add_updates (GsPlugin *plugin,
 {
 	g_autoptr(GsApp) updates_proxy_app = NULL;
 	g_autoptr(GSList) proxied_updates = NULL;
-	const char *proxied_apps[] = {"com.endlessm.Platform.runtime",
+	const char *proxied_apps[] = {"com.endlessm.apps.Platform.runtime",
 				      "com.endlessm.EknServices.desktop",
 				      NULL};
 


### PR DESCRIPTION
Since 3.2, EknServices links to com.endlessm.apps.Platform rather than com.endlessm.Platform, so it's better to group these two together for update purposes, and allow com.endlessm.Platform to appear "normally" by itself.

https://phabricator.endlessm.com/T18238