### PR TITLE
eos: Fix setting the installed state to compulsory apps

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -871,7 +871,7 @@ gs_plugin_eos_refine_core_app (GsApp *app)
 	/* we only allow to remove flatpak apps */
 	gs_app_add_quirk (app, AS_APP_QUIRK_COMPULSORY);
 
-	if (gs_app_is_installed (app)) {
+	if (!gs_app_is_installed (app)) {
 		/* forcibly set the installed state */
 		gs_app_set_state (app, AS_APP_STATE_UNKNOWN);
 		gs_app_set_state (app, AS_APP_STATE_INSTALLED);


### PR DESCRIPTION
By mistake, the condition that checked whether a compulsory app was
installed was inverted. So it would never set the installed state to
those apps.

This patch simply negates the condition, which fixes the issue and makes
core apps be shown again.

https://phabricator.endlessm.com/T19482