### PR TITLE
Fix blacklisting of GNOME apps

### DIFF
--- a/src/gs-category-page.c
+++ b/src/gs-category-page.c
@@ -147,7 +147,8 @@ gs_category_page_reload (GsPage *page)
 						  self->subcategory,
 						  GS_PLUGIN_REFINE_FLAGS_REQUIRE_ICON |
 						  GS_PLUGIN_REFINE_FLAGS_REQUIRE_VERSION |
-						  GS_PLUGIN_REFINE_FLAGS_REQUIRE_RATING,
+						  GS_PLUGIN_REFINE_FLAGS_REQUIRE_RATING |
+						  GS_PLUGIN_REFINE_FLAGS_REQUIRE_ORIGIN_HOSTNAME,
 						  GS_PLUGIN_FAILURE_FLAGS_USE_EVENTS,
 						  self->cancellable,
 						  gs_category_page_get_apps_cb,

--- a/src/gs-overview-page.c
+++ b/src/gs-overview-page.c
@@ -582,7 +582,8 @@ gs_overview_page_load (GsOverviewPage *self)
 	if (FALSE && !priv->loading_featured) {
 		priv->loading_featured = TRUE;
 		gs_plugin_loader_get_featured_async (priv->plugin_loader,
-						     GS_PLUGIN_REFINE_FLAGS_REQUIRE_ICON,
+						     GS_PLUGIN_REFINE_FLAGS_REQUIRE_ICON |
+						     GS_PLUGIN_REFINE_FLAGS_REQUIRE_ORIGIN_HOSTNAME,
 						     GS_PLUGIN_FAILURE_FLAGS_USE_EVENTS,
 						     priv->cancellable,
 						     gs_overview_page_get_featured_cb,
@@ -594,7 +595,8 @@ gs_overview_page_load (GsOverviewPage *self)
 		priv->loading_popular = TRUE;
 		gs_plugin_loader_get_popular_async (priv->plugin_loader,
 						    GS_PLUGIN_REFINE_FLAGS_REQUIRE_REVIEW_RATINGS |
-						    GS_PLUGIN_REFINE_FLAGS_REQUIRE_ICON,
+						    GS_PLUGIN_REFINE_FLAGS_REQUIRE_ICON |
+						    GS_PLUGIN_REFINE_FLAGS_REQUIRE_ORIGIN_HOSTNAME,
 						    GS_PLUGIN_FAILURE_FLAGS_USE_EVENTS,
 						    priv->cancellable,
 						    gs_overview_page_get_popular_cb,
@@ -632,7 +634,8 @@ gs_overview_page_load (GsOverviewPage *self)
 			gs_plugin_loader_get_category_apps_async (priv->plugin_loader,
 								  featured_category,
 								  GS_PLUGIN_REFINE_FLAGS_REQUIRE_REVIEW_RATINGS |
-								  GS_PLUGIN_REFINE_FLAGS_REQUIRE_ICON,
+								  GS_PLUGIN_REFINE_FLAGS_REQUIRE_ICON |
+								  GS_PLUGIN_REFINE_FLAGS_REQUIRE_ORIGIN_HOSTNAME,
 								  GS_PLUGIN_FAILURE_FLAGS_USE_EVENTS,
 								  priv->cancellable,
 								  gs_overview_page_get_category_apps_cb,


### PR DESCRIPTION
Some GNOME apps are blacklisted and they are done so by verifying their
name and hostname. However, in some views like the category and
overview, the hostname is not being requested when refining those apps.
This results in a failure to blacklist the mentioned apps.

To fix this, this patch adds the REQUIRE_ORIGIN_HOSTNAME flag to the
refine flags in the overview and category views.

https://phabricator.endlessm.com/T18685