### PR TITLE
Notify apps' property changes from the main loop

### DIFF
--- a/lib/gs-app.c
+++ b/lib/gs-app.c
@@ -4081,7 +4081,7 @@ gs_app_class_init (GsAppClass *klass)
 	 * GsApp:key-colors:
 	 */
 	pspec = g_param_spec_pointer ("key-colors", NULL, NULL,
-				      G_PARAM_READWRITE | G_PARAM_CONSTRUCT);
+				      G_PARAM_READWRITE);
 	g_object_class_install_property (object_class, PROP_KEY_COLORS, pspec);
 
         /**

--- a/lib/gs-plugin-loader.c
+++ b/lib/gs-plugin-loader.c
@@ -917,6 +917,15 @@ gs_plugin_loader_run_refine_internal (GsPluginLoaderHelper *helper,
 }
 
 static gboolean
+app_thaw_notify_idle (gpointer data)
+{
+	GsApp *app = GS_APP (data);
+	g_object_thaw_notify (G_OBJECT (app));
+	g_object_unref (app);
+	return G_SOURCE_REMOVE;
+}
+
+static gboolean
 gs_plugin_loader_run_refine (GsPluginLoaderHelper *helper,
 			     GsAppList *list,
 			     GCancellable *cancellable,
@@ -1000,7 +1009,7 @@ out:
 	/* now emit all the changed signals */
 	for (guint i = 0; i < gs_app_list_length (freeze_list); i++) {
 		GsApp *app = gs_app_list_index (freeze_list, i);
-		g_object_thaw_notify (G_OBJECT (app));
+		g_idle_add (app_thaw_notify_idle, g_object_ref (app));
 	}
 	return ret;
 }


### PR DESCRIPTION
These changes avoid a race when apps are refined from within a
different thread, as their properties' notification were being
emitted (and thus triggering) code from those.

Specifically there was a race when setting up the CSS for the
background tile as this code was not getting run from the main
loop.

https://phabricator.endlessm.com/T19321