### PR TITLE
eos: remove Polari from blacklist

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -458,8 +458,6 @@ gs_plugin_eos_blacklist_gnome_app_if_needed (GsPlugin *plugin, GsApp *app)
 		"org.gnome.Documents.desktop",
 		/* Doesn't work due to network related problems */
 		"org.gnome.Maps.desktop",
-		/* Requires Telepathy daemons running in the host */
-		"org.gnome.Polari.desktop",
 		NULL
 	};
 


### PR DESCRIPTION
The upstream Flatpak now includes the Telepathy daemons, so this
works on Endless now.

https://phabricator.endlessm.com/T18348