### PR TITLE
eos: Fix blacklist of dconf-editor

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -644,7 +644,7 @@ gs_plugin_eos_blacklist_upstream_app_if_needed (GsPlugin *plugin, GsApp *app)
 	/* Flatpak apps known not to be working properly */
 	static const char *buggy_apps[] = {
 		/* Missing lots of keys and defaults specified in eos-theme */
-		"ca.desrt.dconf-editor",
+		"ca.desrt.dconf-editor.desktop",
 		/* Can't open LibreOffice documents */
 		"org.gnome.Documents.desktop",
 		/* Doesn't work due to network related problems */


### PR DESCRIPTION
The previous attempt was missing the ".desktop" extension.

https://phabricator.endlessm.com/T18993