### PR TITLE
eos: Blacklist com.skype.Client from Flathub

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -508,6 +508,7 @@ gs_plugin_eos_blacklist_upstream_app_if_needed (GsPlugin *plugin, GsApp *app)
 		"com.google.AndroidStudio.desktop",
 		"com.google.Chrome.desktop",
 		"com.microsoft.Skype.desktop",
+		"com.skype.Client.desktop",
 		"com.mojang.Minecraft.desktop",
 		"com.slack.Slack.desktop",
 		"com.sparklinlabs.Superpowers.desktop",


### PR DESCRIPTION
We already blacklisted com.microsoft.Skype, which is the app ID
we use for the external app we provide.  Flathub recently made
an app available as com.skype.Client, which shows as a duplicate
in our app center.  Unfortunately, the version on Flathub is not
currently installable on Endless, and besides we would like to
have a migration path for existing users before switching to
the Flathub build, so for now we only want to show our build.

https://phabricator.endlessm.com/T19782