### PR TITLE
eos: Set the installed state for compulsory applications

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -865,9 +865,17 @@ gs_plugin_adopt_app (GsPlugin *plugin, GsApp *app)
 static void
 gs_plugin_eos_refine_core_app (GsApp *app)
 {
+	if (app_is_flatpak (app))
+		return;
+
 	/* we only allow to remove flatpak apps */
-	if (!app_is_flatpak (app))
-		gs_app_add_quirk (app, AS_APP_QUIRK_COMPULSORY);
+	gs_app_add_quirk (app, AS_APP_QUIRK_COMPULSORY);
+
+	if (gs_app_is_installed (app)) {
+		/* forcibly set the installed state */
+		gs_app_set_state (app, AS_APP_STATE_UNKNOWN);
+		gs_app_set_state (app, AS_APP_STATE_INSTALLED);
+	}
 }
 
 typedef struct


### PR DESCRIPTION
After a2ff48d35186cc612e19ceeb8164b1cb1b645375, core apps (installed in
the system by default) stopped being assigned a state and thus were
geting filtered out. So we need to ensure that such apps are getting
the correct state.

For that reason, now the EOS plugin, besides setting the compulsory
quirk to such apps, also forcibly sets their state to installed.

https://phabricator.endlessm.com/T19482