### PR TITLE
eos: Blacklist dconf-editor

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -594,6 +594,8 @@ gs_plugin_eos_blacklist_upstream_app_if_needed (GsPlugin *plugin, GsApp *app)
 
 	/* Flatpak apps known not to be working properly */
 	static const char *buggy_apps[] = {
+		/* Missing lots of keys and defaults specified in eos-theme */
+		"ca.desrt.dconf-editor",
 		/* Can't open LibreOffice documents */
 		"org.gnome.Documents.desktop",
 		/* Doesn't work due to network related problems */


### PR DESCRIPTION
The flatpak version of dconf-editor does not show the default values
specified in eos-theme, and is missing a lot of keys (e.g., under
/org/gnome/shell, the only keys are command-history and
icon-grid-layout, and they both complain that "No Schema Found").

https://phabricator.endlessm.com/T18993