### PR TITLE
flatpak: Stop refreshing the updates page after every update

### DIFF
--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -3216,9 +3216,6 @@ gs_flatpak_update_app (GsFlatpak *self,
 		return FALSE;
 	}
 
-	/* update UI */
-	gs_plugin_updates_changed (self->plugin);
-
 	/* state is known */
 	gs_app_set_state (app, AS_APP_STATE_INSTALLED);
 	gs_app_set_update_version (app, NULL);

--- a/src/gs-updates-page.c
+++ b/src/gs-updates-page.c
@@ -199,9 +199,16 @@ _get_all_apps (GsUpdatesPage *self)
 {
 	GsAppList *apps = gs_app_list_new ();
 	for (guint i = 0; i < GS_UPDATE_PAGE_SECTION_LAST; i++) {
-		g_autoptr(GsAppList) apps_tmp = NULL;
-		apps_tmp = _get_apps_for_section (self, i);
-		gs_app_list_add_list (apps, apps_tmp);
+		g_autoptr(GList) children = NULL;
+
+		if (self->listboxes[i] == NULL)
+			continue;
+
+		children = gtk_container_get_children (GTK_CONTAINER (self->listboxes[i]));
+		for (GList *l = children; l != NULL; l = l->next) {
+			GsAppRow *app_row = GS_APP_ROW (l->data);
+			gs_app_list_add (apps, gs_app_row_get_app (app_row));
+		}
 	}
 	return apps;
 }


### PR DESCRIPTION
The Flatpak plugin was emitting the "updates-changed" signal after
updating every app. This ended up refreshing the updates page after
each Flatpak update which takes a while and reloads the list of apps.

To prevent that, this patch just removes the call that emits the
mentioned signal. There is no downside from this removal because the
updates page already responds correctly to the apps' state changes.

https://phabricator.endlessm.com/T14214