### PR TITLE
eos: re-add Endless OS Platform to proxy app

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -1046,7 +1046,8 @@ add_updates (GsPlugin *plugin,
 {
 	g_autoptr(GsApp) updates_proxy_app = NULL;
 	g_autoptr(GSList) proxied_updates = NULL;
-	const char *proxied_apps[] = {"com.endlessm.apps.Platform.runtime",
+	const char *proxied_apps[] = {"com.endlessm.Platform.runtime",
+				      "com.endlessm.apps.Platform.runtime",
 				      "com.endlessm.EknServices.desktop",
 				      NULL};
 


### PR DESCRIPTION
After discussing with Joaquim we think it's better to group all of
the runtimes for Endless together, as long as we have/need a separate
Endless OS runtime - hopefully over the next 3-6 months we'll be
able to move off it onto the freedesktop/gnome/SDK stack and remove
it.

https://phabricator.endlessm.com/T18238