### PR TITLE
Use the speedwagon when opening GNOME Software

### DIFF
--- a/src/org.gnome.Software.desktop.in
+++ b/src/org.gnome.Software.desktop.in
@@ -15,3 +15,4 @@ X-GNOME-Bugzilla-Bugzilla=GNOME
 X-GNOME-Bugzilla-Product=gnome-software
 X-GNOME-Bugzilla-Component=gnome-software
 X-GNOME-UsesNotifications=true
+X-Endless-LaunchMaximized=true


### PR DESCRIPTION
The reason is that when maximizing the window it shows a weird jerky
effect that hinders the smooth UX we always pursue.

https://phabricator.endlessm.com/T19697