### PR TITLE
Include "More Apps" as a GenericName in the desktop file

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the gnome-software package.
-# 
+#
 # Translators:
 # Khaled Hosny <khaledhosny@eglug.org>, 2016
 # Muhannad Alrusayni <muhannad.alrusayni@gmail.com>, 2016
@@ -13,15 +13,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-software\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-12 22:31-0700\n"
+"POT-Creation-Date: 2017-11-02 16:28+0100\n"
 "PO-Revision-Date: 2017-10-16 08:58+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
-"Language-Team: Arabic (http://www.transifex.com/endless-mobile-inc/gnome-software/language/ar/)\n"
+"Language-Team: Arabic (http://www.transifex.com/endless-mobile-inc/gnome-"
+"software/language/ar/)\n"
+"Language: ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ar\n"
-"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:7
 msgid "GNOME Software"
@@ -35,7 +37,9 @@ msgstr "مدير تطبيقات لجنوم"
 msgid ""
 "Software allows you to find and install new applications and system "
 "extensions and remove existing installed applications."
-msgstr "يسمح لك «برمجيّات» بالبحث عن تطبيقات جديدة وامتدادات للنّظام وإزالة التّطبيقات المثبّتة."
+msgstr ""
+"يسمح لك «برمجيّات» بالبحث عن تطبيقات جديدة وامتدادات للنّظام وإزالة التّطبيقات "
+"المثبّتة."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:14
 msgid ""
@@ -43,7 +47,10 @@ msgid ""
 "descriptions and multiple screenshots per application. Applications can be "
 "found either through browsing the list of categories or by searching. It "
 "also allows you to update your system using an offline update."
-msgstr "يعرض «برمجيّات جنوم» التّطبيقات المُختارة والشّعبيّة بأوصاف مفيدة وعدّة لقطات شاشة لكلّ تطبيق. يمكن العثور على التّطبيقات من تصفّح قائمة الفئات أو بالبحث. يسمح لك «برمجيّات جنوم» أيضًا بتحديث النّظام باستخدام تحديث دون اتّصال."
+msgstr ""
+"يعرض «برمجيّات جنوم» التّطبيقات المُختارة والشّعبيّة بأوصاف مفيدة وعدّة لقطات شاشة "
+"لكلّ تطبيق. يمكن العثور على التّطبيقات من تصفّح قائمة الفئات أو بالبحث. يسمح لك "
+"«برمجيّات جنوم» أيضًا بتحديث النّظام باستخدام تحديث دون اتّصال."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:25
 msgid "Overview panel"
@@ -87,7 +94,10 @@ msgstr "إذا ما كان من المطلوب إدارة التحديثات ف�
 msgid ""
 "If disabled, GNOME Software will hide the updates panel and not perform any "
 "automatic updates actions."
-msgstr "عند تعطيله، سيقوم برنامج GNOME بإخفاء لوحة التحديثات ولن يقوم بأي أعمال تحديث تلقائية.\n "
+msgstr ""
+"عند تعطيله، سيقوم برنامج GNOME بإخفاء لوحة التحديثات ولن يقوم بأي أعمال "
+"تحديث تلقائية.\n"
+" "
 
 #: data/org.gnome.software.gschema.xml:15
 msgid "Whether to automatically download updates"
@@ -95,9 +105,11 @@ msgstr "فيما إذا كان يجب تنزيل تحديثات تلقائيا �
 
 #: data/org.gnome.software.gschema.xml:16
 msgid ""
-"If enabled, GNOME Software automatically downloads updates in the background"
-" and prompts the user to install them when ready."
-msgstr "إن فُعّل، سينزل «برمجيّات جنوم» التحديثات تلقائيا في الخلفية ويطلب من المستخدم تثبيتها عند جهوزها."
+"If enabled, GNOME Software automatically downloads updates in the background "
+"and prompts the user to install them when ready."
+msgstr ""
+"إن فُعّل، سينزل «برمجيّات جنوم» التحديثات تلقائيا في الخلفية ويطلب من المستخدم "
+"تثبيتها عند جهوزها."
 
 #: data/org.gnome.software.gschema.xml:20
 msgid "Whether to automatically refresh when on a metered connection"
@@ -108,7 +120,10 @@ msgid ""
 "If enabled, GNOME Software automatically refreshes in the background even "
 "when using a metered connection (eventually downloading some metadata, "
 "checking for updates, etc., which may incur in costs for the user)."
-msgstr "إذا تم تمكين هذه الميزة، سيقوم برنامج GNOME بالتحديث في الخلفية حتى مع استخدام اتصال إنترنت محدود (حيث ينتهي الحال بتنزيل بعض البيانات التعريفية، والتحري عن وجود تحديثات، إلخ، وهي أمور قد تتم بتكلفة على المستخدم)."
+msgstr ""
+"إذا تم تمكين هذه الميزة، سيقوم برنامج GNOME بالتحديث في الخلفية حتى مع "
+"استخدام اتصال إنترنت محدود (حيث ينتهي الحال بتنزيل بعض البيانات التعريفية، "
+"والتحري عن وجود تحديثات، إلخ، وهي أمور قد تتم بتكلفة على المستخدم)."
 
 #: data/org.gnome.software.gschema.xml:25
 msgid "Whether it’s the very first run of GNOME Software"
@@ -128,8 +143,8 @@ msgstr "تعرض التطبيقات غير الحرة تحذيرا قبل تثب
 
 #: data/org.gnome.software.gschema.xml:38
 msgid ""
-"When non-free applications are installed a warning dialog can be shown. This"
-" controls if that dialog is suppressed."
+"When non-free applications are installed a warning dialog can be shown. This "
+"controls if that dialog is suppressed."
 msgstr "يمكن عرض تحذير عند تثبيت تطبيقات غير حرة. يتحكم هذا في عرضه من عدمه."
 
 #: data/org.gnome.software.gschema.xml:42
@@ -173,9 +188,13 @@ msgstr "المدة بالثواني للتحقق من لقطة الشاشة مع
 #: data/org.gnome.software.gschema.xml:69
 msgid ""
 "Choosing a larger value will mean less round-trips to the remote server but "
-"updates to the screenshots may take longer to show to the user. A value of 0"
-" means to never check the server if the image already exists in the cache."
-msgstr "اختيار قيمة أكبر يعني استخدام رحلات ذهاب وإياب أقل للوصول إلى الخادم البعيد، ولكن تحديثات لقطات الشاشة قد تستغرق مزيداً من الوقت لتظهر للمستخدم. وتحديد قيمة 0 يعني عدم التحقق من الخادم مطلقاً إذا كانت الصورة موجودة بالفعل في التخزين المؤقت."
+"updates to the screenshots may take longer to show to the user. A value of 0 "
+"means to never check the server if the image already exists in the cache."
+msgstr ""
+"اختيار قيمة أكبر يعني استخدام رحلات ذهاب وإياب أقل للوصول إلى الخادم البعيد، "
+"ولكن تحديثات لقطات الشاشة قد تستغرق مزيداً من الوقت لتظهر للمستخدم. وتحديد "
+"قيمة 0 يعني عدم التحقق من الخادم مطلقاً إذا كانت الصورة موجودة بالفعل في "
+"التخزين المؤقت."
 
 #: data/org.gnome.software.gschema.xml:78
 msgid "The server to use for application reviews"
@@ -199,13 +218,11 @@ msgstr "قائمة المصادر الرسمية كي تُعتبر برمجيا�
 
 #: data/org.gnome.software.gschema.xml:95
 msgid ""
-"The licence URL to use when an application should be considered free "
-"software"
+"The licence URL to use when an application should be considered free software"
 msgstr "عنوان الرخصة لكي يُستخدم لاعتبار تطبيق ما برمجيةً حرة"
 
 #: data/org.gnome.software.gschema.xml:99
-msgid ""
-"Install bundled applications for all users on the system where possible"
+msgid "Install bundled applications for all users on the system where possible"
 msgstr "ثبّت تطبيقات لكل مستخدم النظام متى ما امكن"
 
 #: data/org.gnome.software.gschema.xml:103
@@ -248,7 +265,8 @@ msgstr "قائمة المصادر غير الحرة التي يمكن تفعيل
 msgid ""
 "A list of URLs pointing to appstream files that will be downloaded into an "
 "app-info folder"
-msgstr "قائمة روابط URL تشير إلى ملفات appstream التي سيتم تنزيلها في مجلد app-info"
+msgstr ""
+"قائمة روابط URL تشير إلى ملفات appstream التي سيتم تنزيلها في مجلد app-info"
 
 #: data/org.gnome.software.gschema.xml:143
 msgid "Install the AppStream files to a system-wide location for all users"
@@ -272,8 +290,7 @@ msgstr "تثبيت البرمجيّات"
 msgid "Install selected software on the system"
 msgstr "ثبّت البرمجيّات المحدّدة على النّظام"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 #: src/gnome-software-local-file.desktop.in:10
 msgid "system-software-install"
 msgstr "نظام-برنامج-تثبيت"
@@ -300,14 +317,12 @@ msgstr "ارجع"
 msgid "_All"
 msgstr "ال_كلّ"
 
-#. Translators: A label for a button to show only software which is already
-#. installed.
+#. Translators: A label for a button to show only software which is already installed.
 #: src/gnome-software.ui:104
 msgid "_Installed"
 msgstr "ال_مثبّتة"
 
-#. Translators: A label for a button to show only updates which are available
-#. to install.
+#. Translators: A label for a button to show only updates which are available to install.
 #: src/gnome-software.ui:155
 msgid "_Updates"
 msgstr "ال_تّحديثات"
@@ -355,7 +370,7 @@ msgstr "مُثبّت"
 
 #. TRANSLATORS: this is a button next to the search results that
 #. * shows the status of an application being installed
-#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:443
+#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:439
 msgid "Installing"
 msgstr "يثبّت"
 
@@ -370,7 +385,7 @@ msgid "Folder Name"
 msgstr "اسم المجلّد"
 
 #: src/gs-app-folder-dialog.c:321 src/gs-app-folder-dialog.ui:16
-#: src/gs-details-page.c:383 src/gs-details-page.ui:342 src/gs-editor.c:623
+#: src/gs-details-page.c:379 src/gs-details-page.ui:342 src/gs-editor.c:623
 #: src/gs-editor.c:655 src/gs-installed-page.c:609 src/gs-removal-dialog.ui:33
 #: src/gs-review-dialog.ui:23 src/gs-upgrade-banner.ui:131
 msgid "_Cancel"
@@ -385,90 +400,95 @@ msgid "Add to Application Folder"
 msgstr "أضف إلى مجلّد التّطبيقات"
 
 #. TRANSLATORS: this is a command line option
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "Start up mode: either ‘updates’, ‘updated’, ‘installed’ or ‘overview’"
-msgstr "وضع البدء: واحدٌ من 'updates'، أو 'updated'، أو 'installed' أو 'overview'"
+msgstr ""
+"وضع البدء: واحدٌ من 'updates'، أو 'updated'، أو 'installed' أو 'overview'"
 
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "MODE"
 msgstr "الوضع"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "Search for applications"
 msgstr "ابحث عن تطبيقات"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "SEARCH"
 msgstr "البحث"
 
-#: src/gs-application.c:105
+#: src/gs-application.c:133
 msgid "Show application details (using application ID)"
 msgstr "اعرض تفاصيل التّطبيق (باستخدام معرّفه)"
 
-#: src/gs-application.c:105 src/gs-application.c:109
+#: src/gs-application.c:133 src/gs-application.c:137
 msgid "ID"
 msgstr "المعرّف"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "Show application details (using package name)"
 msgstr "اعرض تفاصيل التّطبيق (باستخدام اسم الحزمة)"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "PKGNAME"
 msgstr "اسم_الحزمة"
 
-#: src/gs-application.c:109
+#: src/gs-application.c:137
 msgid "Install the application (using application ID)"
 msgstr "تثبيت التطبيق (باستخدام مُعَرِّفْ التطبيق)"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "Open a local package file"
 msgstr "افتح ملفّ حزمة محليّة"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "FILENAME"
 msgstr "اسم_الملفّ"
 
-#: src/gs-application.c:113
+#: src/gs-application.c:141
 msgid ""
 "The kind of interaction expected for this action: either ‘none’, ‘notify’, "
 "or ‘full’"
-msgstr "نوع التفاعل المتوقع مع هذا الإجراء: إما ‘لا شيء‘ أو ‘التنبيه‘ أو ‘كامل‘"
+msgstr ""
+"نوع التفاعل المتوقع مع هذا الإجراء: إما ‘لا شيء‘ أو ‘التنبيه‘ أو ‘كامل‘"
 
-#: src/gs-application.c:116
+#: src/gs-application.c:144
 msgid "Show verbose debugging information"
 msgstr "اعرض معلومات تنقيح مطنبة"
 
-#: src/gs-application.c:118
+#: src/gs-application.c:146
 msgid "Show profiling information for the service"
 msgstr "اعرض معلومات التّعرفة للخدمة"
 
-#: src/gs-application.c:120
+#: src/gs-application.c:148
 msgid "Quit the running instance"
 msgstr "أنهِ السيرورة الجارية"
 
-#: src/gs-application.c:122
+#: src/gs-application.c:150
 msgid "Prefer local file sources to AppStream"
 msgstr "فضّل مصادر الملفّات المحليّة على AppStream"
 
-#: src/gs-application.c:124
+#: src/gs-application.c:152
 msgid "Show version number"
 msgstr "اعرض رقم الإصدارة"
 
-#: src/gs-application.c:325
+#: src/gs-application.c:358
 msgid "translator-credits"
-msgstr "فريق عربآيز للترجمة http://www.arabeyes.org :\nشعيب زاهدة\t<shuaib.zahda@gmail.com>\nصفا الفليج\t<safa1996alfulaij@gmail.com>"
+msgstr ""
+"فريق عربآيز للترجمة http://www.arabeyes.org :\n"
+"شعيب زاهدة\t<shuaib.zahda@gmail.com>\n"
+"صفا الفليج\t<safa1996alfulaij@gmail.com>"
 
 #. TRANSLATORS: this is the title of the about window, e.g.
 #. * 'About Software' or 'About Application Installer' where the %s is
 #. * the application name chosen by the distro
-#: src/gs-application.c:332
+#: src/gs-application.c:365
 #, c-format
 msgid "About %s"
 msgstr "معلومات حول %s"
 
 #. TRANSLATORS: well, we seem to think so, anyway
-#: src/gs-application.c:336
+#: src/gs-application.c:369
 msgid "A nice way to manage the software on your system."
 msgstr "طريقة لطيفة لإدارة البرمجيّات في النّظام."
 
@@ -583,7 +603,7 @@ msgid "All"
 msgstr "الكلّ"
 
 #. TRANSLATORS: this is a subcategory of featured apps
-#: lib/gs-category.c:202 src/gs-shell.c:2180
+#: lib/gs-category.c:202 src/gs-shell.c:2181
 msgid "Featured"
 msgstr "مُختارة"
 
@@ -593,9 +613,11 @@ msgstr "إعدادات الامتدادات"
 
 #: src/gs-category-page.ui:110
 msgid ""
-"Extensions are used at your own risk. If you have any system problems, it is"
-" recommended to disable them."
-msgstr "استعمل الامتدادات على مسؤوليتك الخاصة. إن واجهت أية مشاكل في النظام، فمن المستحسن أن تعطلها."
+"Extensions are used at your own risk. If you have any system problems, it is "
+"recommended to disable them."
+msgstr ""
+"استعمل الامتدادات على مسؤوليتك الخاصة. إن واجهت أية مشاكل في النظام، فمن "
+"المستحسن أن تعطلها."
 
 #. TRANSLATORS: the user isn't reading the question
 #: lib/gs-cmd.c:205
@@ -651,13 +673,15 @@ msgstr "أأفعّل مصادر برمجيات من طرف ثالث؟"
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
 #. * 2. Software source name, e.g. fedora-optional
+#.
 #: src/gs-common.c:232
 #, c-format
 msgid ""
 "%s is not <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
-"source_software\">free and open source software</a>, and is provided by "
-"“%s”."
-msgstr "%s ليست <a href=\"https://en.wikipedia.org/wiki/Free_and_open-source_software\">برمجية حرّة وفمتوحة المصدر</a>، وموفّرها هو \"%s\"."
+"source_software\">free and open source software</a>, and is provided by “%s”."
+msgstr ""
+"%s ليست <a href=\"https://en.wikipedia.org/wiki/Free_and_open-source_software"
+"\">برمجية حرّة وفمتوحة المصدر</a>، وموفّرها هو \"%s\"."
 
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
@@ -1012,7 +1036,9 @@ msgstr "ميزة دردشة مرئية أو صوتية بين اللاعبين �
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:258
 msgid "No sharing of social network usernames or email addresses"
-msgstr "غير مسموح بمشاركة أسماء المستخدمين أو عناوين البريد الإلكتروني الخاصة بالشبكة الاجتماعية"
+msgstr ""
+"غير مسموح بمشاركة أسماء المستخدمين أو عناوين البريد الإلكتروني الخاصة "
+"بالشبكة الاجتماعية"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:261
@@ -1039,14 +1065,12 @@ msgstr "غير مصرح بمشاركة الموقع الفعلي مع المست
 msgid "Sharing physical location to other users"
 msgstr "مشاركة الموقع الفيزيائي مع بقية المستخدمين"
 
-#. TRANSLATORS: this is a what we use in notifications if the app's name is
-#. unknown
+#. TRANSLATORS: this is a what we use in notifications if the app's name is unknown
 #: src/gs-dbus-helper.c:294
 msgid "An application"
 msgstr "تطبيق ما"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. MIME types.
+#. TRANSLATORS: this is a notification displayed when an app needs additional MIME types.
 #: src/gs-dbus-helper.c:300
 #, c-format
 msgid "%s is requesting additional file format support."
@@ -1057,8 +1081,7 @@ msgstr "هناك %s يطلب دعما لصيغة ملفات أخرى."
 msgid "Additional MIME Types Required"
 msgstr "أنواع MIME أخرى مطلوبة"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. fonts.
+#. TRANSLATORS: this is a notification displayed when an app needs additional fonts.
 #: src/gs-dbus-helper.c:306
 #, c-format
 msgid "%s is requesting additional fonts."
@@ -1069,8 +1092,7 @@ msgstr "هناك %s يطلب خطوطا أخرى."
 msgid "Additional Fonts Required"
 msgstr "خطوط أخرى مطلوبة"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. codecs.
+#. TRANSLATORS: this is a notification displayed when an app needs additional codecs.
 #: src/gs-dbus-helper.c:312
 #, c-format
 msgid "%s is requesting additional multimedia codecs."
@@ -1081,8 +1103,7 @@ msgstr "هناك %s يطلب مرمازات وسائط أخرى."
 msgid "Additional Multimedia Codecs Required"
 msgstr "مرمازات وسائط أخرى مطلوبة"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. printer drivers.
+#. TRANSLATORS: this is a notification displayed when an app needs additional printer drivers.
 #: src/gs-dbus-helper.c:318
 #, c-format
 msgid "%s is requesting additional printer drivers."
@@ -1093,8 +1114,7 @@ msgstr "هناك %s يطلب مشغلات طابعات أخرى."
 msgid "Additional Printer Drivers Required"
 msgstr "مشغلات طابعات أخرى مطلوبة"
 
-#. TRANSLATORS: this is a notification displayed when an app wants to install
-#. additional packages.
+#. TRANSLATORS: this is a notification displayed when an app wants to install additional packages.
 #: src/gs-dbus-helper.c:324
 #, c-format
 msgid "%s is requesting additional packages."
@@ -1114,14 +1134,14 @@ msgstr "ابحث في «برمجيّات»"
 #. * can be installed
 #. TRANSLATORS: button text in the header when firmware
 #. * can be live-installed
-#: src/gs-details-page.c:281 src/gs-details-page.c:312
-#: src/gs-details-page.ui:206 src/gs-upgrade-banner.ui:146
+#: src/gs-details-page.c:280 src/gs-details-page.c:310
+#: src/gs-details-page.ui:237 src/gs-upgrade-banner.ui:146
 msgid "_Install"
 msgstr "_ثبّت"
 
 #. TRANSLATORS: button text in the header when an application
 #. * can be live-updated
-#: src/gs-details-page.c:316
+#: src/gs-details-page.c:314
 msgid "_Update"
 msgstr "ح_دث"
 
@@ -1129,61 +1149,61 @@ msgstr "ح_دث"
 #. * be installed.
 #. * The ellipsis indicates that further steps are required,
 #. * e.g. enabling software sources or the like
-#: src/gs-details-page.c:330
+#: src/gs-details-page.c:326
 msgid "_Install…"
 msgstr "_ثبّت..."
 
 #. TRANSLATORS: button text in the header when an application can be erased
-#: src/gs-details-page.c:377 src/gs-details-page.ui:547
+#: src/gs-details-page.c:373 src/gs-details-page.ui:547
 msgid "_Uninstall"
 msgstr "_إلغاء التثبيت"
 
-#: src/gs-details-page.c:438 src/gs-sources-dialog.c:513
+#: src/gs-details-page.c:434 src/gs-sources-dialog.c:513
 msgid "Removing…"
 msgstr "يزيل…"
 
 #. TRANSLATORS: this is the warning box
-#: src/gs-details-page.c:748
+#: src/gs-details-page.c:744
 msgid ""
 "This application can only be used when there is an active internet "
 "connection."
 msgstr "يمكن استخدام هذا التّطبيق فقط إن كان هناك اتّصال نشط بالإنترنت."
 
 #. TRANSLATORS: this is where the version is not known
-#: src/gs-details-page.c:892
+#: src/gs-details-page.c:888
 msgctxt "version"
 msgid "Unknown"
 msgstr "مجهول"
 
 #. TRANSLATORS: this is where we don't know the origin of the
 #. * application
-#: src/gs-details-page.c:971
+#: src/gs-details-page.c:967
 msgctxt "origin"
 msgid "Unknown"
 msgstr "مجهول"
 
 #. TRANSLATORS: we need a remote server to process
-#: src/gs-details-page.c:1378
+#: src/gs-details-page.c:1374
 msgid "You need internet access to write a review"
 msgstr "أنت بحاجة للاتصال بالإنترنت لتتمكن من كتابة إبداء رأي"
 
-#: src/gs-details-page.c:1507
+#: src/gs-details-page.c:1503
 #, c-format
 msgid "Unable to find “%s”"
 msgstr "تعذّر العثور على “%s”"
 
 #. TRANSLATORS: see the wikipedia page
-#: src/gs-details-page.c:2087
+#: src/gs-details-page.c:2083
 msgid "Public domain"
 msgstr "ملكية عامة"
 
 #. TRANSLATORS: see GNU page
-#: src/gs-details-page.c:2103 src/gs-details-page.ui:1397
+#: src/gs-details-page.c:2099 src/gs-details-page.ui:1397
 msgid "Free Software"
 msgstr "برمجيات حرة"
 
 #. TRANSLATORS: for the free software popover
-#: src/gs-details-page.c:2160
+#: src/gs-details-page.c:2156
 msgid "Users are bound by the following license:"
 msgid_plural "Users are bound by the following licenses:"
 msgstr[0] "المستخدمون مُحدَّدون بالرخصة الآتية:"
@@ -1193,7 +1213,7 @@ msgstr[3] "المستخدمون مُحدَّدون بالرخص الآتية:"
 msgstr[4] "المستخدمون مُحدَّدون بالرخص الآتية:"
 msgstr[5] "المستخدمون مُحدَّدون بالرخص الآتية:"
 
-#: src/gs-details-page.c:2176 src/gs-details-page.ui:1506
+#: src/gs-details-page.c:2172 src/gs-details-page.ui:1506
 msgid "More information"
 msgstr "معلومات أخرى"
 
@@ -1201,15 +1221,13 @@ msgstr "معلومات أخرى"
 msgid "Details page"
 msgstr "صفحة التّفاصيل"
 
-#. Translators: A label for a button to add a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:228
+#. Translators: A label for a button to add a shortcut to the selected application.
+#: src/gs-details-page.ui:209
 msgid "_Add to Desktop"
 msgstr "_إضافة إلى سطح المكتب"
 
-#. Translators: A label for a button to remove a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:245
+#. Translators: A label for a button to remove a shortcut to the selected application.
+#: src/gs-details-page.ui:226
 msgid "_Remove from Desktop"
 msgstr "_إزالة من سطح المكتب"
 
@@ -1230,7 +1248,9 @@ msgstr "مصادر البرمجيات مُضمَّنة"
 msgid ""
 "This application includes a software source which provides updates, as well "
 "as access to other software."
-msgstr "يتضمّن هذا التّطبيق مصدر برمجيّات يوفّر التّحديثات إلى جانب الوصول إلى برمجيّات أخرى."
+msgstr ""
+"يتضمّن هذا التّطبيق مصدر برمجيّات يوفّر التّحديثات إلى جانب الوصول إلى برمجيّات "
+"أخرى."
 
 #: src/gs-details-page.ui:500
 msgid "No Software Source Included"
@@ -1248,8 +1268,7 @@ msgid ""
 "replaced."
 msgstr "تُوفِّر توزيعتك هذه البرمجيّة بالفعل ولا يجب استبدالها."
 
-#. Translators: a repository file used for installing software has been
-#. discovered.
+#. Translators: a repository file used for installing software has been discovered.
 #: src/gs-details-page.ui:528
 msgid "Software Source Identified"
 msgstr "تعرّفتُ على مصدر برمجيّات"
@@ -1350,14 +1369,12 @@ msgstr "الإضافات"
 msgid "Selected add-ons will be installed with the application."
 msgstr "الإضافات المحدّدة ستُثبَّت مع البرمجيّة."
 
-#. Translators: Header of the section with other users' opinions about the
-#. app.
+#. Translators: Header of the section with other users' opinions about the app.
 #: src/gs-details-page.ui:1233
 msgid "Reviews"
 msgstr "المراجعات"
 
-#. Translators: Button opening a dialog where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Button opening a dialog where the users can write and publish their opinions about the apps.
 #: src/gs-details-page.ui:1249
 msgid "_Write a Review"
 msgstr "ا_كتب مراجعة"
@@ -1369,9 +1386,11 @@ msgstr "ا_عرض المزيد"
 
 #: src/gs-details-page.ui:1414
 msgid ""
-"This means that the software can be freely run, copied, distributed, studied"
-" and modified."
-msgstr "يعني هذا أنه يمكن تشغيل البرمجية، ونسخها، وتوزيعها، ودراستها وتعديلها بحرية تامة."
+"This means that the software can be freely run, copied, distributed, studied "
+"and modified."
+msgstr ""
+"يعني هذا أنه يمكن تشغيل البرمجية، ونسخها، وتوزيعها، ودراستها وتعديلها بحرية "
+"تامة."
 
 #: src/gs-details-page.ui:1473
 msgid "Proprietary Software"
@@ -1382,7 +1401,9 @@ msgid ""
 "This means that the software is owned by an individual or a company. There "
 "are often restrictions on its use and its source code cannot usually be "
 "accessed."
-msgstr "يعني هذا أن البرمجية مملوكة لشخص أو شركة. غالبا ما توجد تقييدات على استخدامها ولا يمكن الوصول إلى النص البرمجي لها."
+msgstr ""
+"يعني هذا أن البرمجية مملوكة لشخص أو شركة. غالبا ما توجد تقييدات على "
+"استخدامها ولا يمكن الوصول إلى النص البرمجي لها."
 
 #: src/gs-details-page.ui:1535
 msgid "Unknown Software License"
@@ -1466,8 +1487,7 @@ msgstr "قائمة التطبيق بها تغييرات لم يتم حفظها."
 msgid "Use verbose logging"
 msgstr "استخدم تسجيل Verbose"
 
-#. TRANSLATORS: program name, an application to add and remove software
-#. repositories
+#. TRANSLATORS: program name, an application to add and remove software repositories
 #: src/gs-editor.c:1119
 msgid "GNOME Software Banner Designer"
 msgstr "مصمم لافتات برنامج GNOME"
@@ -1496,8 +1516,7 @@ msgstr "الملخص"
 msgid "Editor’s Pick"
 msgstr "اختيار المحرر"
 
-#. This check button controls whether the application’s banner appears in the
-#. “Featured” category
+#. This check button controls whether the application’s banner appears in the “Featured” category
 #: src/gs-editor.ui:397
 msgid "Category Featured"
 msgstr "تم تمييز التصنيف"
@@ -1594,9 +1613,10 @@ msgstr "لا تطبيقات متوفرة توفّر الملف %s."
 #: src/gs-extras-page.c:337 src/gs-extras-page.c:348 src/gs-extras-page.c:359
 #, c-format
 msgid ""
-"Information about %s, as well as options for how to get missing applications"
-" might be found %s."
-msgstr "المعلومات عنْ %s وخيارات طريقة الحصول على التطبيقات الناقصة قد تجدها %s."
+"Information about %s, as well as options for how to get missing applications "
+"might be found %s."
+msgstr ""
+"المعلومات عنْ %s وخيارات طريقة الحصول على التطبيقات الناقصة قد تجدها %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1619,7 +1639,9 @@ msgstr "%s غير متوفّر."
 msgid ""
 "Information about %s, as well as options for how to get an application that "
 "can support this format might be found %s."
-msgstr "المعلومات عنْ %s وخيارات طريقة الحصول على التطبيقات التي توفّر هذه الصيغة قد تجدها %s."
+msgstr ""
+"المعلومات عنْ %s وخيارات طريقة الحصول على التطبيقات التي توفّر هذه الصيغة قد "
+"تجدها %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1639,7 +1661,7 @@ msgstr "المعلومات عنْ %s وخيارات طريقة الحصول عل
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
-#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1426
+#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1430
 #, c-format
 msgid "No addon codecs are available for the %s format."
 msgstr "لا إضافات مِرمازات متوفّرة للنُسق %s."
@@ -1651,7 +1673,9 @@ msgstr "لا إضافات مِرمازات متوفّرة للنُسق %s."
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format might be found %s."
-msgstr "المعلومات عنْ %s وخيارات طريقة الحصول على المرماز الذي يمكنه تشغيل هذه الصيغة قد تجدها %s."
+msgstr ""
+"المعلومات عنْ %s وخيارات طريقة الحصول على المرماز الذي يمكنه تشغيل هذه الصيغة "
+"قد تجدها %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1667,7 +1691,8 @@ msgstr "لا موارد بلازما متوفرة لدعم %s."
 msgid ""
 "Information about %s, as well as options for how to get additional Plasma "
 "resources might be found %s."
-msgstr "المعلومات عنْ %s وخيارات طريقة الحصول على موارد بلازما الإضافية قد تجدها %s."
+msgstr ""
+"المعلومات عنْ %s وخيارات طريقة الحصول على موارد بلازما الإضافية قد تجدها %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1683,15 +1708,16 @@ msgstr "لا مشغلات طابعات متوفرة ل‍%s."
 msgid ""
 "Information about %s, as well as options for how to get a driver that "
 "supports this printer might be found %s."
-msgstr "المعلومات عنْ %s وخيارات طريقة الحصول على المشغلات الذي يمكنه تشغيل هذه الطابعة قد تجدها %s."
+msgstr ""
+"المعلومات عنْ %s وخيارات طريقة الحصول على المشغلات الذي يمكنه تشغيل هذه "
+"الطابعة قد تجدها %s."
 
 #. TRANSLATORS: hyperlink title
 #: src/gs-extras-page.c:459
 msgid "this website"
 msgstr "موقع الوِب"
 
-#. TRANSLATORS: no codecs were found. First %s will be replaced by actual
-#. codec name(s), second %s is a link titled "this website"
+#. TRANSLATORS: no codecs were found. First %s will be replaced by actual codec name(s), second %s is a link titled "this website"
 #: src/gs-extras-page.c:463
 #, c-format
 msgid ""
@@ -1700,12 +1726,18 @@ msgid ""
 msgid_plural ""
 "Unfortunately, the %s you were searching for could not be found. Please see "
 "%s for more information."
-msgstr[0] "للأسف، تعذّر إيجاد %s الذي كنت تبحث عنه. من فضلك طالع %s لمعلومات أخرى."
-msgstr[1] "للأسف، تعذّر إيجاد %s الذي كنت تبحث عنه. من فضلك طالع %s لمعلومات أخرى."
-msgstr[2] "للأسف، تعذّر إيجاد %s التين كنت تبحث عنهما. من فضلك طالع %s لمعلومات أخرى."
-msgstr[3] "للأسف، تعذّر إيجاد %s التي كنت تبحث عنها. من فضلك طالع %s لمعلومات أخرى."
-msgstr[4] "للأسف، تعذّر إيجاد %s التي كنت تبحث عنها. من فضلك طالع %s لمعلومات أخرى."
-msgstr[5] "للأسف، تعذّر إيجاد %s التي كنت تبحث عنها. من فضلك طالع %s لمعلومات أخرى."
+msgstr[0] ""
+"للأسف، تعذّر إيجاد %s الذي كنت تبحث عنه. من فضلك طالع %s لمعلومات أخرى."
+msgstr[1] ""
+"للأسف، تعذّر إيجاد %s الذي كنت تبحث عنه. من فضلك طالع %s لمعلومات أخرى."
+msgstr[2] ""
+"للأسف، تعذّر إيجاد %s التين كنت تبحث عنهما. من فضلك طالع %s لمعلومات أخرى."
+msgstr[3] ""
+"للأسف، تعذّر إيجاد %s التي كنت تبحث عنها. من فضلك طالع %s لمعلومات أخرى."
+msgstr[4] ""
+"للأسف، تعذّر إيجاد %s التي كنت تبحث عنها. من فضلك طالع %s لمعلومات أخرى."
+msgstr[5] ""
+"للأسف، تعذّر إيجاد %s التي كنت تبحث عنها. من فضلك طالع %s لمعلومات أخرى."
 
 #: src/gs-extras-page.c:535 src/gs-extras-page.c:591 src/gs-extras-page.c:630
 msgid "Failed to find any search results"
@@ -1730,10 +1762,12 @@ msgstr "مرحبًا في «برمجيّات»"
 
 #: src/gs-first-run-dialog.ui:66
 msgid ""
-"Software lets you install all the software you need, all from one place. See"
-" our recommendations, browse the categories, or search for the applications "
+"Software lets you install all the software you need, all from one place. See "
+"our recommendations, browse the categories, or search for the applications "
 "you want."
-msgstr "يتيح لك «برمجيّات» تثبيت كلّ البرمجيّات التي تحتاج، ومِن مكان واحد. طالع تزكياتنا، تصفّح الفئات أو ابحث عن التّطبيقات التي تريد."
+msgstr ""
+"يتيح لك «برمجيّات» تثبيت كلّ البرمجيّات التي تحتاج، ومِن مكان واحد. طالع "
+"تزكياتنا، تصفّح الفئات أو ابحث عن التّطبيقات التي تريد."
 
 #: src/gs-first-run-dialog.ui:85
 msgid "_Let’s Go Shopping"
@@ -1887,8 +1921,7 @@ msgstr "يتيح الوصول لبرمجياتت إضافية، بما فيها 
 
 #. TRANSLATORS: this is the proprietary info bar
 #: src/gs-overview-page.c:978
-msgid ""
-"Proprietary software has restrictions on use and access to source code."
+msgid "Proprietary software has restrictions on use and access to source code."
 msgstr "تضع البرمجيات المحتكرة قيودًا على استخدام الكود المصدري و الوصول إليه."
 
 #. TRANSLATORS: this is the clickable
@@ -1918,14 +1951,12 @@ msgstr "التطبيق المتميز"
 msgid "Categories"
 msgstr "الفئات"
 
-#. Translators: This is a heading for software which has been featured
-#. ('picked') by the distribution.
+#. Translators: This is a heading for software which has been featured ('picked') by the distribution.
 #: src/gs-overview-page.ui:315
 msgid "Editor’s Picks"
 msgstr "مختارات المحرر"
 
-#. Translators: This is a heading for software which has been recently
-#. released upstream.
+#. Translators: This is a heading for software which has been recently released upstream.
 #: src/gs-overview-page.ui:359
 msgid "Recent Releases"
 msgstr "الإصدارات الأخيرة"
@@ -1972,7 +2003,8 @@ msgstr "أتريد حقا إزالة المصدر %s؟"
 msgid ""
 "All applications from %s will be removed, and you will have to re-install "
 "the source to use them again."
-msgstr "ستُزال كل التطبيقات من %s، وسيكون عليك إعادة تثبيت المصدر لاستعمالها ثانية."
+msgstr ""
+"ستُزال كل التطبيقات من %s، وسيكون عليك إعادة تثبيت المصدر لاستعمالها ثانية."
 
 #. TRANSLATORS: this is a prompt message, and '%s' is an
 #. * application summary, e.g. 'GNOME Clocks'
@@ -1987,12 +2019,14 @@ msgstr "أتريد حقًّا إزالة %s؟"
 msgid "%s will be removed, and you will have to install it to use it again."
 msgstr "%s سيُزال، وعليك تثبيته مرّة أخرى إن أردت استخدامه لاحقًا."
 
-#: lib/gs-plugin-loader.c:1429
+#: lib/gs-plugin-loader.c:1433
 #, c-format
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format can be found on the website."
-msgstr "المعلومات عنْ %s وخيارات طريقة الحصول على المِرماز الذي يمكنه تشغيل هذا النُسق موجودة في موقع الوِب."
+msgstr ""
+"المعلومات عنْ %s وخيارات طريقة الحصول على المِرماز الذي يمكنه تشغيل هذا النُسق "
+"موجودة في موقع الوِب."
 
 #: lib/gs-price.c:111
 #, c-format
@@ -2051,7 +2085,9 @@ msgstr "%s %f"
 msgid ""
 "Some of the currently installed software is not compatible with %s. If you "
 "continue, the following will be automatically removed during the upgrade:"
-msgstr "بعض البرمجيات المثبتة حاليا غير متوافقة مع %s. إن تابعت فسيُزال الآتي تلقائيا أثناء الترقية:"
+msgstr ""
+"بعض البرمجيات المثبتة حاليا غير متوافقة مع %s. إن تابعت فسيُزال الآتي تلقائيا "
+"أثناء الترقية:"
 
 #: src/gs-removal-dialog.ui:27
 msgid "Incompatible Software"
@@ -2121,8 +2157,7 @@ msgstr "الوصف قصير جدا"
 msgid "The description is too long"
 msgstr "الوصف طويل جدا"
 
-#. Translators: Title of the dialog box where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Title of the dialog box where the users can write and publish their opinions about the apps.
 #: src/gs-review-dialog.ui:11
 msgid "Post Review"
 msgstr "نشر مراجعة"
@@ -2182,8 +2217,7 @@ msgstr "أأبلغ عن المراجعة؟"
 msgid "Report"
 msgstr "أبلغ"
 
-#. Translators: Users can express their opinions about other users' opinions
-#. about the apps.
+#. Translators: Users can express their opinions about other users' opinions about the apps.
 #: src/gs-review-row.ui:112
 msgid "Was this review useful to you?"
 msgstr "أكانت هذه المراجعة مفيدة؟"
@@ -2276,81 +2310,81 @@ msgstr "لم يُعثر على التّطبيق"
 #. TRANSLATORS: this is part of the in-app notification,
 #. * where the %s is a multi-word localised app name
 #. * e.g. 'Getting things GNOME!"
-#: src/gs-shell.c:846 src/gs-shell.c:851 src/gs-shell.c:866 src/gs-shell.c:870
+#: src/gs-shell.c:847 src/gs-shell.c:852 src/gs-shell.c:867 src/gs-shell.c:871
 #, c-format
 msgid "“%s”"
 msgstr "“%s”"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:898
+#: src/gs-shell.c:899
 #, c-format
 msgid "Unable to download firmware updates from %s"
 msgstr "لا يمكن تحميل تحديثات البرمجيات المخزونة (firmware) من %s  "
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:904
+#: src/gs-shell.c:905
 #, c-format
 msgid "Unable to download updates from %s"
 msgstr "غير قادر على تنزيل تحديثات من %s"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:911
+#: src/gs-shell.c:912
 msgid "Unable to download updates"
 msgstr "غير قادر على تنزيل التحديثات"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:916
+#: src/gs-shell.c:917
 msgid ""
-"Unable to download updates: internet access was required but wasn’t "
-"available"
-msgstr "غير قادر على تنزيل التحديثات: كان الاتصال بالإنترنت مطلوباً ولم يكن متاحاً"
+"Unable to download updates: internet access was required but wasn’t available"
+msgstr ""
+"غير قادر على تنزيل التحديثات: كان الاتصال بالإنترنت مطلوباً ولم يكن متاحاً"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:925
+#: src/gs-shell.c:926
 #, c-format
 msgid "Unable to download updates from %s: not enough disk space"
 msgstr "غير قادر على تنزيل التحديثات من %s: لا توجد مساحة كافية على القرص"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:930
+#: src/gs-shell.c:931
 msgid "Unable to download updates: not enough disk space"
 msgstr "غير قادر على تنزيل التحديثات: لا توجد مساحة كافية على القرص"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:938
+#: src/gs-shell.c:939
 msgid "Unable to download updates: authentication was required"
 msgstr "غير قادر على تنزيل التحديثات: كان من المطلوب إجراء مصادقة"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:943
+#: src/gs-shell.c:944
 msgid "Unable to download updates: authentication was invalid"
 msgstr "غير قادر على تنزيل التحديثات: كان من المطلوب إجراء مصادقة"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:948
+#: src/gs-shell.c:949
 msgid ""
 "Unable to download updates: you do not have permission to install software"
 msgstr "غير قادر على تنزيل التحديثات: ليس لديك إذن بتثبيت البرامج"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:955
+#: src/gs-shell.c:956
 msgid "Unable to get list of updates"
 msgstr "غير قادر على الحصول على قائمة بالتحديثات"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the application name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1001
+#: src/gs-shell.c:1002
 #, c-format
 msgid "Unable to install %s as download failed from %s"
 msgstr "غير قادر على تثبيت %s لفشل عملية التنزيل من %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1007
+#: src/gs-shell.c:1008
 #, c-format
 msgid "Unable to install %s as download failed"
 msgstr "غير قادر على تثبيت %s لأن عملية التنزيل فشلت"
@@ -2359,51 +2393,51 @@ msgstr "غير قادر على تثبيت %s لأن عملية التنزيل ف
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1019
+#: src/gs-shell.c:1020
 #, c-format
 msgid "Unable to install %s as runtime %s not available"
 msgstr "غير قادر على تثبيت %s حيث أن %s وقت التشغيل غير متاح"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1025
+#: src/gs-shell.c:1026
 #, c-format
 msgid "Unable to install %s as not supported"
 msgstr "غير قادر على تثبيت %s لأنه غير مدعوم"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1032
+#: src/gs-shell.c:1033
 msgid "Unable to install: internet access was required but wasn’t available"
 msgstr "غير قادر على التثبيت: كان الاتصال بالإنترنت مطلوباً ولم يكن متاحاً"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1038
+#: src/gs-shell.c:1039
 msgid "Unable to install: the application has an invalid format"
 msgstr "غير قادر على التثبيت: يحتوي التطبيق على تنسيق غير صالح"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1043
+#: src/gs-shell.c:1044
 #, c-format
 msgid "Unable to install %s: not enough disk space"
 msgstr "غير قادر على تثبيت %s: لا توجد مساحة كافية على القرص"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1051
+#: src/gs-shell.c:1052
 #, c-format
 msgid "Unable to install %s: authentication was required"
 msgstr "غير قادر على تثبيت %s: كان من المطلوب إجراء مصادقة"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1058
+#: src/gs-shell.c:1059
 #, c-format
 msgid "Unable to install %s: authentication was invalid"
 msgstr "غير قادر على تثبيت %s: لم تكن المصادقة صالحة"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1065
+#: src/gs-shell.c:1066
 #, c-format
 msgid "Unable to install %s: you do not have permission to install software"
 msgstr "غير قادر على تثبيت %s: ليس لديك إذن بتثبيت البرامج"
@@ -2411,34 +2445,34 @@ msgstr "غير قادر على تثبيت %s: ليس لديك إذن بتثبي�
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the name of the authentication service,
 #. * e.g. "Ubuntu One"
-#: src/gs-shell.c:1078
+#: src/gs-shell.c:1079
 #, c-format
 msgid "Your %s account has been suspended."
 msgstr "تم تعليق حساب %s الخاص بك."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1082
+#: src/gs-shell.c:1083
 msgid "It is not possible to install software until this has been resolved."
 msgstr "ليس من الممكن تثبيت برامج حتى يتم حل هذه المشكلة."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the clickable link (e.g.
 #. * "http://example.com/what-did-i-do-wrong/")
-#: src/gs-shell.c:1093
+#: src/gs-shell.c:1094
 #, c-format
 msgid "For more information, visit %s."
 msgstr "للحصول على مزيدٍ من المعلومات، قم بزيارة %s. "
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1102
+#: src/gs-shell.c:1103
 #, c-format
 msgid "Unable to install %s: AC power is required"
 msgstr "تعذّر تثبيت %s: مطلوب طاقة التيار المتردد"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1111
+#: src/gs-shell.c:1112
 #, c-format
 msgid "Unable to install %s"
 msgstr "غير قادر على تثبيت %s"
@@ -2447,61 +2481,62 @@ msgstr "غير قادر على تثبيت %s"
 #. * where the first %s is the app name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1157
+#: src/gs-shell.c:1158
 #, c-format
 msgid "Unable to update %s from %s"
 msgstr "غير قادر على تحديث %s من %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1163
+#: src/gs-shell.c:1164
 #, c-format
 msgid "Unable to update %s as download failed"
 msgstr "غير قادر على تحديث %s لفشل عملية التنزيل"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1169
+#: src/gs-shell.c:1170
 msgid "Unable to update: internet access was required but wasn’t available"
-msgstr "غير قادر على عمل تحديث: كان الاتصال بالإنترنت مطلوباً ولكنه لم يكن متاحاً"
+msgstr ""
+"غير قادر على عمل تحديث: كان الاتصال بالإنترنت مطلوباً ولكنه لم يكن متاحاً"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1177
+#: src/gs-shell.c:1178
 #, c-format
 msgid "Unable to update %s: not enough disk space"
 msgstr "غير قادر على تحديث %s: لا توجد مساحة كافية على القرص"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1186
+#: src/gs-shell.c:1187
 #, c-format
 msgid "Unable to update %s: authentication was required"
 msgstr "غير قادر على تحديث %s: كان من المطلوب إجراء مصادقة"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1193
+#: src/gs-shell.c:1194
 #, c-format
 msgid "Unable to update %s: authentication was invalid"
 msgstr "غير قادر على تحديث %s: لم تكن المصادقة صالحة"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1200
+#: src/gs-shell.c:1201
 #, c-format
 msgid "Unable to update %s: you do not have permission to update software"
 msgstr "غير قادر على تحديث %s: ليس لديك إذن بتحديث البرامج"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1208
+#: src/gs-shell.c:1209
 #, c-format
 msgid "Unable to update %s: AC power is required"
 msgstr "تعذَّر تحديث %s: التيار المتردد مطلوب"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1217
+#: src/gs-shell.c:1218
 #, c-format
 msgid "Unable to update %s"
 msgstr "غير قادر على تحديث %s"
@@ -2509,96 +2544,96 @@ msgstr "غير قادر على تحديث %s"
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the distro name (e.g. "Fedora 25") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1262
+#: src/gs-shell.c:1263
 #, c-format
 msgid "Unable to upgrade to %s from %s"
 msgstr "غير قادر على الترقية إلى %s من %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the app name (e.g. "GIMP")
-#: src/gs-shell.c:1267
+#: src/gs-shell.c:1268
 #, c-format
 msgid "Unable to upgrade to %s as download failed"
 msgstr "غير قادر على الترقية إلى %s بسبب فشل عملية التنزيل"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1274
+#: src/gs-shell.c:1275
 msgid "Unable to upgrade: internet access was required but wasn’t available"
 msgstr "غير قادر على عمل ترقية: كان الاتصال بالإنترنت مطلوباً ولم يكن متاحاً"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1282
+#: src/gs-shell.c:1283
 #, c-format
 msgid "Unable to upgrade to %s: not enough disk space"
 msgstr "غير قادر على الترقية لـ %s: لا توجد مساحة كافية على القرص"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1291
+#: src/gs-shell.c:1292
 #, c-format
 msgid "Unable to upgrade to %s: authentication was required"
 msgstr "غير قادر على الترقية لـ %s: كان من المطلوب إجراء مصادقة"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1298
+#: src/gs-shell.c:1299
 #, c-format
 msgid "Unable to upgrade to %s: authentication was invalid"
 msgstr "غير قادر على الترقية لـ %s: لم تكن المصادقة صالحة"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1305
+#: src/gs-shell.c:1306
 #, c-format
 msgid "Unable to upgrade to %s: you do not have permission to upgrade"
 msgstr "غير قادر على الترقية إلى %s: ليس لديك إذن بعمل ترقية"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1312
+#: src/gs-shell.c:1313
 #, c-format
 msgid "Unable to upgrade to %s: AC power is required"
 msgstr "تعذّرت الترقية إلى %s: مطلوب طاقة التيار المتردد"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1321
+#: src/gs-shell.c:1322
 #, c-format
 msgid "Unable to upgrade to %s"
 msgstr "غير قادر على الترقية لـ %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1363
+#: src/gs-shell.c:1364
 #, c-format
 msgid "Unable to remove %s: authentication was required"
 msgstr "غير قادر على إزالة %s: كان من المطلوب إجراء مصادقة"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1369
+#: src/gs-shell.c:1370
 #, c-format
 msgid "Unable to remove %s: authentication was invalid"
 msgstr "غير قادر على إزالة %s: لم تكن المصادقة صالحة"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1375
+#: src/gs-shell.c:1376
 #, c-format
 msgid "Unable to remove %s: you do not have permission to remove software"
 msgstr "غير قادر على إزالة %s: ليس لديك إذن بإزالة البرامج"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1382
+#: src/gs-shell.c:1383
 #, c-format
 msgid "Unable to remove %s: AC power is required"
 msgstr "غير قادر على إزالة %s: مطلوب مصدر طاقة ذو تيار متردد"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1391
+#: src/gs-shell.c:1392
 #, c-format
 msgid "Unable to remove %s"
 msgstr "غير قادر على إزالة %s"
@@ -2607,48 +2642,48 @@ msgstr "غير قادر على إزالة %s"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1437
+#: src/gs-shell.c:1438
 #, c-format
 msgid "Unable to launch %s: %s is not installed"
 msgstr "لا يمكن تشغيل %s. %s غير مثبت."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1444 src/gs-shell.c:1492 src/gs-shell.c:1540
+#: src/gs-shell.c:1445 src/gs-shell.c:1493 src/gs-shell.c:1541
 msgid "Not enough disk space — free up some space and try again"
 msgstr "لا توجد مساحة كافية على القرص — قم بإفراغ بعض المساحة وجدد المحاولة"
 
 #. TRANSLATORS: we failed to get a proper error code
-#: src/gs-shell.c:1452 src/gs-shell.c:1500 src/gs-shell.c:1567
+#: src/gs-shell.c:1453 src/gs-shell.c:1501 src/gs-shell.c:1568
 msgid "Sorry, something went wrong"
 msgstr "عُذرًا، فهناك خطأ ما قد حدث"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1487
+#: src/gs-shell.c:1488
 msgid "Failed to install file: authentication failed"
 msgstr "فشلت عملية تثبيت الملف: فشلت عملية المصادقة"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1534
+#: src/gs-shell.c:1535
 #, c-format
 msgid "Unable to contact %s"
 msgstr "غير قادر على الاتصال بـ %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1549
+#: src/gs-shell.c:1550
 #, c-format
 msgid "%s needs to be restarted to use new plugins."
 msgstr "يحتاج %s لإعادة التشغيل ليتمكن من استخدام الإضافات الجديدة."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1554
+#: src/gs-shell.c:1555
 msgid "This application needs to be restarted to use new plugins."
 msgstr "يحتاج هذا التطبيق إعادة تشغيل، ليتمكن من استخدام الإضافات الجديدة."
 
 #. TRANSLATORS: need to be connected to the AC power
-#: src/gs-shell.c:1561
+#: src/gs-shell.c:1562
 msgid "AC power is required"
 msgstr "مطلوب طاقة التيار المتردد"
 
@@ -2755,7 +2790,9 @@ msgstr "نظام التشغيل"
 msgid ""
 "Software sources can be downloaded from the internet. They give you access "
 "to additional software that is not provided by %s."
-msgstr "يمكن تنزيل مصادر البرمجيات من الإنترنت، فتُعطيك وصولًا إلى برمجيّات أخرى لا توفّرها %s."
+msgstr ""
+"يمكن تنزيل مصادر البرمجيات من الإنترنت، فتُعطيك وصولًا إلى برمجيّات أخرى لا "
+"توفّرها %s."
 
 #: src/gs-sources-dialog.ui:155
 msgid "Additional Sources"
@@ -2970,16 +3007,20 @@ msgstr "أُلغِيَ التّحديث."
 #. * something with no network available
 #: src/gs-update-monitor.c:714
 msgid ""
-"Internet access was required but wasn’t available. Please make sure that you"
-" have internet access and try again."
-msgstr "الوصول إلى الإنترنت كان مطلوبا ولكنه لم يكن متاحا. من فضلك تأكد من اتصال الحاسوب بالإنترنت وحاول مجددا."
+"Internet access was required but wasn’t available. Please make sure that you "
+"have internet access and try again."
+msgstr ""
+"الوصول إلى الإنترنت كان مطلوبا ولكنه لم يكن متاحا. من فضلك تأكد من اتصال "
+"الحاسوب بالإنترنت وحاول مجددا."
 
 #. TRANSLATORS: if the package is not signed correctly
 #: src/gs-update-monitor.c:720
 msgid ""
 "There were security issues with the update. Please consult your software "
 "provider for more details."
-msgstr "هناك مشاكل أمنية في هذا التحديث. من فضلك راجع موفّر البرمجية للمزيد من التفاصيل."
+msgstr ""
+"هناك مشاكل أمنية في هذا التحديث. من فضلك راجع موفّر البرمجية للمزيد من "
+"التفاصيل."
 
 #. TRANSLATORS: we ran out of disk space
 #: src/gs-update-monitor.c:726
@@ -2992,7 +3033,9 @@ msgstr "لم تبق مساحة حرة في القرص. من فضلك أفرغ ب
 msgid ""
 "We’re sorry: the update failed to install. Please wait for another update "
 "and try again. If the problem persists, contact your software provider."
-msgstr "آسفون، تعذّر تثبيت التحديث. من فضلك انتظر تحديثا آخر وحاول مجددا. إن استمرت المشكلة راسل موفّر البرمجية."
+msgstr ""
+"آسفون، تعذّر تثبيت التحديث. من فضلك انتظر تحديثا آخر وحاول مجددا. إن استمرت "
+"المشكلة راسل موفّر البرمجية."
 
 #. TRANSLATORS: Time in 24h format
 #: src/gs-updates-page.c:297
@@ -3276,22 +3319,27 @@ msgid "App Center"
 msgstr "متجر التطبيقات"
 
 #: src/org.gnome.Software.desktop.in:4
+msgid "More Apps"
+msgstr "المزيد من التطبيقات"
+
+#: src/org.gnome.Software.desktop.in:5
 msgid "Add, remove or update software on this computer"
 msgstr "أضف، أزل أو حدّث البرمجيّات على هذا الحاسوب"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
-#: src/org.gnome.Software.desktop.in:6
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: src/org.gnome.Software.desktop.in:7
 #: src/org.gnome.Software.Editor.desktop.in:6
 msgid "org.gnome.Software"
 msgstr "org.gnome.Software"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
-#: src/org.gnome.Software.desktop.in:12
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: src/org.gnome.Software.desktop.in:13
 msgid ""
-"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;"
-msgstr "تحديثات;ترقيات;مصادر;مستودعات;تفضيلات;تثبيت;إزالة;برنامج;برمجية;تطبيق;سوق;تحديث;ترقية;مصدر;مستودع;"
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;"
+msgstr ""
+"تحديثات;ترقيات;مصادر;مستودعات;تفضيلات;تثبيت;إزالة;برنامج;برمجية;تطبيق;سوق;"
+"تحديث;ترقية;مصدر;مستودع;"
 
 #: src/org.gnome.Software.Editor.desktop.in:3
 msgid "Banner Designer"
@@ -3301,8 +3349,7 @@ msgstr "مصمم اللافتات"
 msgid "Design the featured banners for GNOME Software"
 msgstr "تصميم اللافتات المميزة لبرنامج GNOME"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: src/org.gnome.Software.Editor.desktop.in:13
 msgid "AppStream;Software;App;"
 msgstr "AppStream; برنامج; تطبيق"
@@ -3572,100 +3619,111 @@ msgctxt "Menu of Communication & News"
 msgid "Web Browsers"
 msgstr "برامج تصفح الإنترنت"
 
-#: plugins/core/gs-desktop-common.c:247
-msgctxt "Menu of Reference"
-msgid "All"
-msgstr "الكلّ"
-
-#: plugins/core/gs-desktop-common.c:250
-msgctxt "Menu of Reference"
-msgid "Featured"
-msgstr "مُختارة"
-
-#: plugins/core/gs-desktop-common.c:253
-msgctxt "Menu of Reference"
-msgid "Art"
-msgstr "الفنّ"
-
-#: plugins/core/gs-desktop-common.c:256
-msgctxt "Menu of Reference"
-msgid "Biography"
-msgstr "السير الذاتية"
-
-#: plugins/core/gs-desktop-common.c:259
-msgctxt "Menu of Reference"
-msgid "Comics"
-msgstr "القصص المصوّرة"
-
-#: plugins/core/gs-desktop-common.c:262
-msgctxt "Menu of Reference"
-msgid "Fiction"
-msgstr "الخيال"
-
-#: plugins/core/gs-desktop-common.c:265
-msgctxt "Menu of Reference"
-msgid "Health"
-msgstr "الصحة"
-
-#: plugins/core/gs-desktop-common.c:268
-msgctxt "Menu of Reference"
-msgid "History"
-msgstr "التاريخ"
-
-#: plugins/core/gs-desktop-common.c:271
-msgctxt "Menu of Reference"
-msgid "Lifestyle"
-msgstr "نمط الحياة"
-
-#: plugins/core/gs-desktop-common.c:274
+#: plugins/core/gs-desktop-common.c:242
 msgctxt "Menu of Communication & News"
 msgid "News"
 msgstr "الأخبار"
 
+#: plugins/core/gs-desktop-common.c:251
+msgctxt "Menu of Reference"
+msgid "All"
+msgstr "الكلّ"
+
+#: plugins/core/gs-desktop-common.c:254
+msgctxt "Menu of Reference"
+msgid "Featured"
+msgstr "مُختارة"
+
+#: plugins/core/gs-desktop-common.c:257
+msgctxt "Menu of Reference"
+msgid "Art"
+msgstr "الفنّ"
+
+#: plugins/core/gs-desktop-common.c:260
+msgctxt "Menu of Reference"
+msgid "Biography"
+msgstr "السير الذاتية"
+
+#: plugins/core/gs-desktop-common.c:263
+msgctxt "Menu of Reference"
+msgid "Comics"
+msgstr "القصص المصوّرة"
+
+#: plugins/core/gs-desktop-common.c:266
+msgctxt "Menu of Reference"
+msgid "Feed"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:269
+msgctxt "Menu of Reference"
+msgid "Fiction"
+msgstr "الخيال"
+
+#: plugins/core/gs-desktop-common.c:272
+msgctxt "Menu of Reference"
+msgid "Health"
+msgstr "الصحة"
+
+#: plugins/core/gs-desktop-common.c:275
+msgctxt "Menu of Reference"
+msgid "History"
+msgstr "التاريخ"
+
 #: plugins/core/gs-desktop-common.c:278
+msgctxt "Menu of Reference"
+msgid "Lifestyle"
+msgstr "نمط الحياة"
+
+#: plugins/core/gs-desktop-common.c:281
+#, fuzzy
+msgctxt "Menu of Reference"
+msgid "News"
+msgstr "الأخبار"
+
+#: plugins/core/gs-desktop-common.c:284
 msgctxt "Menu of Reference"
 msgid "Politics"
 msgstr "السياسة"
 
-#: plugins/core/gs-desktop-common.c:281
+#: plugins/core/gs-desktop-common.c:287
 msgctxt "Menu of Reference"
 msgid "Sports"
 msgstr "الرّياضة"
 
 #. TRANSLATORS: this is the menu spec main category for Learning
-#: plugins/core/gs-desktop-common.c:291
+#: plugins/core/gs-desktop-common.c:297
 msgid "Learning"
 msgstr "التعلم"
 
 #. TRANSLATORS: this is the menu spec main category for Game
-#: plugins/core/gs-desktop-common.c:294
+#: plugins/core/gs-desktop-common.c:300
 msgid "Games"
 msgstr "الألعاب"
 
 #. TRANSLATORS: this is the menu spec main category for Multimedia
-#: plugins/core/gs-desktop-common.c:297
+#: plugins/core/gs-desktop-common.c:303
 msgid "Multimedia"
 msgstr "الوسائط المتعددة"
 
 #. TRANSLATORS: this is the menu spec main category for Work
-#: plugins/core/gs-desktop-common.c:300
+#: plugins/core/gs-desktop-common.c:306
 msgid "Work"
 msgstr "العمل"
 
 #. TRANSLATORS: this is the menu spec main category for Reference
-#: plugins/core/gs-desktop-common.c:303
+#: plugins/core/gs-desktop-common.c:309
 msgid "Reference & News"
 msgstr "المراجع والأخبار"
 
 #. TRANSLATORS: this is the menu spec main category for Utilities
-#: plugins/core/gs-desktop-common.c:306
+#: plugins/core/gs-desktop-common.c:312
 msgid "Utilities"
 msgstr "الأدوات"
 
 #. TRANSLATORS: this is the menu spec main category for Dev Tools; it
 #. * should be a relatively short label; as an example, in Portuguese and
 #. * Spanish the direct translation of "Programming" (noun) is used
-#: plugins/core/gs-desktop-common.c:311
+#: plugins/core/gs-desktop-common.c:317
 msgid "Dev Tools"
 msgstr "أدوات التّطوير"
 
@@ -3691,16 +3749,16 @@ msgstr "يتضمّن تحسينات الأداء، والثّبات والأمن
 msgid "Downloading featured images…"
 msgstr "تنزيل الصور المميزة..."
 
-#: plugins/eos/gs-plugin-eos.c:1249
+#: plugins/eos/gs-plugin-eos.c:1233
 #, c-format
 msgid "Could not launch this application."
 msgstr "لا يمكن بدء هذا التطبيق."
 
-#: plugins/eos/gs-plugin-eos.c:1305
+#: plugins/eos/gs-plugin-eos.c:1289
 msgid "Endless Platform"
 msgstr "منصة Endless"
 
-#: plugins/eos/gs-plugin-eos.c:1308
+#: plugins/eos/gs-plugin-eos.c:1292
 msgid "Framework for applications"
 msgstr "إطار العمل للتطبيقات"
 
@@ -3760,13 +3818,13 @@ msgid "Flatpak is a framework for desktop applications on Linux"
 msgstr "إن Flatpak هو إطار عمل لتطبيقات سطح المكتب يعمل على نظام التشغيل لينكس"
 
 #. TRANSLATORS: status text when downloading new metadata
-#: plugins/flatpak/gs-flatpak.c:821
+#: plugins/flatpak/gs-flatpak.c:815
 #, c-format
 msgid "Getting flatpak metadata for %s…"
 msgstr "الحصول على بيانات تعريف flatpak لـ %s..."
 
 #. TRANSLATORS: status text when downloading the RuntimeRepo
-#: plugins/flatpak/gs-flatpak.c:2796
+#: plugins/flatpak/gs-flatpak.c:2803
 msgid "Getting runtime source…"
 msgstr "الحصول على مصدر وقت التشغيل..."
 

--- a/po/bn.po
+++ b/po/bn.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the gnome-software package.
-# 
+#
 # Translators:
 # Aditi Kabir <aditi.kabir@gmail.com>, 2016
 # Roddy Shuler <roddy@endlessm.com>, 2016
@@ -10,14 +10,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-software\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-12 22:31-0700\n"
+"POT-Creation-Date: 2017-11-02 16:28+0100\n"
 "PO-Revision-Date: 2017-10-13 05:50+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
-"Language-Team: Bengali (http://www.transifex.com/endless-mobile-inc/gnome-software/language/bn/)\n"
+"Language-Team: Bengali (http://www.transifex.com/endless-mobile-inc/gnome-"
+"software/language/bn/)\n"
+"Language: bn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: bn\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:7
@@ -32,7 +33,9 @@ msgstr "GNOME এর জন্য এ্যাপ্লিকেশন ম্য
 msgid ""
 "Software allows you to find and install new applications and system "
 "extensions and remove existing installed applications."
-msgstr "সফটওয়্যারের মাধ্যমে আপনি নতুন এ্যাপ্লিকেশন ও সিস্টেম সংযোজন খোঁজ ও সংস্থাপন করতে পারেন এবং বিদ্যমান সংস্থাপিত এ্যাপ্লিকেশন মুছে ফেলতে পারবেন।"
+msgstr ""
+"সফটওয়্যারের মাধ্যমে আপনি নতুন এ্যাপ্লিকেশন ও সিস্টেম সংযোজন খোঁজ ও সংস্থাপন করতে "
+"পারেন এবং বিদ্যমান সংস্থাপিত এ্যাপ্লিকেশন মুছে ফেলতে পারবেন।"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:14
 msgid ""
@@ -40,7 +43,11 @@ msgid ""
 "descriptions and multiple screenshots per application. Applications can be "
 "found either through browsing the list of categories or by searching. It "
 "also allows you to update your system using an offline update."
-msgstr "GNOME সফটওয়্যারে দরকারী বর্ণনাসহ এবং প্রতি এ্যাপ্লিকেশন অনুসারে একের অধিক স্ক্রিনশটসহ  বৈশিষ্ট্যসম্পন্ন ও জনপ্রিয় এ্যাপ্লিকেশন প্রদর্শিত হয়। বিভাগের তালিকা অনুসারে অথবা অনুসন্ধান করে এ্যাপ্লিকেশন খুঁজে বের করা যাবে। একটি অফলাইন আপডেট ব্যবহার করে আপনার সিস্টেম আপডেট অনুমোদিত করা হয়।"
+msgstr ""
+"GNOME সফটওয়্যারে দরকারী বর্ণনাসহ এবং প্রতি এ্যাপ্লিকেশন অনুসারে একের অধিক "
+"স্ক্রিনশটসহ  বৈশিষ্ট্যসম্পন্ন ও জনপ্রিয় এ্যাপ্লিকেশন প্রদর্শিত হয়। বিভাগের তালিকা "
+"অনুসারে অথবা অনুসন্ধান করে এ্যাপ্লিকেশন খুঁজে বের করা যাবে। একটি অফলাইন আপডেট "
+"ব্যবহার করে আপনার সিস্টেম আপডেট অনুমোদিত করা হয়।"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:25
 msgid "Overview panel"
@@ -74,7 +81,9 @@ msgstr "উপযুক্ত প্রজেক্টসমূহের এক�
 msgid ""
 "This is a list of compatible projects we should show such as GNOME, KDE and "
 "XFCE."
-msgstr "এটি উপযুক্ত প্রজেক্টসমূহের একটি তালিকা যা আমাদের প্রদর্শন করতে হবে যেমন GNOME, KDE এবং XFCE ।"
+msgstr ""
+"এটি উপযুক্ত প্রজেক্টসমূহের একটি তালিকা যা আমাদের প্রদর্শন করতে হবে যেমন GNOME, KDE "
+"এবং XFCE ।"
 
 #: data/org.gnome.software.gschema.xml:10
 msgid "Whether to manage updates in GNOME Software"
@@ -84,7 +93,9 @@ msgstr "GNOME সফটওয়্যারের হালনাগাদগু�
 msgid ""
 "If disabled, GNOME Software will hide the updates panel and not perform any "
 "automatic updates actions."
-msgstr "নিষ্ক্রিয় করা হলে, GNOME সফটওয়্যার এর হালনাগাদ সূচী লুকিয়ে রাখবে এবং স্বয়ংক্রিয়ভাবে হালনাগাদ করার কোন পদক্ষেপ নেবে না।"
+msgstr ""
+"নিষ্ক্রিয় করা হলে, GNOME সফটওয়্যার এর হালনাগাদ সূচী লুকিয়ে রাখবে এবং স্বয়ংক্রিয়ভাবে "
+"হালনাগাদ করার কোন পদক্ষেপ নেবে না।"
 
 #: data/org.gnome.software.gschema.xml:15
 msgid "Whether to automatically download updates"
@@ -92,9 +103,11 @@ msgstr "আপডেটসমূহ স্বয়ংক্রিয়ভাবে �
 
 #: data/org.gnome.software.gschema.xml:16
 msgid ""
-"If enabled, GNOME Software automatically downloads updates in the background"
-" and prompts the user to install them when ready."
-msgstr "যদি সক্রিয় করা হয়, GNOME সফটওয়্যার পটভূমিতে স্বয়ংক্রিয়ভাবে আপডেটসমূহ ডাউনলোড করে ফেলে এবং প্রস্তুত হয়ে গেলে ব্যবহারকারীকে সংস্থাপন করার জন্য জানান দেয়।"
+"If enabled, GNOME Software automatically downloads updates in the background "
+"and prompts the user to install them when ready."
+msgstr ""
+"যদি সক্রিয় করা হয়, GNOME সফটওয়্যার পটভূমিতে স্বয়ংক্রিয়ভাবে আপডেটসমূহ ডাউনলোড করে "
+"ফেলে এবং প্রস্তুত হয়ে গেলে ব্যবহারকারীকে সংস্থাপন করার জন্য জানান দেয়।"
 
 #: data/org.gnome.software.gschema.xml:20
 msgid "Whether to automatically refresh when on a metered connection"
@@ -105,7 +118,10 @@ msgid ""
 "If enabled, GNOME Software automatically refreshes in the background even "
 "when using a metered connection (eventually downloading some metadata, "
 "checking for updates, etc., which may incur in costs for the user)."
-msgstr "যদি সক্রিয় করা থাকে, নোম সফটওয়্যার পেছনে স্বয়ংক্রিয়ভাবে রিফ্রেশ হবে এমনকি মিটারকৃত সংযোগ ব্যবহারকালেও (অবশেষে কিছু মেটাডাটা ডাউনলোড করে, হালনাগাদ করণ দেখে ইত্যাদি, যা ব্যবহারকারীকেই খরচ বহন করতে হবে)।  "
+msgstr ""
+"যদি সক্রিয় করা থাকে, নোম সফটওয়্যার পেছনে স্বয়ংক্রিয়ভাবে রিফ্রেশ হবে এমনকি মিটারকৃত "
+"সংযোগ ব্যবহারকালেও (অবশেষে কিছু মেটাডাটা ডাউনলোড করে, হালনাগাদ করণ দেখে "
+"ইত্যাদি, যা ব্যবহারকারীকেই খরচ বহন করতে হবে)।  "
 
 #: data/org.gnome.software.gschema.xml:25
 msgid "Whether it’s the very first run of GNOME Software"
@@ -125,9 +141,11 @@ msgstr "সংস্থাপনের আগে নন-ফ্রি এ্য�
 
 #: data/org.gnome.software.gschema.xml:38
 msgid ""
-"When non-free applications are installed a warning dialog can be shown. This"
-" controls if that dialog is suppressed."
-msgstr "যখন নন-ফ্রি এ্যাপ্লিকেশনসমূহ সংস্থাপন করা হয় তখন একটি সতর্কতামূলক বাণী দেখানো যায়। সেই বাণীটি দেখানো হবে কি হবে না এটি তা নিয়ন্ত্রণ করে।"
+"When non-free applications are installed a warning dialog can be shown. This "
+"controls if that dialog is suppressed."
+msgstr ""
+"যখন নন-ফ্রি এ্যাপ্লিকেশনসমূহ সংস্থাপন করা হয় তখন একটি সতর্কতামূলক বাণী দেখানো যায়। "
+"সেই বাণীটি দেখানো হবে কি হবে না এটি তা নিয়ন্ত্রণ করে।"
 
 #: data/org.gnome.software.gschema.xml:42
 msgid "A list of popular applications"
@@ -135,7 +153,8 @@ msgstr "জনপ্রিয় এ্যাপ্লিকেশনসমূহ�
 
 #: data/org.gnome.software.gschema.xml:43
 msgid "A list of applications to use, overriding the system defined ones."
-msgstr "সিস্টেম কর্তৃক নির্ধারিতগুলো বাতিল করে ব্যবহারযোগ্য এ্যাপ্লিকেশনসমূহের একটি তালিকা।"
+msgstr ""
+"সিস্টেম কর্তৃক নির্ধারিতগুলো বাতিল করে ব্যবহারযোগ্য এ্যাপ্লিকেশনসমূহের একটি তালিকা।"
 
 #: data/org.gnome.software.gschema.xml:47
 msgid "The list of extra sources that have been previously enabled"
@@ -145,7 +164,8 @@ msgstr "অতিরিক্ত উৎসসমূহের একটি তা
 msgid ""
 "The list of sources that have been previously enabled when installing third-"
 "party applications."
-msgstr "তৃতীয় পক্ষ এ্যাপ্লিকেশন সংস্থাপনের সময় আগে থেকে সক্রিয় করা উৎসের একটি তালিকা।"
+msgstr ""
+"তৃতীয় পক্ষ এ্যাপ্লিকেশন সংস্থাপনের সময় আগে থেকে সক্রিয় করা উৎসের একটি তালিকা।"
 
 #: data/org.gnome.software.gschema.xml:52
 msgid "The last update check timestamp"
@@ -170,8 +190,8 @@ msgstr ""
 #: data/org.gnome.software.gschema.xml:69
 msgid ""
 "Choosing a larger value will mean less round-trips to the remote server but "
-"updates to the screenshots may take longer to show to the user. A value of 0"
-" means to never check the server if the image already exists in the cache."
+"updates to the screenshots may take longer to show to the user. A value of 0 "
+"means to never check the server if the image already exists in the cache."
 msgstr ""
 
 #: data/org.gnome.software.gschema.xml:78
@@ -196,14 +216,15 @@ msgstr "আনুষ্ঠানিক উৎসের একটি তালি
 
 #: data/org.gnome.software.gschema.xml:95
 msgid ""
-"The licence URL to use when an application should be considered free "
-"software"
-msgstr "যখন একটি এ্যাপ্লিকেশনকে মুক্ত সফটওয়্যার বিবেচনা করা হবে তখন যে লাইসেন্স URL ব্যবহার করা হবে"
+"The licence URL to use when an application should be considered free software"
+msgstr ""
+"যখন একটি এ্যাপ্লিকেশনকে মুক্ত সফটওয়্যার বিবেচনা করা হবে তখন যে লাইসেন্স URL ব্যবহার "
+"করা হবে"
 
 #: data/org.gnome.software.gschema.xml:99
-msgid ""
-"Install bundled applications for all users on the system where possible"
-msgstr "সিস্টেমে যেখানে সম্ভব সেখানে সকল ব্যবহারকারীর জন্য বান্ডিল এ্যাপ্লিকেশন সংস্থাপন করুন"
+msgid "Install bundled applications for all users on the system where possible"
+msgstr ""
+"সিস্টেমে যেখানে সম্ভব সেখানে সকল ব্যবহারকারীর জন্য বান্ডিল এ্যাপ্লিকেশন সংস্থাপন করুন"
 
 #: data/org.gnome.software.gschema.xml:103
 msgid "Show the folder management UI"
@@ -269,8 +290,7 @@ msgstr "সফটওয়্যার সংস্থাপন"
 msgid "Install selected software on the system"
 msgstr "সিস্টেমে নির্বাচিত সফটওয়্যার সংস্থাপন করুন"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 #: src/gnome-software-local-file.desktop.in:10
 msgid "system-software-install"
 msgstr ""
@@ -297,14 +317,12 @@ msgstr "পেছনে যান"
 msgid "_All"
 msgstr "_সকল"
 
-#. Translators: A label for a button to show only software which is already
-#. installed.
+#. Translators: A label for a button to show only software which is already installed.
 #: src/gnome-software.ui:104
 msgid "_Installed"
 msgstr "_সংস্থাপিত"
 
-#. Translators: A label for a button to show only updates which are available
-#. to install.
+#. Translators: A label for a button to show only updates which are available to install.
 #: src/gnome-software.ui:155
 msgid "_Updates"
 msgstr "_আপডেটসমূহ"
@@ -352,7 +370,7 @@ msgstr "সংস্থাপিত"
 
 #. TRANSLATORS: this is a button next to the search results that
 #. * shows the status of an application being installed
-#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:443
+#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:439
 msgid "Installing"
 msgstr "সংস্থাপন হচ্ছে"
 
@@ -367,7 +385,7 @@ msgid "Folder Name"
 msgstr "ফোল্ডারের নাম"
 
 #: src/gs-app-folder-dialog.c:321 src/gs-app-folder-dialog.ui:16
-#: src/gs-details-page.c:383 src/gs-details-page.ui:342 src/gs-editor.c:623
+#: src/gs-details-page.c:379 src/gs-details-page.ui:342 src/gs-editor.c:623
 #: src/gs-editor.c:655 src/gs-installed-page.c:609 src/gs-removal-dialog.ui:33
 #: src/gs-review-dialog.ui:23 src/gs-upgrade-banner.ui:131
 msgid "_Cancel"
@@ -382,90 +400,90 @@ msgid "Add to Application Folder"
 msgstr "এ্যাপ্লিকেশন ফোল্ডারে সংযুক্ত করুন"
 
 #. TRANSLATORS: this is a command line option
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "Start up mode: either ‘updates’, ‘updated’, ‘installed’ or ‘overview’"
 msgstr "শুরুর রূপ: হয় 'আপডেট', 'আপডেট হয়েছে', 'সংস্থাপিত' অথবা 'পরিচিতি'"
 
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "MODE"
 msgstr "MODE"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "Search for applications"
 msgstr "এ্যাপ্লিকেশন অনুসন্ধান"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "SEARCH"
 msgstr "SEARCH"
 
-#: src/gs-application.c:105
+#: src/gs-application.c:133
 msgid "Show application details (using application ID)"
 msgstr "এ্যাপ্লিকেশনের বিশদ প্রদর্শন করুন (এ্যাপ্লিকেশন ID ব্যবহার করে)"
 
-#: src/gs-application.c:105 src/gs-application.c:109
+#: src/gs-application.c:133 src/gs-application.c:137
 msgid "ID"
 msgstr "ID"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "Show application details (using package name)"
 msgstr "এ্যাপ্লিকেশনের বিশদ প্রদর্শন করুন (প্যাকেজের নাম ব্যবহার করে)"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "PKGNAME"
 msgstr "PKGNAME"
 
-#: src/gs-application.c:109
+#: src/gs-application.c:137
 msgid "Install the application (using application ID)"
 msgstr ""
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "Open a local package file"
 msgstr "একটি স্থানীয় প্যাকেজ ফাইল খুলুন"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "FILENAME"
 msgstr "FILENAME"
 
-#: src/gs-application.c:113
+#: src/gs-application.c:141
 msgid ""
 "The kind of interaction expected for this action: either ‘none’, ‘notify’, "
 "or ‘full’"
 msgstr ""
 
-#: src/gs-application.c:116
+#: src/gs-application.c:144
 msgid "Show verbose debugging information"
 msgstr "শব্দবহুল ডিবাগ তথ্য প্রদর্শন করুন"
 
-#: src/gs-application.c:118
+#: src/gs-application.c:146
 msgid "Show profiling information for the service"
 msgstr "এই পরিসেবার জন্য প্রোফাইলিং তথ্য প্রদর্শন করুন"
 
-#: src/gs-application.c:120
+#: src/gs-application.c:148
 msgid "Quit the running instance"
 msgstr "চলমান কাজটি বন্ধ করুন"
 
-#: src/gs-application.c:122
+#: src/gs-application.c:150
 msgid "Prefer local file sources to AppStream"
 msgstr "AppStream থেকে স্থানীয় ফাইলের উৎস পছন্দ করবেন"
 
-#: src/gs-application.c:124
+#: src/gs-application.c:152
 msgid "Show version number"
 msgstr "ভার্সন সংখ্যা প্রদর্শন"
 
-#: src/gs-application.c:325
+#: src/gs-application.c:358
 msgid "translator-credits"
 msgstr "অনুবাদক-কৃতিত্ব"
 
 #. TRANSLATORS: this is the title of the about window, e.g.
 #. * 'About Software' or 'About Application Installer' where the %s is
 #. * the application name chosen by the distro
-#: src/gs-application.c:332
+#: src/gs-application.c:365
 #, c-format
 msgid "About %s"
 msgstr ""
 
 #. TRANSLATORS: well, we seem to think so, anyway
-#: src/gs-application.c:336
+#: src/gs-application.c:369
 msgid "A nice way to manage the software on your system."
 msgstr "আপনার সিস্টেমে সফটওয়্যারটি পরিচালনা করার একটি ভাল উপায়।"
 
@@ -557,7 +575,8 @@ msgstr "পরবর্তীবার স্বয়ংক্রিয়ভাব�
 
 #: src/gs-auth-dialog.ui:210
 msgid "Enter your one-time pin for two-factor authentication."
-msgstr "দুই-ধাপ বিশিষ্ট যাচাইকরণের জন্য আপনার একবার-ব্যবহারযোগ্য পিন নাম্বার প্রবেশ করান"
+msgstr ""
+"দুই-ধাপ বিশিষ্ট যাচাইকরণের জন্য আপনার একবার-ব্যবহারযোগ্য পিন নাম্বার প্রবেশ করান"
 
 #: src/gs-auth-dialog.ui:223
 msgid "PIN"
@@ -580,7 +599,7 @@ msgid "All"
 msgstr "সকল"
 
 #. TRANSLATORS: this is a subcategory of featured apps
-#: lib/gs-category.c:202 src/gs-shell.c:2180
+#: lib/gs-category.c:202 src/gs-shell.c:2181
 msgid "Featured"
 msgstr "বৈশিষ্ট্যসম্পন্ন"
 
@@ -590,9 +609,11 @@ msgstr "সংযোজন সেটিংস"
 
 #: src/gs-category-page.ui:110
 msgid ""
-"Extensions are used at your own risk. If you have any system problems, it is"
-" recommended to disable them."
-msgstr "আপনার নিজ দায়িত্বে সংযোজনসমূহ ব্যবহার করবেন। এদের দ্বারা আপনার যদি কোন সিস্টেমজনিত সমস্যা হয়, তাহলে তাদের অকার্যকরী করে ফেলাকেই আমরা সুপারিশ করি।"
+"Extensions are used at your own risk. If you have any system problems, it is "
+"recommended to disable them."
+msgstr ""
+"আপনার নিজ দায়িত্বে সংযোজনসমূহ ব্যবহার করবেন। এদের দ্বারা আপনার যদি কোন "
+"সিস্টেমজনিত সমস্যা হয়, তাহলে তাদের অকার্যকরী করে ফেলাকেই আমরা সুপারিশ করি।"
 
 #. TRANSLATORS: the user isn't reading the question
 #: lib/gs-cmd.c:205
@@ -648,13 +669,15 @@ msgstr "তৃতীয়-পক্ষ সফটওয়্যার উৎস স�
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
 #. * 2. Software source name, e.g. fedora-optional
+#.
 #: src/gs-common.c:232
 #, c-format
 msgid ""
 "%s is not <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
-"source_software\">free and open source software</a>, and is provided by "
-"“%s”."
-msgstr "%s <a href=\"https://en.wikipedia.org/wiki/Free_and_open-source_software\">মুক্ত ও উন্মুক্ত উৎস সফটওয়্যার</a> নয়, এবং “%s” কর্তৃক সরবরাহকৃত।"
+"source_software\">free and open source software</a>, and is provided by “%s”."
+msgstr ""
+"%s <a href=\"https://en.wikipedia.org/wiki/Free_and_open-source_software"
+"\">মুক্ত ও উন্মুক্ত উৎস সফটওয়্যার</a> নয়, এবং “%s” কর্তৃক সরবরাহকৃত।"
 
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
@@ -989,7 +1012,9 @@ msgstr "খেলার মধ্যে আড্ডার কার্যকা
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:246
 msgid "Player-to-player preset interactions without chat functionality"
-msgstr "খেলার মধ্যে আড্ডার কার্যকারিতা ছাড়া খেলোয়াড়ের সাথে খেলোয়াড়ের পূর্ব নির্ধারিত মিথষ্ক্রিয়া"
+msgstr ""
+"খেলার মধ্যে আড্ডার কার্যকারিতা ছাড়া খেলোয়াড়ের সাথে খেলোয়াড়ের পূর্ব নির্ধারিত "
+"মিথষ্ক্রিয়া"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:249
@@ -1036,14 +1061,12 @@ msgstr ""
 msgid "Sharing physical location to other users"
 msgstr "অন্য খেলোয়াড়দের সাথে শারিরীক অবস্থান ভাগাভাগি করা"
 
-#. TRANSLATORS: this is a what we use in notifications if the app's name is
-#. unknown
+#. TRANSLATORS: this is a what we use in notifications if the app's name is unknown
 #: src/gs-dbus-helper.c:294
 msgid "An application"
 msgstr "একটি এ্যাপ্লিকেশন"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. MIME types.
+#. TRANSLATORS: this is a notification displayed when an app needs additional MIME types.
 #: src/gs-dbus-helper.c:300
 #, c-format
 msgid "%s is requesting additional file format support."
@@ -1054,8 +1077,7 @@ msgstr "%s অতিরিক্ত ফাইল ফরম্যাটে সম
 msgid "Additional MIME Types Required"
 msgstr "অতিরিক্ত MIME ধরণ প্রয়োজন"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. fonts.
+#. TRANSLATORS: this is a notification displayed when an app needs additional fonts.
 #: src/gs-dbus-helper.c:306
 #, c-format
 msgid "%s is requesting additional fonts."
@@ -1066,8 +1088,7 @@ msgstr "%s অতিরিক্ত ফন্টের জন্য অনুর
 msgid "Additional Fonts Required"
 msgstr "অতিরিক্ত ফন্ট প্রয়োজন"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. codecs.
+#. TRANSLATORS: this is a notification displayed when an app needs additional codecs.
 #: src/gs-dbus-helper.c:312
 #, c-format
 msgid "%s is requesting additional multimedia codecs."
@@ -1078,8 +1099,7 @@ msgstr "%s অতিরিক্ত মাল্টিমিডিয়া কো�
 msgid "Additional Multimedia Codecs Required"
 msgstr "অতিরিক্ত মাল্টিমিডিয়া কোডেক প্রয়োজন"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. printer drivers.
+#. TRANSLATORS: this is a notification displayed when an app needs additional printer drivers.
 #: src/gs-dbus-helper.c:318
 #, c-format
 msgid "%s is requesting additional printer drivers."
@@ -1090,8 +1110,7 @@ msgstr "%s অতিরিক্ত প্রিন্টার ড্রাই�
 msgid "Additional Printer Drivers Required"
 msgstr "অতিরিক্ত প্রিন্টার ড্রাইভার প্রয়োজন"
 
-#. TRANSLATORS: this is a notification displayed when an app wants to install
-#. additional packages.
+#. TRANSLATORS: this is a notification displayed when an app wants to install additional packages.
 #: src/gs-dbus-helper.c:324
 #, c-format
 msgid "%s is requesting additional packages."
@@ -1111,14 +1130,14 @@ msgstr "সফটওয়্যারে অনুসন্ধান করুন"
 #. * can be installed
 #. TRANSLATORS: button text in the header when firmware
 #. * can be live-installed
-#: src/gs-details-page.c:281 src/gs-details-page.c:312
-#: src/gs-details-page.ui:206 src/gs-upgrade-banner.ui:146
+#: src/gs-details-page.c:280 src/gs-details-page.c:310
+#: src/gs-details-page.ui:237 src/gs-upgrade-banner.ui:146
 msgid "_Install"
 msgstr "_সংস্থাপন"
 
 #. TRANSLATORS: button text in the header when an application
 #. * can be live-updated
-#: src/gs-details-page.c:316
+#: src/gs-details-page.c:314
 msgid "_Update"
 msgstr "_আপডেট"
 
@@ -1126,67 +1145,67 @@ msgstr "_আপডেট"
 #. * be installed.
 #. * The ellipsis indicates that further steps are required,
 #. * e.g. enabling software sources or the like
-#: src/gs-details-page.c:330
+#: src/gs-details-page.c:326
 msgid "_Install…"
 msgstr "_সংস্থাপন..."
 
 #. TRANSLATORS: button text in the header when an application can be erased
-#: src/gs-details-page.c:377 src/gs-details-page.ui:547
+#: src/gs-details-page.c:373 src/gs-details-page.ui:547
 msgid "_Uninstall"
 msgstr "_আনইনস্টল "
 
-#: src/gs-details-page.c:438 src/gs-sources-dialog.c:513
+#: src/gs-details-page.c:434 src/gs-sources-dialog.c:513
 msgid "Removing…"
 msgstr "সরানো হচ্ছে..."
 
 #. TRANSLATORS: this is the warning box
-#: src/gs-details-page.c:748
+#: src/gs-details-page.c:744
 msgid ""
 "This application can only be used when there is an active internet "
 "connection."
 msgstr "সক্রিয় ইন্টারনেট সংযোগ থাকলেই শুধুমাত্র এই এ্যাপ্লিকেশনটি ব্যবহার করা যাবে।"
 
 #. TRANSLATORS: this is where the version is not known
-#: src/gs-details-page.c:892
+#: src/gs-details-page.c:888
 msgctxt "version"
 msgid "Unknown"
 msgstr "অপরিচিত"
 
 #. TRANSLATORS: this is where we don't know the origin of the
 #. * application
-#: src/gs-details-page.c:971
+#: src/gs-details-page.c:967
 msgctxt "origin"
 msgid "Unknown"
 msgstr "অপরিচিত"
 
 #. TRANSLATORS: we need a remote server to process
-#: src/gs-details-page.c:1378
+#: src/gs-details-page.c:1374
 msgid "You need internet access to write a review"
 msgstr ""
 
-#: src/gs-details-page.c:1507
+#: src/gs-details-page.c:1503
 #, c-format
 msgid "Unable to find “%s”"
 msgstr ""
 
 #. TRANSLATORS: see the wikipedia page
-#: src/gs-details-page.c:2087
+#: src/gs-details-page.c:2083
 msgid "Public domain"
 msgstr "সর্বজনীন ডোমেইন"
 
 #. TRANSLATORS: see GNU page
-#: src/gs-details-page.c:2103 src/gs-details-page.ui:1397
+#: src/gs-details-page.c:2099 src/gs-details-page.ui:1397
 msgid "Free Software"
 msgstr "উন্মুক্ত সফটওয়্যার"
 
 #. TRANSLATORS: for the free software popover
-#: src/gs-details-page.c:2160
+#: src/gs-details-page.c:2156
 msgid "Users are bound by the following license:"
 msgid_plural "Users are bound by the following licenses:"
 msgstr[0] "ব্যবহারকারীরা নিম্নোক্ত লাইসেন্সসমূহ দ্বারা আবদ্ধ:"
 msgstr[1] "ব্যবহারকারীরা নিম্নোক্ত লাইসেন্সসমূহ দ্বারা আবদ্ধ:"
 
-#: src/gs-details-page.c:2176 src/gs-details-page.ui:1506
+#: src/gs-details-page.c:2172 src/gs-details-page.ui:1506
 msgid "More information"
 msgstr "আরো তথ্য"
 
@@ -1194,15 +1213,13 @@ msgstr "আরো তথ্য"
 msgid "Details page"
 msgstr "বিশদ পাতা"
 
-#. Translators: A label for a button to add a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:228
+#. Translators: A label for a button to add a shortcut to the selected application.
+#: src/gs-details-page.ui:209
 msgid "_Add to Desktop"
 msgstr "_ডেস্কটপে যোগ করুন "
 
-#. Translators: A label for a button to remove a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:245
+#. Translators: A label for a button to remove a shortcut to the selected application.
+#: src/gs-details-page.ui:226
 msgid "_Remove from Desktop"
 msgstr "_ডেস্কটপ থেকে সরান "
 
@@ -1223,7 +1240,9 @@ msgstr "সফটওয়্যার উৎস সংযোজিত"
 msgid ""
 "This application includes a software source which provides updates, as well "
 "as access to other software."
-msgstr "এই এ্যাপ্লিকেশনে একটি সফটওয়্যার উৎস সংযোজিত আছে যাতে আপডেট, ও সেইসাথে অন্যান্য সফটওয়্যারে প্রবেশাধিকার সরবরাহ করা হয়েছে।"
+msgstr ""
+"এই এ্যাপ্লিকেশনে একটি সফটওয়্যার উৎস সংযোজিত আছে যাতে আপডেট, ও সেইসাথে অন্যান্য "
+"সফটওয়্যারে প্রবেশাধিকার সরবরাহ করা হয়েছে।"
 
 #: src/gs-details-page.ui:500
 msgid "No Software Source Included"
@@ -1233,16 +1252,19 @@ msgstr "কোন সফটওয়্যার উৎস সংযোজিত �
 msgid ""
 "This application does not include a software source. It will not be updated "
 "with new versions."
-msgstr "এই এ্যাপ্লিকেশনে কোন সফটওয়্যার উৎস উল্লেখ করা হয়নি। কোন নতুন ভার্সন দ্বারা এটি আপডেট হবে না।"
+msgstr ""
+"এই এ্যাপ্লিকেশনে কোন সফটওয়্যার উৎস উল্লেখ করা হয়নি। কোন নতুন ভার্সন দ্বারা এটি "
+"আপডেট হবে না।"
 
 #: src/gs-details-page.ui:515
 msgid ""
 "This software is already provided by your distribution and should not be "
 "replaced."
-msgstr "আপনার বিতরণকারী দ্বারা এই সফটওয়্যারটি ইতিমধ্যেই সরবরাহ করা হয়েছে এবং পরিবর্তন করা ঠিক হবে না।"
+msgstr ""
+"আপনার বিতরণকারী দ্বারা এই সফটওয়্যারটি ইতিমধ্যেই সরবরাহ করা হয়েছে এবং পরিবর্তন "
+"করা ঠিক হবে না।"
 
-#. Translators: a repository file used for installing software has been
-#. discovered.
+#. Translators: a repository file used for installing software has been discovered.
 #: src/gs-details-page.ui:528
 msgid "Software Source Identified"
 msgstr "সফটওয়্যার উৎস চিহ্নিত"
@@ -1251,7 +1273,9 @@ msgstr "সফটওয়্যার উৎস চিহ্নিত"
 msgid ""
 "Adding this software source will give you access to additional software and "
 "upgrades."
-msgstr "এই সফটওয়্যার উৎস সংযুক্ত করলে এটি আপনাকে অন্যান্য সফটওয়্যার ও আপগ্রেডে প্রবেশাধিকার দেবে।"
+msgstr ""
+"এই সফটওয়্যার উৎস সংযুক্ত করলে এটি আপনাকে অন্যান্য সফটওয়্যার ও আপগ্রেডে প্রবেশাধিকার "
+"দেবে।"
 
 #: src/gs-details-page.ui:530
 msgid "Only use software sources that you trust."
@@ -1343,14 +1367,12 @@ msgstr "এ্যাড-অন"
 msgid "Selected add-ons will be installed with the application."
 msgstr "নির্বাচিত এ্যাড-অনসমূহ এ্যাপ্লিকেশনের সাথে সংস্থাপিত হবে।"
 
-#. Translators: Header of the section with other users' opinions about the
-#. app.
+#. Translators: Header of the section with other users' opinions about the app.
 #: src/gs-details-page.ui:1233
 msgid "Reviews"
 msgstr "রিভিউ"
 
-#. Translators: Button opening a dialog where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Button opening a dialog where the users can write and publish their opinions about the apps.
 #: src/gs-details-page.ui:1249
 msgid "_Write a Review"
 msgstr "_একটি রিভিউ লিখুন"
@@ -1362,9 +1384,11 @@ msgstr "_আরো প্রদর্শন করুন"
 
 #: src/gs-details-page.ui:1414
 msgid ""
-"This means that the software can be freely run, copied, distributed, studied"
-" and modified."
-msgstr "এর অর্থ হচ্ছে এই সফটওয়্যারটি অবাধে চালানো, কপি করা, বিতরণ করা, গবেষণা করা এবং পরিবর্তন করা যাবে।"
+"This means that the software can be freely run, copied, distributed, studied "
+"and modified."
+msgstr ""
+"এর অর্থ হচ্ছে এই সফটওয়্যারটি অবাধে চালানো, কপি করা, বিতরণ করা, গবেষণা করা এবং "
+"পরিবর্তন করা যাবে।"
 
 #: src/gs-details-page.ui:1473
 msgid "Proprietary Software"
@@ -1375,7 +1399,10 @@ msgid ""
 "This means that the software is owned by an individual or a company. There "
 "are often restrictions on its use and its source code cannot usually be "
 "accessed."
-msgstr "এর অর্থ হচ্ছে এই সফটওয়্যারটি একজন ব্যক্তি বা একটি সংস্থা দ্বারা স্বত্বাধিকৃত। এর ব্যবহারের উপর প্রায়ই সীমাবদ্ধতা থাকবে এবং এর সোর্স কোডসমূহে সাধারণত প্রবেশাধিকার থাকবে না।"
+msgstr ""
+"এর অর্থ হচ্ছে এই সফটওয়্যারটি একজন ব্যক্তি বা একটি সংস্থা দ্বারা স্বত্বাধিকৃত। এর "
+"ব্যবহারের উপর প্রায়ই সীমাবদ্ধতা থাকবে এবং এর সোর্স কোডসমূহে সাধারণত প্রবেশাধিকার "
+"থাকবে না।"
 
 #: src/gs-details-page.ui:1535
 msgid "Unknown Software License"
@@ -1459,8 +1486,7 @@ msgstr ""
 msgid "Use verbose logging"
 msgstr ""
 
-#. TRANSLATORS: program name, an application to add and remove software
-#. repositories
+#. TRANSLATORS: program name, an application to add and remove software repositories
 #: src/gs-editor.c:1119
 msgid "GNOME Software Banner Designer"
 msgstr ""
@@ -1489,8 +1515,7 @@ msgstr "সারাংশ"
 msgid "Editor’s Pick"
 msgstr ""
 
-#. This check button controls whether the application’s banner appears in the
-#. “Featured” category
+#. This check button controls whether the application’s banner appears in the “Featured” category
 #: src/gs-editor.ui:397
 msgid "Category Featured"
 msgstr ""
@@ -1579,9 +1604,11 @@ msgstr "%s ফাইলটি সরবরাহ করার মতো কো�
 #: src/gs-extras-page.c:337 src/gs-extras-page.c:348 src/gs-extras-page.c:359
 #, c-format
 msgid ""
-"Information about %s, as well as options for how to get missing applications"
-" might be found %s."
-msgstr "%s সম্পর্কে তথ্য, সেইসাথে হারিয়ে যাওয়া এ্যাপ্লিকেশন পাবার উপায়সমূহ হয়তো %s পাওয়া যাবে।"
+"Information about %s, as well as options for how to get missing applications "
+"might be found %s."
+msgstr ""
+"%s সম্পর্কে তথ্য, সেইসাথে হারিয়ে যাওয়া এ্যাপ্লিকেশন পাবার উপায়সমূহ হয়তো %s পাওয়া "
+"যাবে।"
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1604,7 +1631,9 @@ msgstr "%s পাওয়া যায়নি।"
 msgid ""
 "Information about %s, as well as options for how to get an application that "
 "can support this format might be found %s."
-msgstr "%s সম্পর্কে তথ্য, সেইসাথে এই ফরম্যাট চালানোর জন্য এ্যাপ্লিকেশন পাবার উপায়সমূহ %s পাওয়া যাবে।"
+msgstr ""
+"%s সম্পর্কে তথ্য, সেইসাথে এই ফরম্যাট চালানোর জন্য এ্যাপ্লিকেশন পাবার উপায়সমূহ %s "
+"পাওয়া যাবে।"
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1624,7 +1653,7 @@ msgstr "%s সম্পর্কে তথ্য, সেইসাথে অত�
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
-#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1426
+#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1430
 #, c-format
 msgid "No addon codecs are available for the %s format."
 msgstr "%s ফরম্যাটে কোন এ্যাডঅন কোডেক পাওয়া যায়নি।"
@@ -1636,7 +1665,9 @@ msgstr "%s ফরম্যাটে কোন এ্যাডঅন কোডে
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format might be found %s."
-msgstr "%s সম্পর্কে তথ্য, সেইসাথে এই ফরম্যাট চালানোর জন্য কোডেক পাবার উপায়সমূহ %s পাওয়া যাবে।"
+msgstr ""
+"%s সম্পর্কে তথ্য, সেইসাথে এই ফরম্যাট চালানোর জন্য কোডেক পাবার উপায়সমূহ %s পাওয়া "
+"যাবে।"
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1652,7 +1683,9 @@ msgstr "%s সমর্থনের জন্য কোন প্লাজমা
 msgid ""
 "Information about %s, as well as options for how to get additional Plasma "
 "resources might be found %s."
-msgstr "%s সম্পর্কে তথ্য, সেইসাথে অতিরিক্ত প্লাজমা সংস্থান পাবার উপায়সমূহ হয়তো %s পাওয়া যাবে।"
+msgstr ""
+"%s সম্পর্কে তথ্য, সেইসাথে অতিরিক্ত প্লাজমা সংস্থান পাবার উপায়সমূহ হয়তো %s পাওয়া "
+"যাবে।"
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1668,15 +1701,16 @@ msgstr "%s জন্য কোন প্রিন্টার ড্রাইভ
 msgid ""
 "Information about %s, as well as options for how to get a driver that "
 "supports this printer might be found %s."
-msgstr "%s সম্পর্কে তথ্য, সেইসাথে এই প্রিন্টার সমর্থন দেবার মতো ড্রাইভার পাবার উপায়সমূহ হয়তো %s পাওয়া যাবে।"
+msgstr ""
+"%s সম্পর্কে তথ্য, সেইসাথে এই প্রিন্টার সমর্থন দেবার মতো ড্রাইভার পাবার উপায়সমূহ হয়তো "
+"%s পাওয়া যাবে।"
 
 #. TRANSLATORS: hyperlink title
 #: src/gs-extras-page.c:459
 msgid "this website"
 msgstr "এই ওয়েবসাইট"
 
-#. TRANSLATORS: no codecs were found. First %s will be replaced by actual
-#. codec name(s), second %s is a link titled "this website"
+#. TRANSLATORS: no codecs were found. First %s will be replaced by actual codec name(s), second %s is a link titled "this website"
 #: src/gs-extras-page.c:463
 #, c-format
 msgid ""
@@ -1685,8 +1719,12 @@ msgid ""
 msgid_plural ""
 "Unfortunately, the %s you were searching for could not be found. Please see "
 "%s for more information."
-msgstr[0] "দুর্ভাগ্যক্রমে, আপনি যে %s অনুসন্ধান করছে তা পাওয়া যায়নি। আরো তথ্যের জন্য অনুগ্রহ করে %s দেখুন।"
-msgstr[1] "দুর্ভাগ্যক্রমে, আপনি যে %s অনুসন্ধান করছে তা পাওয়া যায়নি। আরো তথ্যের জন্য অনুগ্রহ করে %s দেখুন।"
+msgstr[0] ""
+"দুর্ভাগ্যক্রমে, আপনি যে %s অনুসন্ধান করছে তা পাওয়া যায়নি। আরো তথ্যের জন্য অনুগ্রহ করে "
+"%s দেখুন।"
+msgstr[1] ""
+"দুর্ভাগ্যক্রমে, আপনি যে %s অনুসন্ধান করছে তা পাওয়া যায়নি। আরো তথ্যের জন্য অনুগ্রহ করে "
+"%s দেখুন।"
 
 #: src/gs-extras-page.c:535 src/gs-extras-page.c:591 src/gs-extras-page.c:630
 msgid "Failed to find any search results"
@@ -1711,10 +1749,13 @@ msgstr "সফটওয়্যারে স্বাগতম"
 
 #: src/gs-first-run-dialog.ui:66
 msgid ""
-"Software lets you install all the software you need, all from one place. See"
-" our recommendations, browse the categories, or search for the applications "
+"Software lets you install all the software you need, all from one place. See "
+"our recommendations, browse the categories, or search for the applications "
 "you want."
-msgstr "এই সফটওয়্যারের সাহায্যে আপনার প্রয়োজনীয় সকল সফটওয়্যার সংস্থাপন করে নিন একটিমাত্র জায়গা থেকে। আমাদের সুপারিশসমূহ দেখুন, বিভাগগুলো ঘুরে দেখুন অথবা আপনি যে এ্যাপ্লিকেশনটি চান তা অনুসন্ধান করুন।"
+msgstr ""
+"এই সফটওয়্যারের সাহায্যে আপনার প্রয়োজনীয় সকল সফটওয়্যার সংস্থাপন করে নিন একটিমাত্র "
+"জায়গা থেকে। আমাদের সুপারিশসমূহ দেখুন, বিভাগগুলো ঘুরে দেখুন অথবা আপনি যে "
+"এ্যাপ্লিকেশনটি চান তা অনুসন্ধান করুন।"
 
 #: src/gs-first-run-dialog.ui:85
 msgid "_Let’s Go Shopping"
@@ -1868,8 +1909,7 @@ msgstr "ওয়েব ব্রাউজার ও খেলাসহ, অতি�
 
 #. TRANSLATORS: this is the proprietary info bar
 #: src/gs-overview-page.c:978
-msgid ""
-"Proprietary software has restrictions on use and access to source code."
+msgid "Proprietary software has restrictions on use and access to source code."
 msgstr "স্বত্বসহ সফটওয়্যারের ব্যবহার ও এর উৎস কোডে প্রবেশাধিকারে বিধিনিষেধ রয়েছে।"
 
 #. TRANSLATORS: this is the clickable
@@ -1899,14 +1939,12 @@ msgstr ""
 msgid "Categories"
 msgstr "বিভাগ"
 
-#. Translators: This is a heading for software which has been featured
-#. ('picked') by the distribution.
+#. Translators: This is a heading for software which has been featured ('picked') by the distribution.
 #: src/gs-overview-page.ui:315
 msgid "Editor’s Picks"
 msgstr ""
 
-#. Translators: This is a heading for software which has been recently
-#. released upstream.
+#. Translators: This is a heading for software which has been recently released upstream.
 #: src/gs-overview-page.ui:359
 msgid "Recent Releases"
 msgstr ""
@@ -1953,7 +1991,9 @@ msgstr "আপনি কি নিশ্চিত আপনি %s উ্ৎস�
 msgid ""
 "All applications from %s will be removed, and you will have to re-install "
 "the source to use them again."
-msgstr "%s থেকে সকল এ্যাপ্লিকেশন মুছে ফেলা হবে, এবং এদের ব্যবহার করতে হলে আপনাকে আবার উৎসটি পুনঃসংস্থাপন করতে হবে।"
+msgstr ""
+"%s থেকে সকল এ্যাপ্লিকেশন মুছে ফেলা হবে, এবং এদের ব্যবহার করতে হলে আপনাকে আবার "
+"উৎসটি পুনঃসংস্থাপন করতে হবে।"
 
 #. TRANSLATORS: this is a prompt message, and '%s' is an
 #. * application summary, e.g. 'GNOME Clocks'
@@ -1966,14 +2006,17 @@ msgstr "আপনি কি নিশ্চিত আপনি %s মুছত�
 #: src/gs-page.c:684
 #, c-format
 msgid "%s will be removed, and you will have to install it to use it again."
-msgstr "%s মুছে ফেলা হবে, এবং এটা ব্যবহার করতে হলে আপনাকে আবার সংস্থাপিত করতে হবে।"
+msgstr ""
+"%s মুছে ফেলা হবে, এবং এটা ব্যবহার করতে হলে আপনাকে আবার সংস্থাপিত করতে হবে।"
 
-#: lib/gs-plugin-loader.c:1429
+#: lib/gs-plugin-loader.c:1433
 #, c-format
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format can be found on the website."
-msgstr "%s সম্পর্কে তথ্য, সেইসাথে এই ফরম্যাট চালানোর জন্য কোডেক পাবার উপায়সমূহ এই ওয়েবসাইটে পাওয়া যাবে।"
+msgstr ""
+"%s সম্পর্কে তথ্য, সেইসাথে এই ফরম্যাট চালানোর জন্য কোডেক পাবার উপায়সমূহ এই "
+"ওয়েবসাইটে পাওয়া যাবে।"
 
 #: lib/gs-price.c:111
 #, c-format
@@ -2032,7 +2075,9 @@ msgstr ""
 msgid ""
 "Some of the currently installed software is not compatible with %s. If you "
 "continue, the following will be automatically removed during the upgrade:"
-msgstr "বর্তমানে সংস্থাপিত সফটওয়্যারসমূহের মধ্যে কিছু সংখ্যক %s সাথে সামঞ্জস্যপূর্ণ নয়। আপনি যদি চালাতে থাকেন, তবে আপগ্রেডের সময় নিম্নোক্তগুলো স্বয়ংক্রিয়ভাবে সরিয়ে ফেলা হবে:"
+msgstr ""
+"বর্তমানে সংস্থাপিত সফটওয়্যারসমূহের মধ্যে কিছু সংখ্যক %s সাথে সামঞ্জস্যপূর্ণ নয়। আপনি "
+"যদি চালাতে থাকেন, তবে আপগ্রেডের সময় নিম্নোক্তগুলো স্বয়ংক্রিয়ভাবে সরিয়ে ফেলা হবে:"
 
 #: src/gs-removal-dialog.ui:27
 msgid "Incompatible Software"
@@ -2102,8 +2147,7 @@ msgstr "এই বর্ণনাটি বেশি ছোট"
 msgid "The description is too long"
 msgstr "এই বর্ণনাটি বেশি লম্বা"
 
-#. Translators: Title of the dialog box where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Title of the dialog box where the users can write and publish their opinions about the apps.
 #: src/gs-review-dialog.ui:11
 msgid "Post Review"
 msgstr "রিভিউ পোস্ট করুন"
@@ -2121,7 +2165,9 @@ msgstr "রেটিং"
 msgid ""
 "Give a short summary of your review, for example: “Great app, would "
 "recommend”."
-msgstr "আপনার রিভিউয়ের জন্য একটি ছোট সারাংশ লিখুন, উদাহরণস্বরূপ: \"দারুণ এ্যাপ, আমি সুপারিশ করছি।\""
+msgstr ""
+"আপনার রিভিউয়ের জন্য একটি ছোট সারাংশ লিখুন, উদাহরণস্বরূপ: \"দারুণ এ্যাপ, আমি সুপারিশ "
+"করছি।\""
 
 #. Translators: This is where the users enter their opinions about the apps.
 #: src/gs-review-dialog.ui:199
@@ -2131,7 +2177,8 @@ msgstr "রিভিউ"
 
 #: src/gs-review-dialog.ui:215
 msgid "What do you think of the app? Try to give reasons for your views."
-msgstr "এ্যাপটি সম্পর্কে আপনার মতামত কী? আপনার মতামতের পেছনে কারণ দেখানোর চেষ্টা করুন।"
+msgstr ""
+"এ্যাপটি সম্পর্কে আপনার মতামত কী? আপনার মতামতের পেছনে কারণ দেখানোর চেষ্টা করুন।"
 
 #. Translators: A label for the total number of reviews.
 #: src/gs-review-histogram.ui:413
@@ -2141,14 +2188,18 @@ msgstr ""
 #. TRANSLATORS: we explain what the action is going to do
 #: src/gs-review-row.c:234
 msgid "You can report reviews for abusive, rude, or discriminatory behavior."
-msgstr "অবমাননাকর, অভদ্র বা বৈষম্যমূলক আচরণের জন্য আপনি কোন রিভিউ সম্পর্কে অভিযোগ জানাতে পারেন।"
+msgstr ""
+"অবমাননাকর, অভদ্র বা বৈষম্যমূলক আচরণের জন্য আপনি কোন রিভিউ সম্পর্কে অভিযোগ জানাতে "
+"পারেন।"
 
 #. TRANSLATORS: we ask the user if they really want to do this
 #: src/gs-review-row.c:239
 msgid ""
 "Once reported, a review will be hidden until it has been checked by an "
 "administrator."
-msgstr "একবার অভিযোগ জানালে, উক্ত রিভিউটি একজন প্রশাসক দ্বারা পরীক্ষা না করা পর্যন্ত লুকানো থাকবে।"
+msgstr ""
+"একবার অভিযোগ জানালে, উক্ত রিভিউটি একজন প্রশাসক দ্বারা পরীক্ষা না করা পর্যন্ত লুকানো "
+"থাকবে।"
 
 #. TRANSLATORS: window title when
 #. * reporting a user-submitted review
@@ -2163,8 +2214,7 @@ msgstr "রিভিউ সম্পর্কে অভিযোগ করবে
 msgid "Report"
 msgstr "অভিযোগ"
 
-#. Translators: Users can express their opinions about other users' opinions
-#. about the apps.
+#. Translators: Users can express their opinions about other users' opinions about the apps.
 #: src/gs-review-row.ui:112
 msgid "Was this review useful to you?"
 msgstr "এই রিভিউ পড়ে কি আপনার কোন সাহায্য হয়েছে?"
@@ -2253,81 +2303,80 @@ msgstr "কোন এ্যাপ্লিকেশন পাওয়া যায়
 #. TRANSLATORS: this is part of the in-app notification,
 #. * where the %s is a multi-word localised app name
 #. * e.g. 'Getting things GNOME!"
-#: src/gs-shell.c:846 src/gs-shell.c:851 src/gs-shell.c:866 src/gs-shell.c:870
+#: src/gs-shell.c:847 src/gs-shell.c:852 src/gs-shell.c:867 src/gs-shell.c:871
 #, c-format
 msgid "“%s”"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:898
+#: src/gs-shell.c:899
 #, c-format
 msgid "Unable to download firmware updates from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:904
+#: src/gs-shell.c:905
 #, c-format
 msgid "Unable to download updates from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:911
+#: src/gs-shell.c:912
 msgid "Unable to download updates"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:916
+#: src/gs-shell.c:917
 msgid ""
-"Unable to download updates: internet access was required but wasn’t "
-"available"
+"Unable to download updates: internet access was required but wasn’t available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:925
+#: src/gs-shell.c:926
 #, c-format
 msgid "Unable to download updates from %s: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:930
+#: src/gs-shell.c:931
 msgid "Unable to download updates: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:938
+#: src/gs-shell.c:939
 msgid "Unable to download updates: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:943
+#: src/gs-shell.c:944
 msgid "Unable to download updates: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:948
+#: src/gs-shell.c:949
 msgid ""
 "Unable to download updates: you do not have permission to install software"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:955
+#: src/gs-shell.c:956
 msgid "Unable to get list of updates"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the application name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1001
+#: src/gs-shell.c:1002
 #, c-format
 msgid "Unable to install %s as download failed from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1007
+#: src/gs-shell.c:1008
 #, c-format
 msgid "Unable to install %s as download failed"
 msgstr ""
@@ -2336,51 +2385,51 @@ msgstr ""
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1019
+#: src/gs-shell.c:1020
 #, c-format
 msgid "Unable to install %s as runtime %s not available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1025
+#: src/gs-shell.c:1026
 #, c-format
 msgid "Unable to install %s as not supported"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1032
+#: src/gs-shell.c:1033
 msgid "Unable to install: internet access was required but wasn’t available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1038
+#: src/gs-shell.c:1039
 msgid "Unable to install: the application has an invalid format"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1043
+#: src/gs-shell.c:1044
 #, c-format
 msgid "Unable to install %s: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1051
+#: src/gs-shell.c:1052
 #, c-format
 msgid "Unable to install %s: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1058
+#: src/gs-shell.c:1059
 #, c-format
 msgid "Unable to install %s: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1065
+#: src/gs-shell.c:1066
 #, c-format
 msgid "Unable to install %s: you do not have permission to install software"
 msgstr ""
@@ -2388,34 +2437,34 @@ msgstr ""
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the name of the authentication service,
 #. * e.g. "Ubuntu One"
-#: src/gs-shell.c:1078
+#: src/gs-shell.c:1079
 #, c-format
 msgid "Your %s account has been suspended."
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1082
+#: src/gs-shell.c:1083
 msgid "It is not possible to install software until this has been resolved."
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the clickable link (e.g.
 #. * "http://example.com/what-did-i-do-wrong/")
-#: src/gs-shell.c:1093
+#: src/gs-shell.c:1094
 #, c-format
 msgid "For more information, visit %s."
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1102
+#: src/gs-shell.c:1103
 #, c-format
 msgid "Unable to install %s: AC power is required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1111
+#: src/gs-shell.c:1112
 #, c-format
 msgid "Unable to install %s"
 msgstr ""
@@ -2424,61 +2473,61 @@ msgstr ""
 #. * where the first %s is the app name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1157
+#: src/gs-shell.c:1158
 #, c-format
 msgid "Unable to update %s from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1163
+#: src/gs-shell.c:1164
 #, c-format
 msgid "Unable to update %s as download failed"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1169
+#: src/gs-shell.c:1170
 msgid "Unable to update: internet access was required but wasn’t available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1177
+#: src/gs-shell.c:1178
 #, c-format
 msgid "Unable to update %s: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1186
+#: src/gs-shell.c:1187
 #, c-format
 msgid "Unable to update %s: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1193
+#: src/gs-shell.c:1194
 #, c-format
 msgid "Unable to update %s: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1200
+#: src/gs-shell.c:1201
 #, c-format
 msgid "Unable to update %s: you do not have permission to update software"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1208
+#: src/gs-shell.c:1209
 #, c-format
 msgid "Unable to update %s: AC power is required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1217
+#: src/gs-shell.c:1218
 #, c-format
 msgid "Unable to update %s"
 msgstr ""
@@ -2486,96 +2535,96 @@ msgstr ""
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the distro name (e.g. "Fedora 25") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1262
+#: src/gs-shell.c:1263
 #, c-format
 msgid "Unable to upgrade to %s from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the app name (e.g. "GIMP")
-#: src/gs-shell.c:1267
+#: src/gs-shell.c:1268
 #, c-format
 msgid "Unable to upgrade to %s as download failed"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1274
+#: src/gs-shell.c:1275
 msgid "Unable to upgrade: internet access was required but wasn’t available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1282
+#: src/gs-shell.c:1283
 #, c-format
 msgid "Unable to upgrade to %s: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1291
+#: src/gs-shell.c:1292
 #, c-format
 msgid "Unable to upgrade to %s: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1298
+#: src/gs-shell.c:1299
 #, c-format
 msgid "Unable to upgrade to %s: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1305
+#: src/gs-shell.c:1306
 #, c-format
 msgid "Unable to upgrade to %s: you do not have permission to upgrade"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1312
+#: src/gs-shell.c:1313
 #, c-format
 msgid "Unable to upgrade to %s: AC power is required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1321
+#: src/gs-shell.c:1322
 #, c-format
 msgid "Unable to upgrade to %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1363
+#: src/gs-shell.c:1364
 #, c-format
 msgid "Unable to remove %s: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1369
+#: src/gs-shell.c:1370
 #, c-format
 msgid "Unable to remove %s: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1375
+#: src/gs-shell.c:1376
 #, c-format
 msgid "Unable to remove %s: you do not have permission to remove software"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1382
+#: src/gs-shell.c:1383
 #, c-format
 msgid "Unable to remove %s: AC power is required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1391
+#: src/gs-shell.c:1392
 #, c-format
 msgid "Unable to remove %s"
 msgstr ""
@@ -2584,48 +2633,48 @@ msgstr ""
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1437
+#: src/gs-shell.c:1438
 #, c-format
 msgid "Unable to launch %s: %s is not installed"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1444 src/gs-shell.c:1492 src/gs-shell.c:1540
+#: src/gs-shell.c:1445 src/gs-shell.c:1493 src/gs-shell.c:1541
 msgid "Not enough disk space — free up some space and try again"
 msgstr ""
 
 #. TRANSLATORS: we failed to get a proper error code
-#: src/gs-shell.c:1452 src/gs-shell.c:1500 src/gs-shell.c:1567
+#: src/gs-shell.c:1453 src/gs-shell.c:1501 src/gs-shell.c:1568
 msgid "Sorry, something went wrong"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1487
+#: src/gs-shell.c:1488
 msgid "Failed to install file: authentication failed"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1534
+#: src/gs-shell.c:1535
 #, c-format
 msgid "Unable to contact %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1549
+#: src/gs-shell.c:1550
 #, c-format
 msgid "%s needs to be restarted to use new plugins."
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1554
+#: src/gs-shell.c:1555
 msgid "This application needs to be restarted to use new plugins."
 msgstr ""
 
 #. TRANSLATORS: need to be connected to the AC power
-#: src/gs-shell.c:1561
+#: src/gs-shell.c:1562
 msgid "AC power is required"
 msgstr ""
 
@@ -2712,7 +2761,9 @@ msgstr "অপারেটিং সিস্টেম"
 msgid ""
 "Software sources can be downloaded from the internet. They give you access "
 "to additional software that is not provided by %s."
-msgstr "সফটওয়্যার উৎসসমূহ ইন্টারনেট থেকে ডাউনলোড করা যাবে। সেসব অতিরিক্ত সফটওয়্যারে প্রবেশাধিকার দেয় যা %s কর্তৃক সরবরাহকৃত নয়।"
+msgstr ""
+"সফটওয়্যার উৎসসমূহ ইন্টারনেট থেকে ডাউনলোড করা যাবে। সেসব অতিরিক্ত সফটওয়্যারে "
+"প্রবেশাধিকার দেয় যা %s কর্তৃক সরবরাহকৃত নয়।"
 
 #: src/gs-sources-dialog.ui:155
 msgid "Additional Sources"
@@ -2721,7 +2772,9 @@ msgstr "অতিরিক্ত উৎসগুলো"
 #: src/gs-sources-dialog.ui:175
 msgid ""
 "Removing a source will also remove any software you have installed from it."
-msgstr "একটি উৎস মুছে ফেলার মানে সেই উৎস থেকে যে সফটওয়্যার সংস্থাপন করা হয়েছে তাও মুছে ফেলা।"
+msgstr ""
+"একটি উৎস মুছে ফেলার মানে সেই উৎস থেকে যে সফটওয়্যার সংস্থাপন করা হয়েছে তাও মুছে "
+"ফেলা।"
 
 #: src/gs-sources-dialog.ui:260
 msgid "No software installed from this source"
@@ -2919,29 +2972,37 @@ msgstr "আপডেট বাতিল করা হয়েছে।"
 #. * something with no network available
 #: src/gs-update-monitor.c:714
 msgid ""
-"Internet access was required but wasn’t available. Please make sure that you"
-" have internet access and try again."
-msgstr "ইন্টারনেট সংযোগ প্রয়োজন হলেও ইন্টারনেট সংযোগ পাওয়া যায়নি। অনুগ্রহ করে নিশ্চিত করুন আপনার ইন্টারনেট সংযোগ রয়েছে এবং আবার চেষ্টা করুন।"
+"Internet access was required but wasn’t available. Please make sure that you "
+"have internet access and try again."
+msgstr ""
+"ইন্টারনেট সংযোগ প্রয়োজন হলেও ইন্টারনেট সংযোগ পাওয়া যায়নি। অনুগ্রহ করে নিশ্চিত করুন "
+"আপনার ইন্টারনেট সংযোগ রয়েছে এবং আবার চেষ্টা করুন।"
 
 #. TRANSLATORS: if the package is not signed correctly
 #: src/gs-update-monitor.c:720
 msgid ""
 "There were security issues with the update. Please consult your software "
 "provider for more details."
-msgstr "আপডেট সম্পর্কিত নিরাপত্তা ইস্যু দেখা দিয়েছে। আরো তথ্যের জন্য অনুগ্রহ করে আপনার সফটওয়্যার সরবরাহকারীর সাথে যোগাযোগ করুন।"
+msgstr ""
+"আপডেট সম্পর্কিত নিরাপত্তা ইস্যু দেখা দিয়েছে। আরো তথ্যের জন্য অনুগ্রহ করে আপনার "
+"সফটওয়্যার সরবরাহকারীর সাথে যোগাযোগ করুন।"
 
 #. TRANSLATORS: we ran out of disk space
 #: src/gs-update-monitor.c:726
 msgid ""
 "There wasn’t enough disk space. Please free up some space and try again."
-msgstr "ডিস্কে পর্যাপ্ত জায়গা ছিল না। অনুগ্রহ করে কিছু জায়গা খালি করুন এবং আবার চেষ্টা করুন।"
+msgstr ""
+"ডিস্কে পর্যাপ্ত জায়গা ছিল না। অনুগ্রহ করে কিছু জায়গা খালি করুন এবং আবার চেষ্টা করুন।"
 
 #. TRANSLATORS: We didn't handle the error type
 #: src/gs-update-monitor.c:731
 msgid ""
 "We’re sorry: the update failed to install. Please wait for another update "
 "and try again. If the problem persists, contact your software provider."
-msgstr "আমরা দুঃখিত: আপডেট সংস্থাপিত হতে ব্যর্থ হয়েছে। আরেকটি আপডেটের জন্য অপেক্ষা করুন এবং আবার চেষ্টা করুন। যদি সমস্যা হতে থাকে, তাহলে আপনার সফটওয়্যার সরবরাহকারীর সাথে যোগাযোগ করুন।"
+msgstr ""
+"আমরা দুঃখিত: আপডেট সংস্থাপিত হতে ব্যর্থ হয়েছে। আরেকটি আপডেটের জন্য অপেক্ষা করুন এবং "
+"আবার চেষ্টা করুন। যদি সমস্যা হতে থাকে, তাহলে আপনার সফটওয়্যার সরবরাহকারীর সাথে "
+"যোগাযোগ করুন।"
 
 #. TRANSLATORS: Time in 24h format
 #: src/gs-updates-page.c:297
@@ -3121,7 +3182,9 @@ msgstr "মূল্য পরিশোধ করতে হতে পারে"
 msgid ""
 "Checking for updates while using mobile broadband could cause you to incur "
 "charges."
-msgstr "মোবাইলে ব্রডব্যান্ড ব্যবহার করার সময় আপডেট খোঁজ করতে গেলে আপনাকে মূল্য পরিশোধ করতে হতে পারে।"
+msgstr ""
+"মোবাইলে ব্রডব্যান্ড ব্যবহার করার সময় আপডেট খোঁজ করতে গেলে আপনাকে মূল্য পরিশোধ করতে "
+"হতে পারে।"
 
 #. TRANSLATORS: this is a link to the
 #. * control-center network panel
@@ -3160,7 +3223,9 @@ msgstr "সফটওয়্যার হালনাগাদকৃত আছে"
 msgid ""
 "Checking for updates when using mobile broadband could cause you to incur "
 "charges"
-msgstr "মোবাইলে ব্রডব্যান্ড ব্যবহার করার সময় আপডেট খোঁজ করতে গেলে আপনাকে মূল্য পরিশোধ করতে হতে পারে"
+msgstr ""
+"মোবাইলে ব্রডব্যান্ড ব্যবহার করার সময় আপডেট খোঁজ করতে গেলে আপনাকে মূল্য পরিশোধ করতে "
+"হতে পারে"
 
 #: src/gs-updates-page.ui:257
 msgid "_Check Anyway"
@@ -3225,22 +3290,26 @@ msgid "App Center"
 msgstr "এ্যাপ সেন্টার"
 
 #: src/org.gnome.Software.desktop.in:4
+msgid "More Apps"
+msgstr "আরও অ্যাপস"
+
+#: src/org.gnome.Software.desktop.in:5
 msgid "Add, remove or update software on this computer"
 msgstr "এই কম্পিউটারে সফটওয়্যার সংযুক্তি, মুছে ফেলা অথবা আপডেট"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
-#: src/org.gnome.Software.desktop.in:6
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: src/org.gnome.Software.desktop.in:7
 #: src/org.gnome.Software.Editor.desktop.in:6
 msgid "org.gnome.Software"
 msgstr ""
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
-#: src/org.gnome.Software.desktop.in:12
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: src/org.gnome.Software.desktop.in:13
 msgid ""
-"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;"
-msgstr "আপডেট;আপগ্রেড;উৎস;ভান্ডার;পছন্দ;সংস্থাপন;অসংস্থাপন;প্রোগ্রাম;সফটওয়্যার;এ্যাপ;দোকান;"
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;"
+msgstr ""
+"আপডেট;আপগ্রেড;উৎস;ভান্ডার;পছন্দ;সংস্থাপন;অসংস্থাপন;প্রোগ্রাম;সফটওয়্যার;এ্যাপ;দোকান;"
 
 #: src/org.gnome.Software.Editor.desktop.in:3
 msgid "Banner Designer"
@@ -3250,8 +3319,7 @@ msgstr ""
 msgid "Design the featured banners for GNOME Software"
 msgstr ""
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: src/org.gnome.Software.Editor.desktop.in:13
 msgid "AppStream;Software;App;"
 msgstr ""
@@ -3521,100 +3589,110 @@ msgctxt "Menu of Communication & News"
 msgid "Web Browsers"
 msgstr ""
 
-#: plugins/core/gs-desktop-common.c:247
-msgctxt "Menu of Reference"
-msgid "All"
-msgstr "সকল"
-
-#: plugins/core/gs-desktop-common.c:250
-msgctxt "Menu of Reference"
-msgid "Featured"
-msgstr "বৈশিষ্ট্যসম্পন্ন"
-
-#: plugins/core/gs-desktop-common.c:253
-msgctxt "Menu of Reference"
-msgid "Art"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:256
-msgctxt "Menu of Reference"
-msgid "Biography"
-msgstr "আত্মজীবনী"
-
-#: plugins/core/gs-desktop-common.c:259
-msgctxt "Menu of Reference"
-msgid "Comics"
-msgstr "প্রহসন"
-
-#: plugins/core/gs-desktop-common.c:262
-msgctxt "Menu of Reference"
-msgid "Fiction"
-msgstr "গল্প"
-
-#: plugins/core/gs-desktop-common.c:265
-msgctxt "Menu of Reference"
-msgid "Health"
-msgstr "স্বাস্থ্য"
-
-#: plugins/core/gs-desktop-common.c:268
-msgctxt "Menu of Reference"
-msgid "History"
-msgstr "ইতিহাস"
-
-#: plugins/core/gs-desktop-common.c:271
-msgctxt "Menu of Reference"
-msgid "Lifestyle"
-msgstr "জীবনচর্যা"
-
-#: plugins/core/gs-desktop-common.c:274
+#: plugins/core/gs-desktop-common.c:242
 msgctxt "Menu of Communication & News"
 msgid "News"
 msgstr ""
 
+#: plugins/core/gs-desktop-common.c:251
+msgctxt "Menu of Reference"
+msgid "All"
+msgstr "সকল"
+
+#: plugins/core/gs-desktop-common.c:254
+msgctxt "Menu of Reference"
+msgid "Featured"
+msgstr "বৈশিষ্ট্যসম্পন্ন"
+
+#: plugins/core/gs-desktop-common.c:257
+msgctxt "Menu of Reference"
+msgid "Art"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:260
+msgctxt "Menu of Reference"
+msgid "Biography"
+msgstr "আত্মজীবনী"
+
+#: plugins/core/gs-desktop-common.c:263
+msgctxt "Menu of Reference"
+msgid "Comics"
+msgstr "প্রহসন"
+
+#: plugins/core/gs-desktop-common.c:266
+msgctxt "Menu of Reference"
+msgid "Feed"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:269
+msgctxt "Menu of Reference"
+msgid "Fiction"
+msgstr "গল্প"
+
+#: plugins/core/gs-desktop-common.c:272
+msgctxt "Menu of Reference"
+msgid "Health"
+msgstr "স্বাস্থ্য"
+
+#: plugins/core/gs-desktop-common.c:275
+msgctxt "Menu of Reference"
+msgid "History"
+msgstr "ইতিহাস"
+
 #: plugins/core/gs-desktop-common.c:278
+msgctxt "Menu of Reference"
+msgid "Lifestyle"
+msgstr "জীবনচর্যা"
+
+#: plugins/core/gs-desktop-common.c:281
+msgctxt "Menu of Reference"
+msgid "News"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:284
 msgctxt "Menu of Reference"
 msgid "Politics"
 msgstr "রাজনীতি"
 
-#: plugins/core/gs-desktop-common.c:281
+#: plugins/core/gs-desktop-common.c:287
 msgctxt "Menu of Reference"
 msgid "Sports"
 msgstr "খেলাধুলা"
 
 #. TRANSLATORS: this is the menu spec main category for Learning
-#: plugins/core/gs-desktop-common.c:291
+#: plugins/core/gs-desktop-common.c:297
 msgid "Learning"
 msgstr "শিক্ষা"
 
 #. TRANSLATORS: this is the menu spec main category for Game
-#: plugins/core/gs-desktop-common.c:294
+#: plugins/core/gs-desktop-common.c:300
 msgid "Games"
 msgstr "খেলা"
 
 #. TRANSLATORS: this is the menu spec main category for Multimedia
-#: plugins/core/gs-desktop-common.c:297
+#: plugins/core/gs-desktop-common.c:303
 msgid "Multimedia"
 msgstr "মাল্টিমিডিয়া"
 
 #. TRANSLATORS: this is the menu spec main category for Work
-#: plugins/core/gs-desktop-common.c:300
+#: plugins/core/gs-desktop-common.c:306
 msgid "Work"
 msgstr "কাজ"
 
 #. TRANSLATORS: this is the menu spec main category for Reference
-#: plugins/core/gs-desktop-common.c:303
+#: plugins/core/gs-desktop-common.c:309
 msgid "Reference & News"
 msgstr "প্রসঙ্গক্রম এবং খবর"
 
 #. TRANSLATORS: this is the menu spec main category for Utilities
-#: plugins/core/gs-desktop-common.c:306
+#: plugins/core/gs-desktop-common.c:312
 msgid "Utilities"
 msgstr "উপযোগিতা"
 
 #. TRANSLATORS: this is the menu spec main category for Dev Tools; it
 #. * should be a relatively short label; as an example, in Portuguese and
 #. * Spanish the direct translation of "Programming" (noun) is used
-#: plugins/core/gs-desktop-common.c:311
+#: plugins/core/gs-desktop-common.c:317
 msgid "Dev Tools"
 msgstr ""
 
@@ -3640,16 +3718,16 @@ msgstr "কর্মক্ষমতা, স্থিতিশীলতা ও �
 msgid "Downloading featured images…"
 msgstr ""
 
-#: plugins/eos/gs-plugin-eos.c:1249
+#: plugins/eos/gs-plugin-eos.c:1233
 #, c-format
 msgid "Could not launch this application."
 msgstr ""
 
-#: plugins/eos/gs-plugin-eos.c:1305
+#: plugins/eos/gs-plugin-eos.c:1289
 msgid "Endless Platform"
 msgstr "এন্ডলেস প্রাঙ্গণ"
 
-#: plugins/eos/gs-plugin-eos.c:1308
+#: plugins/eos/gs-plugin-eos.c:1292
 msgid "Framework for applications"
 msgstr "এ্যাপ্লিকেশনসমূহের জন্য ফ্রেমওয়ার্ক"
 
@@ -3709,13 +3787,13 @@ msgid "Flatpak is a framework for desktop applications on Linux"
 msgstr ""
 
 #. TRANSLATORS: status text when downloading new metadata
-#: plugins/flatpak/gs-flatpak.c:821
+#: plugins/flatpak/gs-flatpak.c:815
 #, c-format
 msgid "Getting flatpak metadata for %s…"
 msgstr ""
 
 #. TRANSLATORS: status text when downloading the RuntimeRepo
-#: plugins/flatpak/gs-flatpak.c:2796
+#: plugins/flatpak/gs-flatpak.c:2803
 msgid "Getting runtime source…"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the gnome-software package.
-# 
+#
 # Translators:
 # Marek Černocký <marek@manet.cz>, 2013-2017
 # Petr Kovar <pknbe@volny.cz>, 2015
@@ -9,14 +9,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-software\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-12 22:31-0700\n"
+"POT-Creation-Date: 2017-11-02 16:28+0100\n"
 "PO-Revision-Date: 2017-10-13 05:51+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
-"Language-Team: Czech (http://www.transifex.com/endless-mobile-inc/gnome-software/language/cs/)\n"
+"Language-Team: Czech (http://www.transifex.com/endless-mobile-inc/gnome-"
+"software/language/cs/)\n"
+"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: cs\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:7
@@ -31,7 +32,9 @@ msgstr "Správa aplikací pro GNOME"
 msgid ""
 "Software allows you to find and install new applications and system "
 "extensions and remove existing installed applications."
-msgstr "Aplikace Software umožňuje vyhledávat a instalovat aplikace a systémová rozšíření a odebírat stávající nainstalované aplikace."
+msgstr ""
+"Aplikace Software umožňuje vyhledávat a instalovat aplikace a systémová "
+"rozšíření a odebírat stávající nainstalované aplikace."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:14
 msgid ""
@@ -39,7 +42,11 @@ msgid ""
 "descriptions and multiple screenshots per application. Applications can be "
 "found either through browsing the list of categories or by searching. It "
 "also allows you to update your system using an offline update."
-msgstr "Software GNOME vám představí významné a oblíbené aplikace pomocí srozumitelného popisu a několika snímků obrazovky. Aplikace můžete najít buď ručním procházení podle kategorií nebo pomocí textového vyhledávání. Rovněž můžete aktualizovat svůj systém a to i bez aktuálního připojení k Internetu."
+msgstr ""
+"Software GNOME vám představí významné a oblíbené aplikace pomocí "
+"srozumitelného popisu a několika snímků obrazovky. Aplikace můžete najít buď "
+"ručním procházení podle kategorií nebo pomocí textového vyhledávání. Rovněž "
+"můžete aktualizovat svůj systém a to i bez aktuálního připojení k Internetu."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:25
 msgid "Overview panel"
@@ -73,7 +80,9 @@ msgstr "Seznam kompatibilních projektů"
 msgid ""
 "This is a list of compatible projects we should show such as GNOME, KDE and "
 "XFCE."
-msgstr "Seznam kompatibilních projektů, jako je GNOME, KDE a XFCE, které by se měly zobrazovat."
+msgstr ""
+"Seznam kompatibilních projektů, jako je GNOME, KDE a XFCE, které by se měly "
+"zobrazovat."
 
 #: data/org.gnome.software.gschema.xml:10
 msgid "Whether to manage updates in GNOME Software"
@@ -83,7 +92,9 @@ msgstr "Zda se starat o aktualizace v Softwaru GNOME"
 msgid ""
 "If disabled, GNOME Software will hide the updates panel and not perform any "
 "automatic updates actions."
-msgstr "Když je vypnuto, Software GNOME skryje panel s aktualizacemi a nebude provádět automatické činnosti ohledně aktualizací."
+msgstr ""
+"Když je vypnuto, Software GNOME skryje panel s aktualizacemi a nebude "
+"provádět automatické činnosti ohledně aktualizací."
 
 #: data/org.gnome.software.gschema.xml:15
 msgid "Whether to automatically download updates"
@@ -91,9 +102,11 @@ msgstr "Zda automaticky stahovat aktualizace"
 
 #: data/org.gnome.software.gschema.xml:16
 msgid ""
-"If enabled, GNOME Software automatically downloads updates in the background"
-" and prompts the user to install them when ready."
-msgstr "Když je zapnuto, bude Software GNOME na pozadí automaticky stahovat aktualizace a po stažení nabídne uživateli jejich instalaci."
+"If enabled, GNOME Software automatically downloads updates in the background "
+"and prompts the user to install them when ready."
+msgstr ""
+"Když je zapnuto, bude Software GNOME na pozadí automaticky stahovat "
+"aktualizace a po stažení nabídne uživateli jejich instalaci."
 
 #: data/org.gnome.software.gschema.xml:20
 msgid "Whether to automatically refresh when on a metered connection"
@@ -104,7 +117,11 @@ msgid ""
 "If enabled, GNOME Software automatically refreshes in the background even "
 "when using a metered connection (eventually downloading some metadata, "
 "checking for updates, etc., which may incur in costs for the user)."
-msgstr "Když je zapnuto, bude Software GNOME na pozadí automaticky aktualizovat informace, i v případě, že připojení není účtované paušální částkou (případně stahovat některá metadata, kontrolovat aktualizace atd., což se může projevit v ceně za připojení)."
+msgstr ""
+"Když je zapnuto, bude Software GNOME na pozadí automaticky aktualizovat "
+"informace, i v případě, že připojení není účtované paušální částkou "
+"(případně stahovat některá metadata, kontrolovat aktualizace atd., což se "
+"může projevit v ceně za připojení)."
 
 #: data/org.gnome.software.gschema.xml:25
 msgid "Whether it’s the very first run of GNOME Software"
@@ -116,7 +133,8 @@ msgstr "Zobrazovat vedle aplikace hodnocení hvězdičkami"
 
 #: data/org.gnome.software.gschema.xml:33
 msgid "Filter applications based on the default branch set for the remote"
-msgstr "Filtrovat aplikace podle výchozí větve nastavené pro vzdálený protějšek"
+msgstr ""
+"Filtrovat aplikace podle výchozí větve nastavené pro vzdálený protějšek"
 
 #: data/org.gnome.software.gschema.xml:37
 msgid "Non-free applications show a warning dialog before install"
@@ -124,9 +142,11 @@ msgstr "Před instalací nesvobodných aplikací zobrazit varovné dialogové ok
 
 #: data/org.gnome.software.gschema.xml:38
 msgid ""
-"When non-free applications are installed a warning dialog can be shown. This"
-" controls if that dialog is suppressed."
-msgstr "Když se instaluje nesvobodná aplikace, může být zobrazeno varovné dialogové okno. Tímto se řídí potlačení tohoto dialogového okna."
+"When non-free applications are installed a warning dialog can be shown. This "
+"controls if that dialog is suppressed."
+msgstr ""
+"Když se instaluje nesvobodná aplikace, může být zobrazeno varovné dialogové "
+"okno. Tímto se řídí potlačení tohoto dialogového okna."
 
 #: data/org.gnome.software.gschema.xml:42
 msgid "A list of popular applications"
@@ -134,7 +154,8 @@ msgstr "Seznam populárních aplikací"
 
 #: data/org.gnome.software.gschema.xml:43
 msgid "A list of applications to use, overriding the system defined ones."
-msgstr "Seznam aplikací, které se mají použít. Přepíše ty definované v systému."
+msgstr ""
+"Seznam aplikací, které se mají použít. Přepíše ty definované v systému."
 
 #: data/org.gnome.software.gschema.xml:47
 msgid "The list of extra sources that have been previously enabled"
@@ -144,7 +165,9 @@ msgstr "Seznam dodatečných zdrojů, které byly již dříve povoleny"
 msgid ""
 "The list of sources that have been previously enabled when installing third-"
 "party applications."
-msgstr "Seznam zdrojů, které byly již dříve povoleny při instalaci aplikací třetích stran."
+msgstr ""
+"Seznam zdrojů, které byly již dříve povoleny při instalaci aplikací třetích "
+"stran."
 
 #: data/org.gnome.software.gschema.xml:52
 msgid "The last update check timestamp"
@@ -164,14 +187,20 @@ msgstr "Datum a čas poslední aktualizace"
 
 #: data/org.gnome.software.gschema.xml:68
 msgid "The age in seconds to verify the upstream screenshot is still valid"
-msgstr "Doba v sekundách, po které se má ověřit, jestli je snímek obrazovky z hlavního zdroje stále platný"
+msgstr ""
+"Doba v sekundách, po které se má ověřit, jestli je snímek obrazovky z "
+"hlavního zdroje stále platný"
 
 #: data/org.gnome.software.gschema.xml:69
 msgid ""
 "Choosing a larger value will mean less round-trips to the remote server but "
-"updates to the screenshots may take longer to show to the user. A value of 0"
-" means to never check the server if the image already exists in the cache."
-msgstr "Čím větší hodnotu zvolíte, tím méně návštěv vzdáleného serveru se provede, ale může trvat déle, než se uživateli zobrazí aktuálnější snímek. Hodnota 0 znamená, že se kontroly na serveru nemají provádět vůbec, pokud je již snímek v mezipaměti."
+"updates to the screenshots may take longer to show to the user. A value of 0 "
+"means to never check the server if the image already exists in the cache."
+msgstr ""
+"Čím větší hodnotu zvolíte, tím méně návštěv vzdáleného serveru se provede, "
+"ale může trvat déle, než se uživateli zobrazí aktuálnější snímek. Hodnota 0 "
+"znamená, že se kontroly na serveru nemají provádět vůbec, pokud je již "
+"snímek v mezipaměti."
 
 #: data/org.gnome.software.gschema.xml:78
 msgid "The server to use for application reviews"
@@ -187,22 +216,25 @@ msgstr "Recenze s karmou nižší než toto číslo nebudou zobrazovány."
 
 #: data/org.gnome.software.gschema.xml:87
 msgid "A list of official sources that should not be considered 3rd party"
-msgstr "Seznam oficiálních zdrojů, které by neměly být považovány za třetí stranu"
+msgstr ""
+"Seznam oficiálních zdrojů, které by neměly být považovány za třetí stranu"
 
 #: data/org.gnome.software.gschema.xml:91
 msgid "A list of official sources that should be considered free software"
-msgstr "Seznam oficiálních zdrojů, které by měly být považovány za svobodný software"
+msgstr ""
+"Seznam oficiálních zdrojů, které by měly být považovány za svobodný software"
 
 #: data/org.gnome.software.gschema.xml:95
 msgid ""
-"The licence URL to use when an application should be considered free "
-"software"
-msgstr "Adresa URL licence, která se má použít, když má aplikace považována za svobodný software"
+"The licence URL to use when an application should be considered free software"
+msgstr ""
+"Adresa URL licence, která se má použít, když má aplikace považována za "
+"svobodný software"
 
 #: data/org.gnome.software.gschema.xml:99
-msgid ""
-"Install bundled applications for all users on the system where possible"
-msgstr "Kde je to možné, instalovat všem uživatelům v systému přibalené aplikace"
+msgid "Install bundled applications for all users on the system where possible"
+msgstr ""
+"Kde je to možné, instalovat všem uživatelům v systému přibalené aplikace"
 
 #: data/org.gnome.software.gschema.xml:103
 msgid "Show the folder management UI"
@@ -218,7 +250,9 @@ msgstr "Nabízet povýšení na předběžná vydání"
 
 #: data/org.gnome.software.gschema.xml:115
 msgid "Show some UI elements informing the user that an app is non-free"
-msgstr "Zobrazovat v rozhraní prvky, které informují uživatele, že aplikace není svobodná"
+msgstr ""
+"Zobrazovat v rozhraní prvky, které informují uživatele, že aplikace není "
+"svobodná"
 
 #: data/org.gnome.software.gschema.xml:119
 msgid "Show the prompt to install nonfree software sources"
@@ -230,7 +264,8 @@ msgstr "Zobrazovat nesvobodný software ve výsledcích hledání"
 
 #: data/org.gnome.software.gschema.xml:127
 msgid "Show the installed size for apps in the list of installed applications"
-msgstr "Zobrazovat velikost instalace pro aplikace v seznamu nainstalovaných aplikací"
+msgstr ""
+"Zobrazovat velikost instalace pro aplikace v seznamu nainstalovaných aplikací"
 
 #: data/org.gnome.software.gschema.xml:131
 msgid "The URI that explains nonfree and proprietary software"
@@ -244,11 +279,15 @@ msgstr "Seznam nesvobodných zdrojů, které mohou být volitelně povoleny"
 msgid ""
 "A list of URLs pointing to appstream files that will be downloaded into an "
 "app-info folder"
-msgstr "Seznam adres URL ukazujících na soubory appstream, které byly stažené do složky app-info"
+msgstr ""
+"Seznam adres URL ukazujících na soubory appstream, které byly stažené do "
+"složky app-info"
 
 #: data/org.gnome.software.gschema.xml:143
 msgid "Install the AppStream files to a system-wide location for all users"
-msgstr "Instalovat soubory AppStream do celosystémového umístění pro všechny uživatele"
+msgstr ""
+"Instalovat soubory AppStream do celosystémového umístění pro všechny "
+"uživatele"
 
 #: data/org.gnome.software.gschema.xml:147
 msgid "Sorts the apps shown in the overview in alphabetical order"
@@ -268,8 +307,7 @@ msgstr "Instalace softwaru"
 msgid "Install selected software on the system"
 msgstr "Nainstalujte si vybraný software do systému"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 #: src/gnome-software-local-file.desktop.in:10
 msgid "system-software-install"
 msgstr "system-software-install"
@@ -296,14 +334,12 @@ msgstr "Přejít zpět"
 msgid "_All"
 msgstr "_Vše"
 
-#. Translators: A label for a button to show only software which is already
-#. installed.
+#. Translators: A label for a button to show only software which is already installed.
 #: src/gnome-software.ui:104
 msgid "_Installed"
 msgstr "Na_instalované"
 
-#. Translators: A label for a button to show only updates which are available
-#. to install.
+#. Translators: A label for a button to show only updates which are available to install.
 #: src/gnome-software.ui:155
 msgid "_Updates"
 msgstr "_Aktualizace"
@@ -351,7 +387,7 @@ msgstr "Nainstalováno"
 
 #. TRANSLATORS: this is a button next to the search results that
 #. * shows the status of an application being installed
-#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:443
+#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:439
 msgid "Installing"
 msgstr "Instaluje se"
 
@@ -366,7 +402,7 @@ msgid "Folder Name"
 msgstr "Název složky"
 
 #: src/gs-app-folder-dialog.c:321 src/gs-app-folder-dialog.ui:16
-#: src/gs-details-page.c:383 src/gs-details-page.ui:342 src/gs-editor.c:623
+#: src/gs-details-page.c:379 src/gs-details-page.ui:342 src/gs-editor.c:623
 #: src/gs-editor.c:655 src/gs-installed-page.c:609 src/gs-removal-dialog.ui:33
 #: src/gs-review-dialog.ui:23 src/gs-upgrade-banner.ui:131
 msgid "_Cancel"
@@ -381,90 +417,94 @@ msgid "Add to Application Folder"
 msgstr "Přidání do složky aplikací"
 
 #. TRANSLATORS: this is a command line option
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "Start up mode: either ‘updates’, ‘updated’, ‘installed’ or ‘overview’"
-msgstr "Režim spuštění: buď „updates“ (aktualizace), „updated“ (aktualizované), „installed“ (nainstalované) nebo „overview“ (přehled)"
+msgstr ""
+"Režim spuštění: buď „updates“ (aktualizace), „updated“ (aktualizované), "
+"„installed“ (nainstalované) nebo „overview“ (přehled)"
 
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "MODE"
 msgstr "REŽIM"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "Search for applications"
 msgstr "Hledat aplikaci"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "SEARCH"
 msgstr "HLEDAT"
 
-#: src/gs-application.c:105
+#: src/gs-application.c:133
 msgid "Show application details (using application ID)"
 msgstr "Zobrazit informace o aplikaci (pomocí ID aplikace)"
 
-#: src/gs-application.c:105 src/gs-application.c:109
+#: src/gs-application.c:133 src/gs-application.c:137
 msgid "ID"
 msgstr "ID"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "Show application details (using package name)"
 msgstr "Zobrazit informace o aplikaci (pomocí názvu balíčku)"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "PKGNAME"
 msgstr "NÁZEV_BALÍČKU"
 
-#: src/gs-application.c:109
+#: src/gs-application.c:137
 msgid "Install the application (using application ID)"
 msgstr "Nainstalovat aplikaci (pomocí ID aplikace)"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "Open a local package file"
 msgstr "Otevřít místní soubor s balíčkem"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "FILENAME"
 msgstr "NÁZEV_SOUBORU"
 
-#: src/gs-application.c:113
+#: src/gs-application.c:141
 msgid ""
 "The kind of interaction expected for this action: either ‘none’, ‘notify’, "
 "or ‘full’"
-msgstr "Pro tuto činnost je očekáván druh interakce: buď „none“ (nic), „notify“ (upozornit) nebo „full“ (úplná)"
+msgstr ""
+"Pro tuto činnost je očekáván druh interakce: buď „none“ (nic), "
+"„notify“ (upozornit) nebo „full“ (úplná)"
 
-#: src/gs-application.c:116
+#: src/gs-application.c:144
 msgid "Show verbose debugging information"
 msgstr "Zobrazovat podrobné ladicí informace"
 
-#: src/gs-application.c:118
+#: src/gs-application.c:146
 msgid "Show profiling information for the service"
 msgstr "Zobrazit profilovací informace pro službu"
 
-#: src/gs-application.c:120
+#: src/gs-application.c:148
 msgid "Quit the running instance"
 msgstr "Ukončit běžící instanci"
 
-#: src/gs-application.c:122
+#: src/gs-application.c:150
 msgid "Prefer local file sources to AppStream"
 msgstr "Upřednostnit zdroje v místních souborech před zdroji on-line"
 
-#: src/gs-application.c:124
+#: src/gs-application.c:152
 msgid "Show version number"
 msgstr "Zobrazit číslo verze"
 
-#: src/gs-application.c:325
+#: src/gs-application.c:358
 msgid "translator-credits"
 msgstr "Marek Černocký <marek@manet.cz>"
 
 #. TRANSLATORS: this is the title of the about window, e.g.
 #. * 'About Software' or 'About Application Installer' where the %s is
 #. * the application name chosen by the distro
-#: src/gs-application.c:332
+#: src/gs-application.c:365
 #, c-format
 msgid "About %s"
 msgstr "O aplikaci %s"
 
 #. TRANSLATORS: well, we seem to think so, anyway
-#: src/gs-application.c:336
+#: src/gs-application.c:369
 msgid "A nice way to manage the software on your system."
 msgstr "Elegantní způsob správy softwaru ve vašem počítači."
 
@@ -579,7 +619,7 @@ msgid "All"
 msgstr "Vše"
 
 #. TRANSLATORS: this is a subcategory of featured apps
-#: lib/gs-category.c:202 src/gs-shell.c:2180
+#: lib/gs-category.c:202 src/gs-shell.c:2181
 msgid "Featured"
 msgstr "Významné"
 
@@ -589,9 +629,11 @@ msgstr "Nastavení rozšíření"
 
 #: src/gs-category-page.ui:110
 msgid ""
-"Extensions are used at your own risk. If you have any system problems, it is"
-" recommended to disable them."
-msgstr "Rozšíření používáte na vlastní riziko. Pokud narazíte na nějaké problémy se systémem, je doporučeno rozšíření zakázat."
+"Extensions are used at your own risk. If you have any system problems, it is "
+"recommended to disable them."
+msgstr ""
+"Rozšíření používáte na vlastní riziko. Pokud narazíte na nějaké problémy se "
+"systémem, je doporučeno rozšíření zakázat."
 
 #. TRANSLATORS: the user isn't reading the question
 #: lib/gs-cmd.c:205
@@ -647,13 +689,15 @@ msgstr "Povolit zdroj softwaru třetí strany?"
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
 #. * 2. Software source name, e.g. fedora-optional
+#.
 #: src/gs-common.c:232
 #, c-format
 msgid ""
 "%s is not <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
-"source_software\">free and open source software</a>, and is provided by "
-"“%s”."
-msgstr "%s není <a href=\"https://en.wikipedia.org/wiki/Free_and_open-source_software\">svobodný a otevřený software</a> a poskytuje jej „%s“."
+"source_software\">free and open source software</a>, and is provided by “%s”."
+msgstr ""
+"%s není <a href=\"https://en.wikipedia.org/wiki/Free_and_open-source_software"
+"\">svobodný a otevřený software</a> a poskytuje jej „%s“."
 
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
@@ -666,18 +710,21 @@ msgstr "%s poskytuje „%s“."
 #. TRANSLATORS: a software source is a repo
 #: src/gs-common.c:252
 msgid "This software source must be enabled to continue installation."
-msgstr "Aby bylo možné pokračovat v instalaci, je nutné povolit tento zdroj softwaru."
+msgstr ""
+"Aby bylo možné pokračovat v instalaci, je nutné povolit tento zdroj softwaru."
 
 #. TRANSLATORS: Laws are geographical, urgh...
 #: src/gs-common.c:262
 #, c-format
 msgid "It may be illegal to install or use %s in some countries."
-msgstr "V některých zemích nemusí být instalace a používání softwaru %s legální."
+msgstr ""
+"V některých zemích nemusí být instalace a používání softwaru %s legální."
 
 #. TRANSLATORS: Laws are geographical, urgh...
 #: src/gs-common.c:268
 msgid "It may be illegal to install or use this codec in some countries."
-msgstr "V některých zemích nemusí být instalace a používání tohoto kodeku legální."
+msgstr ""
+"V některých zemích nemusí být instalace a používání tohoto kodeku legální."
 
 #. TRANSLATORS: this is button text to not ask about non-free content again
 #: src/gs-common.c:275
@@ -923,7 +970,9 @@ msgstr "Diskriminace cílící na způsobení citové újmy"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:207
 msgid "Explicit discrimination based on gender, sexuality, race or religion"
-msgstr "Výslovná diskriminace založená na pohlaví, sexuální orientaci, rase nebo náboženství"
+msgstr ""
+"Výslovná diskriminace založená na pohlaví, sexuální orientaci, rase nebo "
+"náboženství"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:210
@@ -1008,7 +1057,8 @@ msgstr "Neřízená zvuková a obrazová komunikace mezi hráči"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:258
 msgid "No sharing of social network usernames or email addresses"
-msgstr "Žádné sdílení uživatelských jmen ze sociálních sítí a e-mailových adres"
+msgstr ""
+"Žádné sdílení uživatelských jmen ze sociálních sítí a e-mailových adres"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:261
@@ -1035,14 +1085,12 @@ msgstr "Žádné sdílení fyzické polohy s ostatními uživateli"
 msgid "Sharing physical location to other users"
 msgstr "Sdílení fyzické polohy s ostatními uživateli"
 
-#. TRANSLATORS: this is a what we use in notifications if the app's name is
-#. unknown
+#. TRANSLATORS: this is a what we use in notifications if the app's name is unknown
 #: src/gs-dbus-helper.c:294
 msgid "An application"
 msgstr "Nějaká aplikace"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. MIME types.
+#. TRANSLATORS: this is a notification displayed when an app needs additional MIME types.
 #: src/gs-dbus-helper.c:300
 #, c-format
 msgid "%s is requesting additional file format support."
@@ -1053,8 +1101,7 @@ msgstr "%s požaduje dodatečnou podporu formátů souborů."
 msgid "Additional MIME Types Required"
 msgstr "Požadavek na dodatečné typy MIME"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. fonts.
+#. TRANSLATORS: this is a notification displayed when an app needs additional fonts.
 #: src/gs-dbus-helper.c:306
 #, c-format
 msgid "%s is requesting additional fonts."
@@ -1065,8 +1112,7 @@ msgstr "%s požaduje dodatečná písma."
 msgid "Additional Fonts Required"
 msgstr "Požadavek na dodatečná písma"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. codecs.
+#. TRANSLATORS: this is a notification displayed when an app needs additional codecs.
 #: src/gs-dbus-helper.c:312
 #, c-format
 msgid "%s is requesting additional multimedia codecs."
@@ -1077,8 +1123,7 @@ msgstr "%s požaduje dodatečné multimediální kodeky."
 msgid "Additional Multimedia Codecs Required"
 msgstr "Požadavek na dodatečné multimediální kodeky"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. printer drivers.
+#. TRANSLATORS: this is a notification displayed when an app needs additional printer drivers.
 #: src/gs-dbus-helper.c:318
 #, c-format
 msgid "%s is requesting additional printer drivers."
@@ -1089,8 +1134,7 @@ msgstr "%s požaduje dodatečné tiskové ovladače."
 msgid "Additional Printer Drivers Required"
 msgstr "Požadavek na dodatečné tiskové ovladače"
 
-#. TRANSLATORS: this is a notification displayed when an app wants to install
-#. additional packages.
+#. TRANSLATORS: this is a notification displayed when an app wants to install additional packages.
 #: src/gs-dbus-helper.c:324
 #, c-format
 msgid "%s is requesting additional packages."
@@ -1110,14 +1154,14 @@ msgstr "Najít v aplikaci Software"
 #. * can be installed
 #. TRANSLATORS: button text in the header when firmware
 #. * can be live-installed
-#: src/gs-details-page.c:281 src/gs-details-page.c:312
-#: src/gs-details-page.ui:206 src/gs-upgrade-banner.ui:146
+#: src/gs-details-page.c:280 src/gs-details-page.c:310
+#: src/gs-details-page.ui:237 src/gs-upgrade-banner.ui:146
 msgid "_Install"
 msgstr "_Instalovat"
 
 #. TRANSLATORS: button text in the header when an application
 #. * can be live-updated
-#: src/gs-details-page.c:316
+#: src/gs-details-page.c:314
 msgid "_Update"
 msgstr "_Aktualizovat"
 
@@ -1125,68 +1169,69 @@ msgstr "_Aktualizovat"
 #. * be installed.
 #. * The ellipsis indicates that further steps are required,
 #. * e.g. enabling software sources or the like
-#: src/gs-details-page.c:330
+#: src/gs-details-page.c:326
 msgid "_Install…"
 msgstr "_Instalovat…"
 
 #. TRANSLATORS: button text in the header when an application can be erased
-#: src/gs-details-page.c:377 src/gs-details-page.ui:547
+#: src/gs-details-page.c:373 src/gs-details-page.ui:547
 msgid "_Uninstall"
 msgstr ""
 
-#: src/gs-details-page.c:438 src/gs-sources-dialog.c:513
+#: src/gs-details-page.c:434 src/gs-sources-dialog.c:513
 msgid "Removing…"
 msgstr "Odebírá se…"
 
 #. TRANSLATORS: this is the warning box
-#: src/gs-details-page.c:748
+#: src/gs-details-page.c:744
 msgid ""
 "This application can only be used when there is an active internet "
 "connection."
-msgstr "Tuto aplikaci je možné používat, jen když je funkční připojení k Internetu."
+msgstr ""
+"Tuto aplikaci je možné používat, jen když je funkční připojení k Internetu."
 
 #. TRANSLATORS: this is where the version is not known
-#: src/gs-details-page.c:892
+#: src/gs-details-page.c:888
 msgctxt "version"
 msgid "Unknown"
 msgstr "Neznámá"
 
 #. TRANSLATORS: this is where we don't know the origin of the
 #. * application
-#: src/gs-details-page.c:971
+#: src/gs-details-page.c:967
 msgctxt "origin"
 msgid "Unknown"
 msgstr "Neznámý"
 
 #. TRANSLATORS: we need a remote server to process
-#: src/gs-details-page.c:1378
+#: src/gs-details-page.c:1374
 msgid "You need internet access to write a review"
 msgstr "Abyste mohli napsat recenzi, musíte být připojeni k Internetu"
 
-#: src/gs-details-page.c:1507
+#: src/gs-details-page.c:1503
 #, c-format
 msgid "Unable to find “%s”"
 msgstr "Nelze najít „%s“"
 
 #. TRANSLATORS: see the wikipedia page
-#: src/gs-details-page.c:2087
+#: src/gs-details-page.c:2083
 msgid "Public domain"
 msgstr "Volné dílo"
 
 #. TRANSLATORS: see GNU page
-#: src/gs-details-page.c:2103 src/gs-details-page.ui:1397
+#: src/gs-details-page.c:2099 src/gs-details-page.ui:1397
 msgid "Free Software"
 msgstr "Svobodný software"
 
 #. TRANSLATORS: for the free software popover
-#: src/gs-details-page.c:2160
+#: src/gs-details-page.c:2156
 msgid "Users are bound by the following license:"
 msgid_plural "Users are bound by the following licenses:"
 msgstr[0] "Uživatelé jsou vázání následující licencí:"
 msgstr[1] "Uživatelé jsou vázání následujícími licencemi:"
 msgstr[2] "Uživatelé jsou vázání následujícími licencemi:"
 
-#: src/gs-details-page.c:2176 src/gs-details-page.ui:1506
+#: src/gs-details-page.c:2172 src/gs-details-page.ui:1506
 msgid "More information"
 msgstr "Podrobné informace"
 
@@ -1194,15 +1239,13 @@ msgstr "Podrobné informace"
 msgid "Details page"
 msgstr "Stránka s podrobnostmi"
 
-#. Translators: A label for a button to add a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:228
+#. Translators: A label for a button to add a shortcut to the selected application.
+#: src/gs-details-page.ui:209
 msgid "_Add to Desktop"
 msgstr ""
 
-#. Translators: A label for a button to remove a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:245
+#. Translators: A label for a button to remove a shortcut to the selected application.
+#: src/gs-details-page.ui:226
 msgid "_Remove from Desktop"
 msgstr ""
 
@@ -1223,7 +1266,9 @@ msgstr "Součástí je zdroj softwaru"
 msgid ""
 "This application includes a software source which provides updates, as well "
 "as access to other software."
-msgstr "Tato aplikace v sobě zahrnuje zdroj softwaru, který poskytuje aktualizace a přístup k dalšímu softwaru."
+msgstr ""
+"Tato aplikace v sobě zahrnuje zdroj softwaru, který poskytuje aktualizace a "
+"přístup k dalšímu softwaru."
 
 #: src/gs-details-page.ui:500
 msgid "No Software Source Included"
@@ -1233,16 +1278,18 @@ msgstr "Zdroj softwaru není součástí"
 msgid ""
 "This application does not include a software source. It will not be updated "
 "with new versions."
-msgstr "Tato aplikace nezahrnuje zdroj softwaru. Nebude průběžně aktualizována na novější verze."
+msgstr ""
+"Tato aplikace nezahrnuje zdroj softwaru. Nebude průběžně aktualizována na "
+"novější verze."
 
 #: src/gs-details-page.ui:515
 msgid ""
 "This software is already provided by your distribution and should not be "
 "replaced."
-msgstr "Tento software již poskytuje vaše distribuce a neměli byste jej nahrazovat."
+msgstr ""
+"Tento software již poskytuje vaše distribuce a neměli byste jej nahrazovat."
 
-#. Translators: a repository file used for installing software has been
-#. discovered.
+#. Translators: a repository file used for installing software has been discovered.
 #: src/gs-details-page.ui:528
 msgid "Software Source Identified"
 msgstr "Rozpoznán zdroj softwaru"
@@ -1251,7 +1298,9 @@ msgstr "Rozpoznán zdroj softwaru"
 msgid ""
 "Adding this software source will give you access to additional software and "
 "upgrades."
-msgstr "Přídáním tohoto zdroje softwaru získáte přístup k dalšímu softwaru a aktualizacím."
+msgstr ""
+"Přídáním tohoto zdroje softwaru získáte přístup k dalšímu softwaru a "
+"aktualizacím."
 
 #: src/gs-details-page.ui:530
 msgid "Only use software sources that you trust."
@@ -1343,14 +1392,12 @@ msgstr "Doplňky"
 msgid "Selected add-ons will be installed with the application."
 msgstr "Vybrané doplňky budou nainstalovány spolu s aplikací."
 
-#. Translators: Header of the section with other users' opinions about the
-#. app.
+#. Translators: Header of the section with other users' opinions about the app.
 #: src/gs-details-page.ui:1233
 msgid "Reviews"
 msgstr "Recenze"
 
-#. Translators: Button opening a dialog where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Button opening a dialog where the users can write and publish their opinions about the apps.
 #: src/gs-details-page.ui:1249
 msgid "_Write a Review"
 msgstr "Nap_sat recenzi"
@@ -1362,9 +1409,11 @@ msgstr "_Zobrazit další"
 
 #: src/gs-details-page.ui:1414
 msgid ""
-"This means that the software can be freely run, copied, distributed, studied"
-" and modified."
-msgstr "To znamená, že software můžete svobodně používat, kopírovat, šířit, studovat a upravovat."
+"This means that the software can be freely run, copied, distributed, studied "
+"and modified."
+msgstr ""
+"To znamená, že software můžete svobodně používat, kopírovat, šířit, studovat "
+"a upravovat."
 
 #: src/gs-details-page.ui:1473
 msgid "Proprietary Software"
@@ -1375,7 +1424,10 @@ msgid ""
 "This means that the software is owned by an individual or a company. There "
 "are often restrictions on its use and its source code cannot usually be "
 "accessed."
-msgstr "To znamená, že software je vlastněn jednotlivcem nebo firmou. Často jste nějak omezeni v jeho používání a obvykle nemáte přístup k jeho zdrojovým kódům."
+msgstr ""
+"To znamená, že software je vlastněn jednotlivcem nebo firmou. Často jste "
+"nějak omezeni v jeho používání a obvykle nemáte přístup k jeho zdrojovým "
+"kódům."
 
 #: src/gs-details-page.ui:1535
 msgid "Unknown Software License"
@@ -1459,8 +1511,7 @@ msgstr "V seznamu aplikací jsou neuložené změny."
 msgid "Use verbose logging"
 msgstr "Použít podrobné zaznamenávání"
 
-#. TRANSLATORS: program name, an application to add and remove software
-#. repositories
+#. TRANSLATORS: program name, an application to add and remove software repositories
 #: src/gs-editor.c:1119
 msgid "GNOME Software Banner Designer"
 msgstr "Návrhář upoutávek do Softwaru GNOME"
@@ -1489,8 +1540,7 @@ msgstr "Celkový dojem"
 msgid "Editor’s Pick"
 msgstr "Doporučujeme"
 
-#. This check button controls whether the application’s banner appears in the
-#. “Featured” category
+#. This check button controls whether the application’s banner appears in the “Featured” category
 #: src/gs-editor.ui:397
 msgid "Category Featured"
 msgstr "Kategorie Významné"
@@ -1581,9 +1631,11 @@ msgstr "Nejsou k dispozici žádné aplikace, které by poskytovaly soubor %s."
 #: src/gs-extras-page.c:337 src/gs-extras-page.c:348 src/gs-extras-page.c:359
 #, c-format
 msgid ""
-"Information about %s, as well as options for how to get missing applications"
-" might be found %s."
-msgstr "Informace o formátu %s, včetně toho, jak získat chybějící aplikace, najdete %s."
+"Information about %s, as well as options for how to get missing applications "
+"might be found %s."
+msgstr ""
+"Informace o formátu %s, včetně toho, jak získat chybějící aplikace, najdete "
+"%s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1606,7 +1658,9 @@ msgstr "%s není k dispozici."
 msgid ""
 "Information about %s, as well as options for how to get an application that "
 "can support this format might be found %s."
-msgstr "Informace o formátu %s, včetně toho, jak získat aplikaci, který umí tento tento formát podporovat, najdete %s."
+msgstr ""
+"Informace o formátu %s, včetně toho, jak získat aplikaci, který umí tento "
+"tento formát podporovat, najdete %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1622,11 +1676,12 @@ msgstr "Pro podporu písma %s nejsou k dispozici žádné fonty."
 msgid ""
 "Information about %s, as well as options for how to get additional fonts "
 "might be found %s."
-msgstr "Informace o písmu %s, včetně toho, jak získat dodatečná písma, najdete %s."
+msgstr ""
+"Informace o písmu %s, včetně toho, jak získat dodatečná písma, najdete %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
-#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1426
+#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1430
 #, c-format
 msgid "No addon codecs are available for the %s format."
 msgstr "Pro formát %s nejsou k dispozici žádné dodatečné kodeky."
@@ -1638,7 +1693,9 @@ msgstr "Pro formát %s nejsou k dispozici žádné dodatečné kodeky."
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format might be found %s."
-msgstr "Informace o kodeku %s, včetně toho, jak získat kodek, který umí tento formát přehrát, najdete %s."
+msgstr ""
+"Informace o kodeku %s, včetně toho, jak získat kodek, který umí tento formát "
+"přehrát, najdete %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1654,7 +1711,9 @@ msgstr "Pro podporu %s nejsou k dispozici žádné prostředky Plasma."
 msgid ""
 "Information about %s, as well as options for how to get additional Plasma "
 "resources might be found %s."
-msgstr "Informace o kodeku %s, včetně toho, jak získat dodatečné prostředky Plasma, najdete %s."
+msgstr ""
+"Informace o kodeku %s, včetně toho, jak získat dodatečné prostředky Plasma, "
+"najdete %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1670,15 +1729,16 @@ msgstr "Pro %s nejsou k dispozici žádné tiskové ovladače."
 msgid ""
 "Information about %s, as well as options for how to get a driver that "
 "supports this printer might be found %s."
-msgstr "Informace o tiskárně %s, včetně toho, jak získat ovladač, který podporuje tuto tiskárnu, najdete %s."
+msgstr ""
+"Informace o tiskárně %s, včetně toho, jak získat ovladač, který podporuje "
+"tuto tiskárnu, najdete %s."
 
 #. TRANSLATORS: hyperlink title
 #: src/gs-extras-page.c:459
 msgid "this website"
 msgstr "tyto webové stránky"
 
-#. TRANSLATORS: no codecs were found. First %s will be replaced by actual
-#. codec name(s), second %s is a link titled "this website"
+#. TRANSLATORS: no codecs were found. First %s will be replaced by actual codec name(s), second %s is a link titled "this website"
 #: src/gs-extras-page.c:463
 #, c-format
 msgid ""
@@ -1687,9 +1747,15 @@ msgid ""
 msgid_plural ""
 "Unfortunately, the %s you were searching for could not be found. Please see "
 "%s for more information."
-msgstr[0] "Bohužel, ale pro „%s“ nebylo nic nalezeno. Na další informace se prosím podívejte na %s."
-msgstr[1] "Bohužel, ale pro „%s“ nebylo nic nalezeno. Na další informace se prosím podívejte na %s."
-msgstr[2] "Bohužel, ale pro „%s“ nebylo nic nalezeno. Na další informace se prosím podívejte na %s."
+msgstr[0] ""
+"Bohužel, ale pro „%s“ nebylo nic nalezeno. Na další informace se prosím "
+"podívejte na %s."
+msgstr[1] ""
+"Bohužel, ale pro „%s“ nebylo nic nalezeno. Na další informace se prosím "
+"podívejte na %s."
+msgstr[2] ""
+"Bohužel, ale pro „%s“ nebylo nic nalezeno. Na další informace se prosím "
+"podívejte na %s."
 
 #: src/gs-extras-page.c:535 src/gs-extras-page.c:591 src/gs-extras-page.c:630
 msgid "Failed to find any search results"
@@ -1714,10 +1780,13 @@ msgstr "Vítejte v aplikaci Software"
 
 #: src/gs-first-run-dialog.ui:66
 msgid ""
-"Software lets you install all the software you need, all from one place. See"
-" our recommendations, browse the categories, or search for the applications "
+"Software lets you install all the software you need, all from one place. See "
+"our recommendations, browse the categories, or search for the applications "
 "you want."
-msgstr "Pomocí aplikace Software můžete nainstalovat veškerý software, který potřebujete, naráz z jediného místa. Podívejte se na naše doporučení, procházejte si kategorie nebo vyhledejte přímo aplikaci, kterou chcete."
+msgstr ""
+"Pomocí aplikace Software můžete nainstalovat veškerý software, který "
+"potřebujete, naráz z jediného místa. Podívejte se na naše doporučení, "
+"procházejte si kategorie nebo vyhledejte přímo aplikaci, kterou chcete."
 
 #: src/gs-first-run-dialog.ui:85
 msgid "_Let’s Go Shopping"
@@ -1867,13 +1936,15 @@ msgstr "Z kategorie kancelář doporučujeme"
 #: src/gs-overview-page.c:974
 msgid ""
 "Provides access to additional software, including web browsers and games."
-msgstr "Poskytuje přístup k dalšímu softwaru, včetně webových prohlížečů a her."
+msgstr ""
+"Poskytuje přístup k dalšímu softwaru, včetně webových prohlížečů a her."
 
 #. TRANSLATORS: this is the proprietary info bar
 #: src/gs-overview-page.c:978
-msgid ""
-"Proprietary software has restrictions on use and access to source code."
-msgstr "Nesvobodný software má omezení v tom, jak jej smíte používat, a v přístupu ke zdrojovým kódům."
+msgid "Proprietary software has restrictions on use and access to source code."
+msgstr ""
+"Nesvobodný software má omezení v tom, jak jej smíte používat, a v přístupu "
+"ke zdrojovým kódům."
 
 #. TRANSLATORS: this is the clickable
 #. * link on the proprietary info bar
@@ -1902,14 +1973,12 @@ msgstr "Významné aplikace"
 msgid "Categories"
 msgstr "Kategorie"
 
-#. Translators: This is a heading for software which has been featured
-#. ('picked') by the distribution.
+#. Translators: This is a heading for software which has been featured ('picked') by the distribution.
 #: src/gs-overview-page.ui:315
 msgid "Editor’s Picks"
 msgstr "Doporučujeme"
 
-#. Translators: This is a heading for software which has been recently
-#. released upstream.
+#. Translators: This is a heading for software which has been recently released upstream.
 #: src/gs-overview-page.ui:359
 msgid "Recent Releases"
 msgstr "Poslední vydání"
@@ -1956,7 +2025,9 @@ msgstr "Opravdu chcete odebrat zdroj %s?"
 msgid ""
 "All applications from %s will be removed, and you will have to re-install "
 "the source to use them again."
-msgstr "Všechny aplikace pocházející ze zdroje %s budou odebrány. Abyste je mohli znovu použít, budete muset zdroj znovu nainstalovat."
+msgstr ""
+"Všechny aplikace pocházející ze zdroje %s budou odebrány. Abyste je mohli "
+"znovu použít, budete muset zdroj znovu nainstalovat."
 
 #. TRANSLATORS: this is a prompt message, and '%s' is an
 #. * application summary, e.g. 'GNOME Clocks'
@@ -1969,14 +2040,18 @@ msgstr "Opravdu chcete odebrat %s?"
 #: src/gs-page.c:684
 #, c-format
 msgid "%s will be removed, and you will have to install it to use it again."
-msgstr "%s bude odebrán a když jej budete chtít použít, budete jej muset znovu nainstalovat."
+msgstr ""
+"%s bude odebrán a když jej budete chtít použít, budete jej muset znovu "
+"nainstalovat."
 
-#: lib/gs-plugin-loader.c:1429
+#: lib/gs-plugin-loader.c:1433
 #, c-format
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format can be found on the website."
-msgstr "Informace o formátu %s, včetně toho, jak získat kodek, který umí tento formát přehrát, najdete na webových stránkách."
+msgstr ""
+"Informace o formátu %s, včetně toho, jak získat kodek, který umí tento "
+"formát přehrát, najdete na webových stránkách."
 
 #: lib/gs-price.c:111
 #, c-format
@@ -2035,7 +2110,9 @@ msgstr "%2$f %1$s"
 msgid ""
 "Some of the currently installed software is not compatible with %s. If you "
 "continue, the following will be automatically removed during the upgrade:"
-msgstr "Některý z právě instalovaného softwaru není kompatibilní s distribucí %s. Pokud budete pokračovat, následujíc se během povýšení odstraní:"
+msgstr ""
+"Některý z právě instalovaného softwaru není kompatibilní s distribucí %s. "
+"Pokud budete pokračovat, následujíc se během povýšení odstraní:"
 
 #: src/gs-removal-dialog.ui:27
 msgid "Incompatible Software"
@@ -2105,8 +2182,7 @@ msgstr "Recenze je příliš krátká"
 msgid "The description is too long"
 msgstr "Recenze je příliš dlouhá"
 
-#. Translators: Title of the dialog box where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Title of the dialog box where the users can write and publish their opinions about the apps.
 #: src/gs-review-dialog.ui:11
 msgid "Post Review"
 msgstr "Příspěvek do recenzí"
@@ -2124,7 +2200,8 @@ msgstr "Hodnocení"
 msgid ""
 "Give a short summary of your review, for example: “Great app, would "
 "recommend”."
-msgstr "Uveďte krátké shrnutí své recenze, například: „Skvělá aplikace, doporučuji“."
+msgstr ""
+"Uveďte krátké shrnutí své recenze, například: „Skvělá aplikace, doporučuji“."
 
 #. Translators: This is where the users enter their opinions about the apps.
 #: src/gs-review-dialog.ui:199
@@ -2144,7 +2221,8 @@ msgstr "celkové hodnocení"
 #. TRANSLATORS: we explain what the action is going to do
 #: src/gs-review-row.c:234
 msgid "You can report reviews for abusive, rude, or discriminatory behavior."
-msgstr "Můžete nahlásit recenze, které jsou urážlivé, sprosté nebo diskriminační."
+msgstr ""
+"Můžete nahlásit recenze, které jsou urážlivé, sprosté nebo diskriminační."
 
 #. TRANSLATORS: we ask the user if they really want to do this
 #: src/gs-review-row.c:239
@@ -2166,8 +2244,7 @@ msgstr "Nahlásit recenzi?"
 msgid "Report"
 msgstr "Nahlásit"
 
-#. Translators: Users can express their opinions about other users' opinions
-#. about the apps.
+#. Translators: Users can express their opinions about other users' opinions about the apps.
 #: src/gs-review-row.ui:112
 msgid "Was this review useful to you?"
 msgstr "Byla pro vás tato recenze přínosná?"
@@ -2257,81 +2334,82 @@ msgstr "Žádná aplikace nebyla nalezena"
 #. TRANSLATORS: this is part of the in-app notification,
 #. * where the %s is a multi-word localised app name
 #. * e.g. 'Getting things GNOME!"
-#: src/gs-shell.c:846 src/gs-shell.c:851 src/gs-shell.c:866 src/gs-shell.c:870
+#: src/gs-shell.c:847 src/gs-shell.c:852 src/gs-shell.c:867 src/gs-shell.c:871
 #, c-format
 msgid "“%s”"
 msgstr "„%s“"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:898
+#: src/gs-shell.c:899
 #, c-format
 msgid "Unable to download firmware updates from %s"
 msgstr "Nelze stáhnout aktualizace firmwaru z %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:904
+#: src/gs-shell.c:905
 #, c-format
 msgid "Unable to download updates from %s"
 msgstr "Nelze stáhnout aktualizace z %s"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:911
+#: src/gs-shell.c:912
 msgid "Unable to download updates"
 msgstr "Nelze stáhnout aktualizace"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:916
+#: src/gs-shell.c:917
 msgid ""
-"Unable to download updates: internet access was required but wasn’t "
-"available"
-msgstr "Nelze stáhout aktualizace: přístup k internetu je nezbytný, ale není k dispozici"
+"Unable to download updates: internet access was required but wasn’t available"
+msgstr ""
+"Nelze stáhout aktualizace: přístup k internetu je nezbytný, ale není k "
+"dispozici"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:925
+#: src/gs-shell.c:926
 #, c-format
 msgid "Unable to download updates from %s: not enough disk space"
 msgstr "Nelze stáhnout aktualizace z %s: není dostatek místa na disku"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:930
+#: src/gs-shell.c:931
 msgid "Unable to download updates: not enough disk space"
 msgstr "Nelze stáhnout aktualizace: není dostatek místa na disku"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:938
+#: src/gs-shell.c:939
 msgid "Unable to download updates: authentication was required"
 msgstr "Nelze stáhnout aktualizace: je vyžadováno ověření"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:943
+#: src/gs-shell.c:944
 msgid "Unable to download updates: authentication was invalid"
 msgstr "Nelze stáhnout aktualizace: ověření nebylo platné"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:948
+#: src/gs-shell.c:949
 msgid ""
 "Unable to download updates: you do not have permission to install software"
 msgstr "Nelze stáhnout aktualizace: nemáte oprávnění instalovat software"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:955
+#: src/gs-shell.c:956
 msgid "Unable to get list of updates"
 msgstr "Nelze získat seznam aktualizací"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the application name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1001
+#: src/gs-shell.c:1002
 #, c-format
 msgid "Unable to install %s as download failed from %s"
 msgstr "Nelze nainstalovat balíček %s, protože selhalo jeho stažení z %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1007
+#: src/gs-shell.c:1008
 #, c-format
 msgid "Unable to install %s as download failed"
 msgstr "Nelze nainstalovat balíček %s, protože selhalo stažení"
@@ -2340,51 +2418,53 @@ msgstr "Nelze nainstalovat balíček %s, protože selhalo stažení"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1019
+#: src/gs-shell.c:1020
 #, c-format
 msgid "Unable to install %s as runtime %s not available"
-msgstr "Nelze nainstalovat balíček %s, protože není k dispozici běhové prostředí %s"
+msgstr ""
+"Nelze nainstalovat balíček %s, protože není k dispozici běhové prostředí %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1025
+#: src/gs-shell.c:1026
 #, c-format
 msgid "Unable to install %s as not supported"
 msgstr "Nelze nainstalovat balíček %s, protože není podporovaný"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1032
+#: src/gs-shell.c:1033
 msgid "Unable to install: internet access was required but wasn’t available"
-msgstr "Nelze nainstalovat: přístup k internetu je nezbytný, ale není k dispozici"
+msgstr ""
+"Nelze nainstalovat: přístup k internetu je nezbytný, ale není k dispozici"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1038
+#: src/gs-shell.c:1039
 msgid "Unable to install: the application has an invalid format"
 msgstr "Nelze nainstalovat: aplikace má neplatný formát"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1043
+#: src/gs-shell.c:1044
 #, c-format
 msgid "Unable to install %s: not enough disk space"
 msgstr "Nelze nainstalovat balíček %s: není dostatek místa na disku"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1051
+#: src/gs-shell.c:1052
 #, c-format
 msgid "Unable to install %s: authentication was required"
 msgstr "Nelze nainstalovat balíček %s: je vyžadováno ověření"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1058
+#: src/gs-shell.c:1059
 #, c-format
 msgid "Unable to install %s: authentication was invalid"
 msgstr "Nelze nainstalovat balíček %s: ověření nebylo platné"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1065
+#: src/gs-shell.c:1066
 #, c-format
 msgid "Unable to install %s: you do not have permission to install software"
 msgstr "Nelze nainstalovat balíček %s: nemáte oprávnění k instalaci softwaru"
@@ -2392,34 +2472,34 @@ msgstr "Nelze nainstalovat balíček %s: nemáte oprávnění k instalaci softwa
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the name of the authentication service,
 #. * e.g. "Ubuntu One"
-#: src/gs-shell.c:1078
+#: src/gs-shell.c:1079
 #, c-format
 msgid "Your %s account has been suspended."
 msgstr "Váš účet %s byl zablokován."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1082
+#: src/gs-shell.c:1083
 msgid "It is not possible to install software until this has been resolved."
 msgstr "Dokud se to nevyřeší, není možné instalovat software."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the clickable link (e.g.
 #. * "http://example.com/what-did-i-do-wrong/")
-#: src/gs-shell.c:1093
+#: src/gs-shell.c:1094
 #, c-format
 msgid "For more information, visit %s."
 msgstr "Pro další informace navštivte %s."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1102
+#: src/gs-shell.c:1103
 #, c-format
 msgid "Unable to install %s: AC power is required"
 msgstr "Nelze nainstalovat balíček %s: je vyžadováno připojené napájení"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1111
+#: src/gs-shell.c:1112
 #, c-format
 msgid "Unable to install %s"
 msgstr "Nelze nainstalovat balíček %s"
@@ -2428,61 +2508,62 @@ msgstr "Nelze nainstalovat balíček %s"
 #. * where the first %s is the app name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1157
+#: src/gs-shell.c:1158
 #, c-format
 msgid "Unable to update %s from %s"
 msgstr "Nelze aktualizovat balíček %s z %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1163
+#: src/gs-shell.c:1164
 #, c-format
 msgid "Unable to update %s as download failed"
 msgstr "Nelze aktualizovat balíček %s, protože selhalo stažení"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1169
+#: src/gs-shell.c:1170
 msgid "Unable to update: internet access was required but wasn’t available"
-msgstr "Nelze aktualizovat: přístup k internetu je nezbytný, ale není k dispozici"
+msgstr ""
+"Nelze aktualizovat: přístup k internetu je nezbytný, ale není k dispozici"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1177
+#: src/gs-shell.c:1178
 #, c-format
 msgid "Unable to update %s: not enough disk space"
 msgstr "Nelze aktualizovat balíček %s: není dostatek místa na disku"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1186
+#: src/gs-shell.c:1187
 #, c-format
 msgid "Unable to update %s: authentication was required"
 msgstr "Nelze aktualizovat balíček %s: je vyžadováno ověření"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1193
+#: src/gs-shell.c:1194
 #, c-format
 msgid "Unable to update %s: authentication was invalid"
 msgstr "Nelze aktualizovat balíček %s: ověření nebylo platné"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1200
+#: src/gs-shell.c:1201
 #, c-format
 msgid "Unable to update %s: you do not have permission to update software"
 msgstr "Nelze aktualizovat balíček %s: nemáte oprávnění k aktualizaci softwaru"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1208
+#: src/gs-shell.c:1209
 #, c-format
 msgid "Unable to update %s: AC power is required"
 msgstr "Nelze aktualizovat balíček %s: je vyžadováno připojené napájení"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1217
+#: src/gs-shell.c:1218
 #, c-format
 msgid "Unable to update %s"
 msgstr "Nelze aktualizovat balíček %s"
@@ -2490,96 +2571,96 @@ msgstr "Nelze aktualizovat balíček %s"
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the distro name (e.g. "Fedora 25") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1262
+#: src/gs-shell.c:1263
 #, c-format
 msgid "Unable to upgrade to %s from %s"
 msgstr "Nelze povýšit na %s z %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the app name (e.g. "GIMP")
-#: src/gs-shell.c:1267
+#: src/gs-shell.c:1268
 #, c-format
 msgid "Unable to upgrade to %s as download failed"
 msgstr "Nelze povýšit na %s, protože selhalo stažení"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1274
+#: src/gs-shell.c:1275
 msgid "Unable to upgrade: internet access was required but wasn’t available"
 msgstr "Nelze povýšit: přístup k internetu je nezbytný, ale není k dispozici"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1282
+#: src/gs-shell.c:1283
 #, c-format
 msgid "Unable to upgrade to %s: not enough disk space"
 msgstr "Nelze povýšit na %s: není dostatek místa na disku"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1291
+#: src/gs-shell.c:1292
 #, c-format
 msgid "Unable to upgrade to %s: authentication was required"
 msgstr "Nelze povýšit na %s: je vyžadováno ověření"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1298
+#: src/gs-shell.c:1299
 #, c-format
 msgid "Unable to upgrade to %s: authentication was invalid"
 msgstr "Nelze povýšit na %s: ověření nebylo platné"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1305
+#: src/gs-shell.c:1306
 #, c-format
 msgid "Unable to upgrade to %s: you do not have permission to upgrade"
 msgstr "Nelze povýšit na %s: nemáte oprávnění k povyšování"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1312
+#: src/gs-shell.c:1313
 #, c-format
 msgid "Unable to upgrade to %s: AC power is required"
 msgstr "Nelze povýšit na %s: je vyžadováno připojené napájení"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1321
+#: src/gs-shell.c:1322
 #, c-format
 msgid "Unable to upgrade to %s"
 msgstr "Nelze povýšit na %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1363
+#: src/gs-shell.c:1364
 #, c-format
 msgid "Unable to remove %s: authentication was required"
 msgstr "Nelze odstranit balíček %s: je vyžadováno ověření"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1369
+#: src/gs-shell.c:1370
 #, c-format
 msgid "Unable to remove %s: authentication was invalid"
 msgstr "Nelze odstranit balíček %s: ověření nebylo platné"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1375
+#: src/gs-shell.c:1376
 #, c-format
 msgid "Unable to remove %s: you do not have permission to remove software"
 msgstr "Nelze odstranit balíček %s: nemáte oprávnění k odstranění softwaru"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1382
+#: src/gs-shell.c:1383
 #, c-format
 msgid "Unable to remove %s: AC power is required"
 msgstr "Nelze odstranit balíček %s: je vyžadováno připojené napájení"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1391
+#: src/gs-shell.c:1392
 #, c-format
 msgid "Unable to remove %s"
 msgstr "Nelze odstranit balíček %s"
@@ -2588,48 +2669,51 @@ msgstr "Nelze odstranit balíček %s"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1437
+#: src/gs-shell.c:1438
 #, c-format
 msgid "Unable to launch %s: %s is not installed"
 msgstr "Nelze spustit aplikaci %s: balíček %s není nainstalovaný"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1444 src/gs-shell.c:1492 src/gs-shell.c:1540
+#: src/gs-shell.c:1445 src/gs-shell.c:1493 src/gs-shell.c:1541
 msgid "Not enough disk space — free up some space and try again"
-msgstr "Nebyl dostatek místa na disku – uvolněte nějaké místo a pak to zkuste znovu"
+msgstr ""
+"Nebyl dostatek místa na disku – uvolněte nějaké místo a pak to zkuste znovu"
 
 #. TRANSLATORS: we failed to get a proper error code
-#: src/gs-shell.c:1452 src/gs-shell.c:1500 src/gs-shell.c:1567
+#: src/gs-shell.c:1453 src/gs-shell.c:1501 src/gs-shell.c:1568
 msgid "Sorry, something went wrong"
 msgstr "Litujeme, ale něco se stalo špatně"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1487
+#: src/gs-shell.c:1488
 msgid "Failed to install file: authentication failed"
 msgstr "Selhala instalace souboru: selhalo ověření"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1534
+#: src/gs-shell.c:1535
 #, c-format
 msgid "Unable to contact %s"
 msgstr "Nelze kontaktovat %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1549
+#: src/gs-shell.c:1550
 #, c-format
 msgid "%s needs to be restarted to use new plugins."
-msgstr "Aplikace %s musí být restartována, aby mohla nový zásuvný modul používat."
+msgstr ""
+"Aplikace %s musí být restartována, aby mohla nový zásuvný modul používat."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1554
+#: src/gs-shell.c:1555
 msgid "This application needs to be restarted to use new plugins."
-msgstr "Tato aplikace musí být restartována, aby mohla nový zásuvný modul používat."
+msgstr ""
+"Tato aplikace musí být restartována, aby mohla nový zásuvný modul používat."
 
 #. TRANSLATORS: need to be connected to the AC power
-#: src/gs-shell.c:1561
+#: src/gs-shell.c:1562
 msgid "AC power is required"
 msgstr "Je vyžadováno připojené napájení"
 
@@ -2637,7 +2721,9 @@ msgstr "Je vyžadováno připojené napájení"
 #. has no software installed from it.
 #: src/gs-sources-dialog.c:98
 msgid "No applications or addons installed; other software might still be"
-msgstr "Žádné aplikace nebo doplňky nenainstalovány; jiný software může být nainstalován"
+msgstr ""
+"Žádné aplikace nebo doplňky nenainstalovány; jiný software může být "
+"nainstalován"
 
 #. TRANSLATORS: This string is used to construct the 'X applications
 #. installed' sentence, describing a software source.
@@ -2696,7 +2782,9 @@ msgstr[2] "%s a %s"
 #. TRANSLATORS: nonfree software
 #: src/gs-sources-dialog.c:257
 msgid "Typically has restrictions on use and access to source code."
-msgstr "Typicky má omezení v tom, jak je smíte používat, a v přístup ke zdrojovým kódům."
+msgstr ""
+"Typicky má omezení v tom, jak je smíte používat, a v přístup ke zdrojovým "
+"kódům."
 
 #. TRANSLATORS: list header
 #: src/gs-sources-dialog.c:278
@@ -2721,7 +2809,9 @@ msgstr "operačního systému"
 msgid ""
 "Software sources can be downloaded from the internet. They give you access "
 "to additional software that is not provided by %s."
-msgstr "Zdroje softwaru lze stáhnout z Internetu. Poskytnou vám přístup k dalšímu softwaru, který není nabízen v rámci %s."
+msgstr ""
+"Zdroje softwaru lze stáhnout z Internetu. Poskytnou vám přístup k dalšímu "
+"softwaru, který není nabízen v rámci %s."
 
 #: src/gs-sources-dialog.ui:155
 msgid "Additional Sources"
@@ -2730,7 +2820,9 @@ msgstr "Další zdroje"
 #: src/gs-sources-dialog.ui:175
 msgid ""
 "Removing a source will also remove any software you have installed from it."
-msgstr "Odebráním zdroje rovněž odeberete případný software, který z něj byl nainstalován."
+msgstr ""
+"Odebráním zdroje rovněž odeberete případný software, který z něj byl "
+"nainstalován."
 
 #: src/gs-sources-dialog.ui:260
 msgid "No software installed from this source"
@@ -2930,29 +3022,38 @@ msgstr "Aktualizace byla zrušena."
 #. * something with no network available
 #: src/gs-update-monitor.c:714
 msgid ""
-"Internet access was required but wasn’t available. Please make sure that you"
-" have internet access and try again."
-msgstr "Je vyžadován přístup k Internetu, ale není dostupný. Zkontrolujte své připojení k Internetu a zkuste to znovu."
+"Internet access was required but wasn’t available. Please make sure that you "
+"have internet access and try again."
+msgstr ""
+"Je vyžadován přístup k Internetu, ale není dostupný. Zkontrolujte své "
+"připojení k Internetu a zkuste to znovu."
 
 #. TRANSLATORS: if the package is not signed correctly
 #: src/gs-update-monitor.c:720
 msgid ""
 "There were security issues with the update. Please consult your software "
 "provider for more details."
-msgstr "S aktualizací nastal bezpečnostní problém. Podrobnosti prosím proberte se svým poskytovatelem softwaru."
+msgstr ""
+"S aktualizací nastal bezpečnostní problém. Podrobnosti prosím proberte se "
+"svým poskytovatelem softwaru."
 
 #. TRANSLATORS: we ran out of disk space
 #: src/gs-update-monitor.c:726
 msgid ""
 "There wasn’t enough disk space. Please free up some space and try again."
-msgstr "Nebyl dostatek místa na disku. Uvolněte prosím nějaké místo a pak to zkuste znovu."
+msgstr ""
+"Nebyl dostatek místa na disku. Uvolněte prosím nějaké místo a pak to zkuste "
+"znovu."
 
 #. TRANSLATORS: We didn't handle the error type
 #: src/gs-update-monitor.c:731
 msgid ""
 "We’re sorry: the update failed to install. Please wait for another update "
 "and try again. If the problem persists, contact your software provider."
-msgstr "Bohužel, instalace aktualizace selhala. Vyčkejte prosím na další aktualizaci a pak to zkuste znovu. Pokud problém přetrvá, kontaktujte svého poskytovatele softwaru."
+msgstr ""
+"Bohužel, instalace aktualizace selhala. Vyčkejte prosím na další aktualizaci "
+"a pak to zkuste znovu. Pokud problém přetrvá, kontaktujte svého "
+"poskytovatele softwaru."
 
 #. TRANSLATORS: Time in 24h format
 #: src/gs-updates-page.c:297
@@ -3114,7 +3215,8 @@ msgstr "Váš operační systém není nadále podporován."
 #. TRANSLATORS: EOL distros do not get important updates
 #: src/gs-updates-page.c:1144
 msgid "This means that it does not receive security updates."
-msgstr "Znamená to, že pro něj již nadále nejsou poskytovány bezpečnostní opravy."
+msgstr ""
+"Znamená to, že pro něj již nadále nejsou poskytovány bezpečnostní opravy."
 
 #. TRANSLATORS: upgrade refers to a major update, e.g. Fedora 25 to 26
 #: src/gs-updates-page.c:1148
@@ -3132,7 +3234,9 @@ msgstr "Možné zpoplatnění"
 msgid ""
 "Checking for updates while using mobile broadband could cause you to incur "
 "charges."
-msgstr "Kontrola aktualizací přes mobilní připojení může být zpoplatněna vaším operátorem."
+msgstr ""
+"Kontrola aktualizací přes mobilní připojení může být zpoplatněna vaším "
+"operátorem."
 
 #. TRANSLATORS: this is a link to the
 #. * control-center network panel
@@ -3171,7 +3275,9 @@ msgstr "Software je aktuální"
 msgid ""
 "Checking for updates when using mobile broadband could cause you to incur "
 "charges"
-msgstr "Kontrola aktualizací přes mobilní připojení může způsobit finanční náklady ze strany operátora připojení"
+msgstr ""
+"Kontrola aktualizací přes mobilní připojení může způsobit finanční náklady "
+"ze strany operátora připojení"
 
 #: src/gs-updates-page.ui:257
 msgid "_Check Anyway"
@@ -3236,22 +3342,27 @@ msgid "App Center"
 msgstr ""
 
 #: src/org.gnome.Software.desktop.in:4
+msgid "More Apps"
+msgstr "Více aplikací"
+
+#: src/org.gnome.Software.desktop.in:5
 msgid "Add, remove or update software on this computer"
 msgstr "Přidat, odebrat nebo aktualizovat software v tomto počítači"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
-#: src/org.gnome.Software.desktop.in:6
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: src/org.gnome.Software.desktop.in:7
 #: src/org.gnome.Software.Editor.desktop.in:6
 msgid "org.gnome.Software"
 msgstr "org.gnome.Software"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
-#: src/org.gnome.Software.desktop.in:12
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: src/org.gnome.Software.desktop.in:13
 msgid ""
-"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;"
-msgstr "aktualizace;povýšení;zdroje;repozitáře;předvolby;nastavení;instalace;odinstalace;odebrání;program;software;aplikace;obchod;"
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;"
+msgstr ""
+"aktualizace;povýšení;zdroje;repozitáře;předvolby;nastavení;instalace;"
+"odinstalace;odebrání;program;software;aplikace;obchod;"
 
 #: src/org.gnome.Software.Editor.desktop.in:3
 msgid "Banner Designer"
@@ -3261,8 +3372,7 @@ msgstr "Návrhář upoutávek"
 msgid "Design the featured banners for GNOME Software"
 msgstr "Navrhujte do Softwaru GNOME upoutávky na významné aplikace"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: src/org.gnome.Software.Editor.desktop.in:13
 msgid "AppStream;Software;App;"
 msgstr "AppStream;software;app;aplikace;"
@@ -3532,100 +3642,111 @@ msgctxt "Menu of Communication & News"
 msgid "Web Browsers"
 msgstr "Webové prohlížeče"
 
-#: plugins/core/gs-desktop-common.c:247
-msgctxt "Menu of Reference"
-msgid "All"
-msgstr "Vše"
-
-#: plugins/core/gs-desktop-common.c:250
-msgctxt "Menu of Reference"
-msgid "Featured"
-msgstr "Významné"
-
-#: plugins/core/gs-desktop-common.c:253
-msgctxt "Menu of Reference"
-msgid "Art"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:256
-msgctxt "Menu of Reference"
-msgid "Biography"
-msgstr "Životopisy"
-
-#: plugins/core/gs-desktop-common.c:259
-msgctxt "Menu of Reference"
-msgid "Comics"
-msgstr "Komiksy"
-
-#: plugins/core/gs-desktop-common.c:262
-msgctxt "Menu of Reference"
-msgid "Fiction"
-msgstr "Beletrie"
-
-#: plugins/core/gs-desktop-common.c:265
-msgctxt "Menu of Reference"
-msgid "Health"
-msgstr "Zdraví"
-
-#: plugins/core/gs-desktop-common.c:268
-msgctxt "Menu of Reference"
-msgid "History"
-msgstr "Historie"
-
-#: plugins/core/gs-desktop-common.c:271
-msgctxt "Menu of Reference"
-msgid "Lifestyle"
-msgstr "Životní styl"
-
-#: plugins/core/gs-desktop-common.c:274
+#: plugins/core/gs-desktop-common.c:242
 msgctxt "Menu of Communication & News"
 msgid "News"
 msgstr "Diskuzní skupiny"
 
+#: plugins/core/gs-desktop-common.c:251
+msgctxt "Menu of Reference"
+msgid "All"
+msgstr "Vše"
+
+#: plugins/core/gs-desktop-common.c:254
+msgctxt "Menu of Reference"
+msgid "Featured"
+msgstr "Významné"
+
+#: plugins/core/gs-desktop-common.c:257
+msgctxt "Menu of Reference"
+msgid "Art"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:260
+msgctxt "Menu of Reference"
+msgid "Biography"
+msgstr "Životopisy"
+
+#: plugins/core/gs-desktop-common.c:263
+msgctxt "Menu of Reference"
+msgid "Comics"
+msgstr "Komiksy"
+
+#: plugins/core/gs-desktop-common.c:266
+msgctxt "Menu of Reference"
+msgid "Feed"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:269
+msgctxt "Menu of Reference"
+msgid "Fiction"
+msgstr "Beletrie"
+
+#: plugins/core/gs-desktop-common.c:272
+msgctxt "Menu of Reference"
+msgid "Health"
+msgstr "Zdraví"
+
+#: plugins/core/gs-desktop-common.c:275
+msgctxt "Menu of Reference"
+msgid "History"
+msgstr "Historie"
+
 #: plugins/core/gs-desktop-common.c:278
+msgctxt "Menu of Reference"
+msgid "Lifestyle"
+msgstr "Životní styl"
+
+#: plugins/core/gs-desktop-common.c:281
+#, fuzzy
+msgctxt "Menu of Reference"
+msgid "News"
+msgstr "Diskuzní skupiny"
+
+#: plugins/core/gs-desktop-common.c:284
 msgctxt "Menu of Reference"
 msgid "Politics"
 msgstr "Politika"
 
-#: plugins/core/gs-desktop-common.c:281
+#: plugins/core/gs-desktop-common.c:287
 msgctxt "Menu of Reference"
 msgid "Sports"
 msgstr "Sporty"
 
 #. TRANSLATORS: this is the menu spec main category for Learning
-#: plugins/core/gs-desktop-common.c:291
+#: plugins/core/gs-desktop-common.c:297
 msgid "Learning"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Game
-#: plugins/core/gs-desktop-common.c:294
+#: plugins/core/gs-desktop-common.c:300
 msgid "Games"
 msgstr "Hry"
 
 #. TRANSLATORS: this is the menu spec main category for Multimedia
-#: plugins/core/gs-desktop-common.c:297
+#: plugins/core/gs-desktop-common.c:303
 msgid "Multimedia"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Work
-#: plugins/core/gs-desktop-common.c:300
+#: plugins/core/gs-desktop-common.c:306
 msgid "Work"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Reference
-#: plugins/core/gs-desktop-common.c:303
+#: plugins/core/gs-desktop-common.c:309
 msgid "Reference & News"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Utilities
-#: plugins/core/gs-desktop-common.c:306
+#: plugins/core/gs-desktop-common.c:312
 msgid "Utilities"
 msgstr "Nástroje"
 
 #. TRANSLATORS: this is the menu spec main category for Dev Tools; it
 #. * should be a relatively short label; as an example, in Portuguese and
 #. * Spanish the direct translation of "Programming" (noun) is used
-#: plugins/core/gs-desktop-common.c:311
+#: plugins/core/gs-desktop-common.c:317
 msgid "Dev Tools"
 msgstr "Vývojářské nástroje"
 
@@ -3651,16 +3772,16 @@ msgstr "Zahrnuje zdokonalení výkonu, stability a bezpečnosti."
 msgid "Downloading featured images…"
 msgstr "Stahují se obrázky k významným aplikacím…"
 
-#: plugins/eos/gs-plugin-eos.c:1249
+#: plugins/eos/gs-plugin-eos.c:1233
 #, c-format
 msgid "Could not launch this application."
 msgstr ""
 
-#: plugins/eos/gs-plugin-eos.c:1305
+#: plugins/eos/gs-plugin-eos.c:1289
 msgid "Endless Platform"
 msgstr ""
 
-#: plugins/eos/gs-plugin-eos.c:1308
+#: plugins/eos/gs-plugin-eos.c:1292
 msgid "Framework for applications"
 msgstr ""
 
@@ -3720,13 +3841,13 @@ msgid "Flatpak is a framework for desktop applications on Linux"
 msgstr "Flatpak je systém pro provozování aplikací na Linuxu"
 
 #. TRANSLATORS: status text when downloading new metadata
-#: plugins/flatpak/gs-flatpak.c:821
+#: plugins/flatpak/gs-flatpak.c:815
 #, c-format
 msgid "Getting flatpak metadata for %s…"
 msgstr "Získávají se metadata Flatpak pro %s…"
 
 #. TRANSLATORS: status text when downloading the RuntimeRepo
-#: plugins/flatpak/gs-flatpak.c:2796
+#: plugins/flatpak/gs-flatpak.c:2803
 msgid "Getting runtime source…"
 msgstr "Získávají se zdroje běhových prostředí…"
 
@@ -3759,7 +3880,8 @@ msgstr "Podpora pro Limba"
 
 #: plugins/limba/org.gnome.Software.Plugin.Limba.metainfo.xml.in:7
 msgid "Limba provides developers a way to easily create software bundles"
-msgstr "Limba poskytuje vývojářům způsob, jak snadno vytvářet softwarové balíčky"
+msgstr ""
+"Limba poskytuje vývojářům způsob, jak snadno vytvářet softwarové balíčky"
 
 #. TRANSLATORS: status text when downloading
 #: plugins/odrs/gs-plugin-odrs.c:205

--- a/po/de.po
+++ b/po/de.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the gnome-software package.
-# 
+#
 # Translators:
 # Alexander Wilms <f.alexander.wilms _at_ gmail.com>, 2013
 # Bernd Homuth <dev@hmt.im>, 2015
@@ -14,14 +14,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-software\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-12 22:31-0700\n"
+"POT-Creation-Date: 2017-11-02 16:28+0100\n"
 "PO-Revision-Date: 2017-10-13 05:53+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
-"Language-Team: German (http://www.transifex.com/endless-mobile-inc/gnome-software/language/de/)\n"
+"Language-Team: German (http://www.transifex.com/endless-mobile-inc/gnome-"
+"software/language/de/)\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:7
@@ -36,7 +37,10 @@ msgstr "Anwendungsverwaltung für GNOME"
 msgid ""
 "Software allows you to find and install new applications and system "
 "extensions and remove existing installed applications."
-msgstr "Software ermöglicht es Ihnen, neue Anwendungen und Systemerweiterungen zu finden und zu installieren sowie bereits installierte Anwendungen zu entfernen."
+msgstr ""
+"Software ermöglicht es Ihnen, neue Anwendungen und Systemerweiterungen zu "
+"finden und zu installieren sowie bereits installierte Anwendungen zu "
+"entfernen."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:14
 msgid ""
@@ -44,7 +48,13 @@ msgid ""
 "descriptions and multiple screenshots per application. Applications can be "
 "found either through browsing the list of categories or by searching. It "
 "also allows you to update your system using an offline update."
-msgstr "GNOME Software präsentiert vorgestellte und beliebte Anwendungen mit nützlichen Beschreibungen und mehreren Bildschirmfotos je Anwendung. Anwendungen können entweder durch Stöbern in den verschiedenen Kategorien oder mithilfe der Suchfunktion gefunden werden. Zudem ermöglicht es Ihnen, Ihr System mittels einer Offline-Aktualisierung auf den neuesten Stand zu bringen."
+msgstr ""
+"GNOME Software präsentiert vorgestellte und beliebte Anwendungen mit "
+"nützlichen Beschreibungen und mehreren Bildschirmfotos je Anwendung. "
+"Anwendungen können entweder durch Stöbern in den verschiedenen Kategorien "
+"oder mithilfe der Suchfunktion gefunden werden. Zudem ermöglicht es Ihnen, "
+"Ihr System mittels einer Offline-Aktualisierung auf den neuesten Stand zu "
+"bringen."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:25
 msgid "Overview panel"
@@ -78,17 +88,22 @@ msgstr "Eine Liste kompatibler Projekte"
 msgid ""
 "This is a list of compatible projects we should show such as GNOME, KDE and "
 "XFCE."
-msgstr "Hier ist eine Liste kompatibler Projekte, die wir anzeigen sollten, z.B. GNOME, KDE und XFCE."
+msgstr ""
+"Hier ist eine Liste kompatibler Projekte, die wir anzeigen sollten, z.B. "
+"GNOME, KDE und XFCE."
 
 #: data/org.gnome.software.gschema.xml:10
 msgid "Whether to manage updates in GNOME Software"
-msgstr "Legt fest, ob Aktualisierungen von GNOME-Software verwaltet werden sollen"
+msgstr ""
+"Legt fest, ob Aktualisierungen von GNOME-Software verwaltet werden sollen"
 
 #: data/org.gnome.software.gschema.xml:11
 msgid ""
 "If disabled, GNOME Software will hide the updates panel and not perform any "
 "automatic updates actions."
-msgstr "Wenn deaktiviert, wird GNOME Software das Aktualisierungsfeld nicht anzeigen und keine automatischen Aktualisierungen durchführen."
+msgstr ""
+"Wenn deaktiviert, wird GNOME Software das Aktualisierungsfeld nicht anzeigen "
+"und keine automatischen Aktualisierungen durchführen."
 
 #: data/org.gnome.software.gschema.xml:15
 msgid "Whether to automatically download updates"
@@ -96,20 +111,29 @@ msgstr "Legt fest, ob Aktualisierungen automatisch geladen werden sollen"
 
 #: data/org.gnome.software.gschema.xml:16
 msgid ""
-"If enabled, GNOME Software automatically downloads updates in the background"
-" and prompts the user to install them when ready."
-msgstr "GNOME-Software lädt Aktualisierungen automatisch und im Hintergrund herunter und fragt den Nutzer, ob es installiert werden soll, wenn diese Einstellung aktiviert ist."
+"If enabled, GNOME Software automatically downloads updates in the background "
+"and prompts the user to install them when ready."
+msgstr ""
+"GNOME-Software lädt Aktualisierungen automatisch und im Hintergrund herunter "
+"und fragt den Nutzer, ob es installiert werden soll, wenn diese Einstellung "
+"aktiviert ist."
 
 #: data/org.gnome.software.gschema.xml:20
 msgid "Whether to automatically refresh when on a metered connection"
-msgstr "Legt fest, ob automatisch aktualisiert werden soll, wenn die Internetverbindung des Rechners volumenbasiert abgerechnet wird."
+msgstr ""
+"Legt fest, ob automatisch aktualisiert werden soll, wenn die "
+"Internetverbindung des Rechners volumenbasiert abgerechnet wird."
 
 #: data/org.gnome.software.gschema.xml:21
 msgid ""
 "If enabled, GNOME Software automatically refreshes in the background even "
 "when using a metered connection (eventually downloading some metadata, "
 "checking for updates, etc., which may incur in costs for the user)."
-msgstr "Wenn aktiviert, wird GNOME Software automatisch im Hintergrund aktualisiert, auch wenn die Internetverbindung des Rechners volumenbasierten abgerechnet wird. Dabei können Metadaten, Aktualisierungsinformationen, usw. heruntergeladen werden, was Kosten für den Nutzer verursachen kann."
+msgstr ""
+"Wenn aktiviert, wird GNOME Software automatisch im Hintergrund aktualisiert, "
+"auch wenn die Internetverbindung des Rechners volumenbasierten abgerechnet "
+"wird. Dabei können Metadaten, Aktualisierungsinformationen, usw. "
+"heruntergeladen werden, was Kosten für den Nutzer verursachen kann."
 
 #: data/org.gnome.software.gschema.xml:25
 msgid "Whether it’s the very first run of GNOME Software"
@@ -121,17 +145,23 @@ msgstr "Sternchenbewertungen neben den Anwendungen anzeigen"
 
 #: data/org.gnome.software.gschema.xml:33
 msgid "Filter applications based on the default branch set for the remote"
-msgstr "Filtern der Anwendungen in Abhängigkeit vom festgelegten Standard-Branch der entfernten Quelle"
+msgstr ""
+"Filtern der Anwendungen in Abhängigkeit vom festgelegten Standard-Branch der "
+"entfernten Quelle"
 
 #: data/org.gnome.software.gschema.xml:37
 msgid "Non-free applications show a warning dialog before install"
-msgstr "Unfreie Anwendungen zeigen einen Warnhinweis, bevor sie installiert werden können"
+msgstr ""
+"Unfreie Anwendungen zeigen einen Warnhinweis, bevor sie installiert werden "
+"können"
 
 #: data/org.gnome.software.gschema.xml:38
 msgid ""
-"When non-free applications are installed a warning dialog can be shown. This"
-" controls if that dialog is suppressed."
-msgstr "Wenn unfreie Anwendungen installiert werden, kann dieser Dialog angezeigt werden. Diese Einstellung legt fest, ob die Meldung unterdrückt werden soll."
+"When non-free applications are installed a warning dialog can be shown. This "
+"controls if that dialog is suppressed."
+msgstr ""
+"Wenn unfreie Anwendungen installiert werden, kann dieser Dialog angezeigt "
+"werden. Diese Einstellung legt fest, ob die Meldung unterdrückt werden soll."
 
 #: data/org.gnome.software.gschema.xml:42
 msgid "A list of popular applications"
@@ -139,7 +169,9 @@ msgstr "Eine Liste beliebter Anwendungen"
 
 #: data/org.gnome.software.gschema.xml:43
 msgid "A list of applications to use, overriding the system defined ones."
-msgstr "Eine Liste von Anwendungen, die verwendet werden sollen; überschreibt die Systemeinstellungen."
+msgstr ""
+"Eine Liste von Anwendungen, die verwendet werden sollen; überschreibt die "
+"Systemeinstellungen."
 
 #: data/org.gnome.software.gschema.xml:47
 msgid "The list of extra sources that have been previously enabled"
@@ -149,7 +181,9 @@ msgstr "Die Liste der zusätzlichen Quellen, die bereits aktiviert worden sind"
 msgid ""
 "The list of sources that have been previously enabled when installing third-"
 "party applications."
-msgstr "Die Liste von Quellen, die bei vorhergehenden Installationen von Drittanbieter-Anwendungen aktiviert worden sind."
+msgstr ""
+"Die Liste von Quellen, die bei vorhergehenden Installationen von "
+"Drittanbieter-Anwendungen aktiviert worden sind."
 
 #: data/org.gnome.software.gschema.xml:52
 msgid "The last update check timestamp"
@@ -161,7 +195,9 @@ msgstr "Zeitstempel der Benachrichtigung zur letzten Systemaktualisierung"
 
 #: data/org.gnome.software.gschema.xml:60
 msgid "The timestamp of the first security update, cleared after update"
-msgstr "Der Zeitstempel der ersten Sicherheitsaktualisierung, wird entfernt nach einer Aktualisierung"
+msgstr ""
+"Der Zeitstempel der ersten Sicherheitsaktualisierung, wird entfernt nach "
+"einer Aktualisierung"
 
 #: data/org.gnome.software.gschema.xml:64
 msgid "The last update timestamp"
@@ -169,14 +205,21 @@ msgstr "Zeitstempel der letzten Aktualisierung"
 
 #: data/org.gnome.software.gschema.xml:68
 msgid "The age in seconds to verify the upstream screenshot is still valid"
-msgstr "Das Alter in Sekunden, bis zu dem ein Bildschirmfoto des Upstream-Projekts noch als aktuell angesehen wird"
+msgstr ""
+"Das Alter in Sekunden, bis zu dem ein Bildschirmfoto des Upstream-Projekts "
+"noch als aktuell angesehen wird"
 
 #: data/org.gnome.software.gschema.xml:69
 msgid ""
 "Choosing a larger value will mean less round-trips to the remote server but "
-"updates to the screenshots may take longer to show to the user. A value of 0"
-" means to never check the server if the image already exists in the cache."
-msgstr "Die Wahl eines größeren Werts verursacht weniger Datenaustausch mit dem entfernten Server, aber Aktualisierungen der Bildschirmfotos benötigen mehr Zeit, bis sie angezeigt werden. Ein Wert von 0 bedeutet, dass der Server niemals abgefragt wird, wenn das Bild bereits im Zwischenspeicher vorhanden ist."
+"updates to the screenshots may take longer to show to the user. A value of 0 "
+"means to never check the server if the image already exists in the cache."
+msgstr ""
+"Die Wahl eines größeren Werts verursacht weniger Datenaustausch mit dem "
+"entfernten Server, aber Aktualisierungen der Bildschirmfotos benötigen mehr "
+"Zeit, bis sie angezeigt werden. Ein Wert von 0 bedeutet, dass der Server "
+"niemals abgefragt wird, wenn das Bild bereits im Zwischenspeicher vorhanden "
+"ist."
 
 #: data/org.gnome.software.gschema.xml:78
 msgid "The server to use for application reviews"
@@ -188,11 +231,14 @@ msgstr "Mindest-Karma-Punktestand für Rezensionen"
 
 #: data/org.gnome.software.gschema.xml:83
 msgid "Reviews with karma less than this number will not be shown."
-msgstr "Rezensionen mit einem Karma unterhalb der angegebenen Punktezahl werden nicht angezeigt."
+msgstr ""
+"Rezensionen mit einem Karma unterhalb der angegebenen Punktezahl werden "
+"nicht angezeigt."
 
 #: data/org.gnome.software.gschema.xml:87
 msgid "A list of official sources that should not be considered 3rd party"
-msgstr "Eine Liste von offiziellen Quellen, die nicht als Drittanbieter gelten sollen"
+msgstr ""
+"Eine Liste von offiziellen Quellen, die nicht als Drittanbieter gelten sollen"
 
 #: data/org.gnome.software.gschema.xml:91
 msgid "A list of official sources that should be considered free software"
@@ -200,14 +246,16 @@ msgstr "Eine Liste von offiziellen Quellen, die als freie Software gelten soll"
 
 #: data/org.gnome.software.gschema.xml:95
 msgid ""
-"The licence URL to use when an application should be considered free "
-"software"
-msgstr "Die Adresse der genutzten Lizenz für den Fall, dass die Software als frei angesehen werden kann."
+"The licence URL to use when an application should be considered free software"
+msgstr ""
+"Die Adresse der genutzten Lizenz für den Fall, dass die Software als frei "
+"angesehen werden kann."
 
 #: data/org.gnome.software.gschema.xml:99
-msgid ""
-"Install bundled applications for all users on the system where possible"
-msgstr "Mitgelieferte Anwendungen für alle Benutzer auf dem System installieren, sofern möglich"
+msgid "Install bundled applications for all users on the system where possible"
+msgstr ""
+"Mitgelieferte Anwendungen für alle Benutzer auf dem System installieren, "
+"sofern möglich"
 
 #: data/org.gnome.software.gschema.xml:103
 msgid "Show the folder management UI"
@@ -223,11 +271,14 @@ msgstr "Systemaktualisierungen für Vorab-Veröffentlichungen anbieten"
 
 #: data/org.gnome.software.gschema.xml:115
 msgid "Show some UI elements informing the user that an app is non-free"
-msgstr "Elemente der grafischen Oberfläche anzeigen, die den Benutzer auf den unfreien Status einer Anwendung hinweisen"
+msgstr ""
+"Elemente der grafischen Oberfläche anzeigen, die den Benutzer auf den "
+"unfreien Status einer Anwendung hinweisen"
 
 #: data/org.gnome.software.gschema.xml:119
 msgid "Show the prompt to install nonfree software sources"
-msgstr "Abfrage anzeigen, ob unfreie Softwarequellen eingerichtet werden sollen"
+msgstr ""
+"Abfrage anzeigen, ob unfreie Softwarequellen eingerichtet werden sollen"
 
 #: data/org.gnome.software.gschema.xml:123
 msgid "Show non-free software in search results"
@@ -249,7 +300,9 @@ msgstr "Eine Liste unfreier Quellen, die optional aktiviert werden können"
 msgid ""
 "A list of URLs pointing to appstream files that will be downloaded into an "
 "app-info folder"
-msgstr "Eine Liste von Adressen von Appstream-Dateien, die in einen app-info-Ordner heruntergeladen werden"
+msgstr ""
+"Eine Liste von Adressen von Appstream-Dateien, die in einen app-info-Ordner "
+"heruntergeladen werden"
 
 #: data/org.gnome.software.gschema.xml:143
 msgid "Install the AppStream files to a system-wide location for all users"
@@ -273,8 +326,7 @@ msgstr "Software-Installation"
 msgid "Install selected software on the system"
 msgstr "Gewählte Software auf dem System installieren"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 #: src/gnome-software-local-file.desktop.in:10
 msgid "system-software-install"
 msgstr "system-software-install"
@@ -301,14 +353,12 @@ msgstr "Zurück gehen"
 msgid "_All"
 msgstr "_Alle"
 
-#. Translators: A label for a button to show only software which is already
-#. installed.
+#. Translators: A label for a button to show only software which is already installed.
 #: src/gnome-software.ui:104
 msgid "_Installed"
 msgstr "_Installiert"
 
-#. Translators: A label for a button to show only updates which are available
-#. to install.
+#. Translators: A label for a button to show only updates which are available to install.
 #: src/gnome-software.ui:155
 msgid "_Updates"
 msgstr "A_ktualisierungen"
@@ -356,7 +406,7 @@ msgstr "Installiert"
 
 #. TRANSLATORS: this is a button next to the search results that
 #. * shows the status of an application being installed
-#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:443
+#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:439
 msgid "Installing"
 msgstr "Installieren"
 
@@ -371,7 +421,7 @@ msgid "Folder Name"
 msgstr "Ordnername"
 
 #: src/gs-app-folder-dialog.c:321 src/gs-app-folder-dialog.ui:16
-#: src/gs-details-page.c:383 src/gs-details-page.ui:342 src/gs-editor.c:623
+#: src/gs-details-page.c:379 src/gs-details-page.ui:342 src/gs-editor.c:623
 #: src/gs-editor.c:655 src/gs-installed-page.c:609 src/gs-removal-dialog.ui:33
 #: src/gs-review-dialog.ui:23 src/gs-upgrade-banner.ui:131
 msgid "_Cancel"
@@ -386,90 +436,102 @@ msgid "Add to Application Folder"
 msgstr "Zu Anwendungsordner hinzufügen"
 
 #. TRANSLATORS: this is a command line option
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "Start up mode: either ‘updates’, ‘updated’, ‘installed’ or ‘overview’"
-msgstr "Startmodus: entweder »updates« (Aktualisierungen), »updated« (aktualisiert), »installed« (installiert) oder »overview« (Übersicht)"
+msgstr ""
+"Startmodus: entweder »updates« (Aktualisierungen), »updated« (aktualisiert), "
+"»installed« (installiert) oder »overview« (Übersicht)"
 
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "MODE"
 msgstr "MODUS"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "Search for applications"
 msgstr "Nach Anwendungen suchen"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "SEARCH"
 msgstr "SUCHE"
 
-#: src/gs-application.c:105
+#: src/gs-application.c:133
 msgid "Show application details (using application ID)"
 msgstr "Details zur Anwendung zeigen (mit der Kennung der Anwendung)"
 
-#: src/gs-application.c:105 src/gs-application.c:109
+#: src/gs-application.c:133 src/gs-application.c:137
 msgid "ID"
 msgstr "Kennung"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "Show application details (using package name)"
 msgstr "Details zur Anwendung zeigen (mit Hilfe des Paketnamens)"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "PKGNAME"
 msgstr "PAKETNAME"
 
-#: src/gs-application.c:109
+#: src/gs-application.c:137
 msgid "Install the application (using application ID)"
 msgstr "Anwendung installieren (mit der Kennung der Anwendung)"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "Open a local package file"
 msgstr "Ein lokales Paket öffnen"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "FILENAME"
 msgstr "DATEINAME"
 
-#: src/gs-application.c:113
+#: src/gs-application.c:141
 msgid ""
 "The kind of interaction expected for this action: either ‘none’, ‘notify’, "
 "or ‘full’"
-msgstr "Die erwartete Interaktion für diese Aktion. Entweder »none« (keine), »notify« (benachrichtigen) oder »full« (vollständig)"
+msgstr ""
+"Die erwartete Interaktion für diese Aktion. Entweder »none« (keine), "
+"»notify« (benachrichtigen) oder »full« (vollständig)"
 
-#: src/gs-application.c:116
+#: src/gs-application.c:144
 msgid "Show verbose debugging information"
 msgstr "Ausführliche Informationen zur Fehlerdiagnose anzeigen"
 
-#: src/gs-application.c:118
+#: src/gs-application.c:146
 msgid "Show profiling information for the service"
 msgstr "Profiling-Informationen für den Dienst anzeigen"
 
-#: src/gs-application.c:120
+#: src/gs-application.c:148
 msgid "Quit the running instance"
 msgstr "Die laufende Instanz beenden"
 
-#: src/gs-application.c:122
+#: src/gs-application.c:150
 msgid "Prefer local file sources to AppStream"
 msgstr "Lokale Quelldateien dem AppStream vorziehen"
 
-#: src/gs-application.c:124
+#: src/gs-application.c:152
 msgid "Show version number"
 msgstr "Versionsnummer anzeigen"
 
-#: src/gs-application.c:325
+#: src/gs-application.c:358
 msgid "translator-credits"
-msgstr "Eduard Gotwig <gotwig@ubuntu.com>, 2013\nChristian Kirbach <christian.kirbach@gmail.com>, 2013\nBenjamin Steinwender <b@stbe.at>, 2014\nPaul Seyfert <pseyfert@mathphys.fsk.uni-heidelberg.de>, 2015, 2017\nBernd Homuth <dev@hmt.im>, 2015, 2016\nChristian Kirbach <christian.kirbach@gmail.com>, 2015\nJ.M. Ruetter <jm@jublo.net>, 2015\nMario Blättermann <mario.blaettermann@gmail.com>, 2016"
+msgstr ""
+"Eduard Gotwig <gotwig@ubuntu.com>, 2013\n"
+"Christian Kirbach <christian.kirbach@gmail.com>, 2013\n"
+"Benjamin Steinwender <b@stbe.at>, 2014\n"
+"Paul Seyfert <pseyfert@mathphys.fsk.uni-heidelberg.de>, 2015, 2017\n"
+"Bernd Homuth <dev@hmt.im>, 2015, 2016\n"
+"Christian Kirbach <christian.kirbach@gmail.com>, 2015\n"
+"J.M. Ruetter <jm@jublo.net>, 2015\n"
+"Mario Blättermann <mario.blaettermann@gmail.com>, 2016"
 
 #. TRANSLATORS: this is the title of the about window, e.g.
 #. * 'About Software' or 'About Application Installer' where the %s is
 #. * the application name chosen by the distro
-#: src/gs-application.c:332
+#: src/gs-application.c:365
 #, c-format
 msgid "About %s"
 msgstr "Info zu %s"
 
 #. TRANSLATORS: well, we seem to think so, anyway
-#: src/gs-application.c:336
+#: src/gs-application.c:369
 msgid "A nice way to manage the software on your system."
 msgstr "Ein einfacher Weg, um Software auf Ihrem System zu verwalten."
 
@@ -584,7 +646,7 @@ msgid "All"
 msgstr "Alle"
 
 #. TRANSLATORS: this is a subcategory of featured apps
-#: lib/gs-category.c:202 src/gs-shell.c:2180
+#: lib/gs-category.c:202 src/gs-shell.c:2181
 msgid "Featured"
 msgstr "Vorgestellt"
 
@@ -594,9 +656,11 @@ msgstr "Erweiterungseinstellungen"
 
 #: src/gs-category-page.ui:110
 msgid ""
-"Extensions are used at your own risk. If you have any system problems, it is"
-" recommended to disable them."
-msgstr "Erweiterungen werden auf eigene Gefahr verwendet. Bei Systemproblemen wird empfohlen, sie wieder abzuschalten."
+"Extensions are used at your own risk. If you have any system problems, it is "
+"recommended to disable them."
+msgstr ""
+"Erweiterungen werden auf eigene Gefahr verwendet. Bei Systemproblemen wird "
+"empfohlen, sie wieder abzuschalten."
 
 #. TRANSLATORS: the user isn't reading the question
 #: lib/gs-cmd.c:205
@@ -619,7 +683,8 @@ msgstr "Betriebssystemaktualisierungen sind jetzt installiert"
 #. * have been successfully installed
 #: src/gs-common.c:138
 msgid "Recently installed updates are available to review"
-msgstr "Kürzlich installierte Aktualisierungen stehen für Bewertungen zur Verfügung"
+msgstr ""
+"Kürzlich installierte Aktualisierungen stehen für Bewertungen zur Verfügung"
 
 #. TRANSLATORS: this is the summary of a notification that an application
 #. * has been successfully installed
@@ -652,13 +717,16 @@ msgstr "Soll die Softwarequelle von Drittanbietern aktiviert werden?"
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
 #. * 2. Software source name, e.g. fedora-optional
+#.
 #: src/gs-common.c:232
 #, c-format
 msgid ""
 "%s is not <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
-"source_software\">free and open source software</a>, and is provided by "
-"“%s”."
-msgstr "%s ist nicht <a href=\"https://en.wikipedia.org/wiki/Free_and_open-source_software\">freie und quelloffene Software</a> und wird durch »%s« bereitgestellt."
+"source_software\">free and open source software</a>, and is provided by “%s”."
+msgstr ""
+"%s ist nicht <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
+"source_software\">freie und quelloffene Software</a> und wird durch »%s« "
+"bereitgestellt."
 
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
@@ -671,18 +739,24 @@ msgstr "%s wird durch »%s« zur Verfügung gestellt."
 #. TRANSLATORS: a software source is a repo
 #: src/gs-common.c:252
 msgid "This software source must be enabled to continue installation."
-msgstr "Diese Softwarequelle muss aktiviert werden, um mit der Installation fortzufahren."
+msgstr ""
+"Diese Softwarequelle muss aktiviert werden, um mit der Installation "
+"fortzufahren."
 
 #. TRANSLATORS: Laws are geographical, urgh...
 #: src/gs-common.c:262
 #, c-format
 msgid "It may be illegal to install or use %s in some countries."
-msgstr "In manchen Ländern ist es möglicherweise illegal, %s zu installieren oder zu benutzen."
+msgstr ""
+"In manchen Ländern ist es möglicherweise illegal, %s zu installieren oder zu "
+"benutzen."
 
 #. TRANSLATORS: Laws are geographical, urgh...
 #: src/gs-common.c:268
 msgid "It may be illegal to install or use this codec in some countries."
-msgstr "In manchen Ländern ist es möglicherweise illegal, diesen Codec zu installieren oder zu benutzen."
+msgstr ""
+"In manchen Ländern ist es möglicherweise illegal, diesen Codec zu "
+"installieren oder zu benutzen."
 
 #. TRANSLATORS: this is button text to not ask about non-free content again
 #: src/gs-common.c:275
@@ -699,7 +773,8 @@ msgstr "Aktivieren und installieren"
 #. * but google might know what they mean
 #: src/gs-common.c:429
 msgid "Detailed errors from the package manager follow:"
-msgstr "Siehe nachfolgend die detaillierten Fehlermeldungen von der Paketverwaltung:"
+msgstr ""
+"Siehe nachfolgend die detaillierten Fehlermeldungen von der Paketverwaltung:"
 
 #: src/gs-common.c:448 src/gs-details-page.ui:590
 msgid "Details"
@@ -733,12 +808,16 @@ msgstr "Keine Gewalt in Fantasy"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:90
 msgid "Characters in unsafe situations easily distinguishable from reality"
-msgstr "Figuren in unsicheren Situationen, die einfach von der Realität zu unterscheiden sind"
+msgstr ""
+"Figuren in unsicheren Situationen, die einfach von der Realität zu "
+"unterscheiden sind"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:93
 msgid "Characters in aggressive conflict easily distinguishable from reality"
-msgstr "Figuren in aggressiven Konflikten, die einfach von der Realität zu unterscheiden sind"
+msgstr ""
+"Figuren in aggressiven Konflikten, die einfach von der Realität zu "
+"unterscheiden sind"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:96
@@ -758,7 +837,9 @@ msgstr "Harmlose realistische Figuren in unsicheren Situationen"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:105
 msgid "Depictions of realistic characters in aggressive conflict"
-msgstr "Darstellung von realistischen Charakteren, die im aggressiven Konflikt zueinander stehen"
+msgstr ""
+"Darstellung von realistischen Charakteren, die im aggressiven Konflikt "
+"zueinander stehen"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:108
@@ -928,7 +1009,8 @@ msgstr "Diskriminierung mit dem Ziel der emotionellen Kränkung"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:207
 msgid "Explicit discrimination based on gender, sexuality, race or religion"
-msgstr "Explizite Diskriminierung von Geschlecht, Sexualität, Rasse oder Religion"
+msgstr ""
+"Explizite Diskriminierung von Geschlecht, Sexualität, Rasse oder Religion"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:210
@@ -1013,7 +1095,8 @@ msgstr "Nicht kontrollierte Audio- oder Video-Chat-Funktion zwischen Spielern"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:258
 msgid "No sharing of social network usernames or email addresses"
-msgstr "Kein Teilen von Benutzernamen in sozialen Netzwerken oder E-Mail-Adressen"
+msgstr ""
+"Kein Teilen von Benutzernamen in sozialen Netzwerken oder E-Mail-Adressen"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:261
@@ -1040,14 +1123,12 @@ msgstr "Kein Teilen des physischen Aufenthaltsortes mit anderen Benutzern"
 msgid "Sharing physical location to other users"
 msgstr "Teilen des physischen Aufenthaltsortes mit anderen Benutzern"
 
-#. TRANSLATORS: this is a what we use in notifications if the app's name is
-#. unknown
+#. TRANSLATORS: this is a what we use in notifications if the app's name is unknown
 #: src/gs-dbus-helper.c:294
 msgid "An application"
 msgstr "Eine Anwendung"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. MIME types.
+#. TRANSLATORS: this is a notification displayed when an app needs additional MIME types.
 #: src/gs-dbus-helper.c:300
 #, c-format
 msgid "%s is requesting additional file format support."
@@ -1058,8 +1139,7 @@ msgstr "%s verlangt Unterstützung für zusätzliche Dateiformate."
 msgid "Additional MIME Types Required"
 msgstr "Es werden zusätzliche MIME-Typen benötigt"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. fonts.
+#. TRANSLATORS: this is a notification displayed when an app needs additional fonts.
 #: src/gs-dbus-helper.c:306
 #, c-format
 msgid "%s is requesting additional fonts."
@@ -1070,8 +1150,7 @@ msgstr "%s benötigt zusätzliche Schriftarten."
 msgid "Additional Fonts Required"
 msgstr "Zusätzliche Schriftarten werden benötigt"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. codecs.
+#. TRANSLATORS: this is a notification displayed when an app needs additional codecs.
 #: src/gs-dbus-helper.c:312
 #, c-format
 msgid "%s is requesting additional multimedia codecs."
@@ -1082,8 +1161,7 @@ msgstr "%s benötigt zusätzliche Multimedia-Codecs."
 msgid "Additional Multimedia Codecs Required"
 msgstr "Zusätzliche Multimedia-Codecs werden benötigt"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. printer drivers.
+#. TRANSLATORS: this is a notification displayed when an app needs additional printer drivers.
 #: src/gs-dbus-helper.c:318
 #, c-format
 msgid "%s is requesting additional printer drivers."
@@ -1094,8 +1172,7 @@ msgstr "%s benötigt zusätzliche Druckertreiber."
 msgid "Additional Printer Drivers Required"
 msgstr "Zusätzliche Druckertreiber werden benötigt"
 
-#. TRANSLATORS: this is a notification displayed when an app wants to install
-#. additional packages.
+#. TRANSLATORS: this is a notification displayed when an app wants to install additional packages.
 #: src/gs-dbus-helper.c:324
 #, c-format
 msgid "%s is requesting additional packages."
@@ -1115,14 +1192,14 @@ msgstr "Software suchen"
 #. * can be installed
 #. TRANSLATORS: button text in the header when firmware
 #. * can be live-installed
-#: src/gs-details-page.c:281 src/gs-details-page.c:312
-#: src/gs-details-page.ui:206 src/gs-upgrade-banner.ui:146
+#: src/gs-details-page.c:280 src/gs-details-page.c:310
+#: src/gs-details-page.ui:237 src/gs-upgrade-banner.ui:146
 msgid "_Install"
 msgstr "_Installieren"
 
 #. TRANSLATORS: button text in the header when an application
 #. * can be live-updated
-#: src/gs-details-page.c:316
+#: src/gs-details-page.c:314
 msgid "_Update"
 msgstr "Akt_ualisieren"
 
@@ -1130,67 +1207,70 @@ msgstr "Akt_ualisieren"
 #. * be installed.
 #. * The ellipsis indicates that further steps are required,
 #. * e.g. enabling software sources or the like
-#: src/gs-details-page.c:330
+#: src/gs-details-page.c:326
 msgid "_Install…"
 msgstr "_Installieren …"
 
 #. TRANSLATORS: button text in the header when an application can be erased
-#: src/gs-details-page.c:377 src/gs-details-page.ui:547
+#: src/gs-details-page.c:373 src/gs-details-page.ui:547
 msgid "_Uninstall"
 msgstr "_Deinstallieren"
 
-#: src/gs-details-page.c:438 src/gs-sources-dialog.c:513
+#: src/gs-details-page.c:434 src/gs-sources-dialog.c:513
 msgid "Removing…"
 msgstr "Wird entfernt …"
 
 #. TRANSLATORS: this is the warning box
-#: src/gs-details-page.c:748
+#: src/gs-details-page.c:744
 msgid ""
 "This application can only be used when there is an active internet "
 "connection."
-msgstr "Diese Anwendung kann nur bei bestehender Internetverbindung verwendet werden."
+msgstr ""
+"Diese Anwendung kann nur bei bestehender Internetverbindung verwendet werden."
 
 #. TRANSLATORS: this is where the version is not known
-#: src/gs-details-page.c:892
+#: src/gs-details-page.c:888
 msgctxt "version"
 msgid "Unknown"
 msgstr "Unbekannt"
 
 #. TRANSLATORS: this is where we don't know the origin of the
 #. * application
-#: src/gs-details-page.c:971
+#: src/gs-details-page.c:967
 msgctxt "origin"
 msgid "Unknown"
 msgstr "Unbekannt"
 
 #. TRANSLATORS: we need a remote server to process
-#: src/gs-details-page.c:1378
+#: src/gs-details-page.c:1374
 msgid "You need internet access to write a review"
-msgstr "Sie brauchen eine Verbindung mit dem Internet, um eine Bewertung abgeben zu können"
+msgstr ""
+"Sie brauchen eine Verbindung mit dem Internet, um eine Bewertung abgeben zu "
+"können"
 
-#: src/gs-details-page.c:1507
+#: src/gs-details-page.c:1503
 #, c-format
 msgid "Unable to find “%s”"
 msgstr "»%s« konnte nicht gefunden werden"
 
 #. TRANSLATORS: see the wikipedia page
-#: src/gs-details-page.c:2087
+#: src/gs-details-page.c:2083
 msgid "Public domain"
 msgstr "Gemeinfrei"
 
 #. TRANSLATORS: see GNU page
-#: src/gs-details-page.c:2103 src/gs-details-page.ui:1397
+#: src/gs-details-page.c:2099 src/gs-details-page.ui:1397
 msgid "Free Software"
 msgstr "Freie Software"
 
 #. TRANSLATORS: for the free software popover
-#: src/gs-details-page.c:2160
+#: src/gs-details-page.c:2156
 msgid "Users are bound by the following license:"
 msgid_plural "Users are bound by the following licenses:"
 msgstr[0] "Benutzer sind an die folgende Lizenz gebunden:"
 msgstr[1] "Benutzer sind an die folgenden Lizenzen gebunden:"
 
-#: src/gs-details-page.c:2176 src/gs-details-page.ui:1506
+#: src/gs-details-page.c:2172 src/gs-details-page.ui:1506
 msgid "More information"
 msgstr "Weitere Informationen"
 
@@ -1198,15 +1278,13 @@ msgstr "Weitere Informationen"
 msgid "Details page"
 msgstr "Seite mit Details"
 
-#. Translators: A label for a button to add a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:228
+#. Translators: A label for a button to add a shortcut to the selected application.
+#: src/gs-details-page.ui:209
 msgid "_Add to Desktop"
 msgstr "_Zur Arbeitsfläche hinzufügen"
 
-#. Translators: A label for a button to remove a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:245
+#. Translators: A label for a button to remove a shortcut to the selected application.
+#: src/gs-details-page.ui:226
 msgid "_Remove from Desktop"
 msgstr "_Von der Arbeitsfläche entfernen"
 
@@ -1227,7 +1305,9 @@ msgstr "Software-Quelle eingeschlossen"
 msgid ""
 "This application includes a software source which provides updates, as well "
 "as access to other software."
-msgstr "Diese Anwendung enthält eine Software-Quelle, die Aktualisierungen als auch Zugriff auf weitere Software anbietet."
+msgstr ""
+"Diese Anwendung enthält eine Software-Quelle, die Aktualisierungen als auch "
+"Zugriff auf weitere Software anbietet."
 
 #: src/gs-details-page.ui:500
 msgid "No Software Source Included"
@@ -1237,16 +1317,19 @@ msgstr "Keine Software-Quelle eingeschlossen"
 msgid ""
 "This application does not include a software source. It will not be updated "
 "with new versions."
-msgstr "Diese Anwendung enthält keine Software-Quelle. Sie wird nicht mit neuen Versionen aktualisiert."
+msgstr ""
+"Diese Anwendung enthält keine Software-Quelle. Sie wird nicht mit neuen "
+"Versionen aktualisiert."
 
 #: src/gs-details-page.ui:515
 msgid ""
 "This software is already provided by your distribution and should not be "
 "replaced."
-msgstr "Diese Software wird bereits von Ihrer Distribution angeboten und sollte nicht ersetzt werden."
+msgstr ""
+"Diese Software wird bereits von Ihrer Distribution angeboten und sollte "
+"nicht ersetzt werden."
 
-#. Translators: a repository file used for installing software has been
-#. discovered.
+#. Translators: a repository file used for installing software has been discovered.
 #: src/gs-details-page.ui:528
 msgid "Software Source Identified"
 msgstr "Software-Quelle identifiziert"
@@ -1255,7 +1338,9 @@ msgstr "Software-Quelle identifiziert"
 msgid ""
 "Adding this software source will give you access to additional software and "
 "upgrades."
-msgstr "Hinzufügen dieser Software-Quelle gewährt Ihnen Zugriff auf zusätzliche Software und Systemaktualisierungen."
+msgstr ""
+"Hinzufügen dieser Software-Quelle gewährt Ihnen Zugriff auf zusätzliche "
+"Software und Systemaktualisierungen."
 
 #: src/gs-details-page.ui:530
 msgid "Only use software sources that you trust."
@@ -1347,14 +1432,12 @@ msgstr "Erweiterungen"
 msgid "Selected add-ons will be installed with the application."
 msgstr "Die gewählten Erweiterungen werden mit der Anwendung installiert."
 
-#. Translators: Header of the section with other users' opinions about the
-#. app.
+#. Translators: Header of the section with other users' opinions about the app.
 #: src/gs-details-page.ui:1233
 msgid "Reviews"
 msgstr "Rezensionen"
 
-#. Translators: Button opening a dialog where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Button opening a dialog where the users can write and publish their opinions about the apps.
 #: src/gs-details-page.ui:1249
 msgid "_Write a Review"
 msgstr "Eine _Rezension schreiben"
@@ -1366,9 +1449,11 @@ msgstr "_Mehr anzeigen"
 
 #: src/gs-details-page.ui:1414
 msgid ""
-"This means that the software can be freely run, copied, distributed, studied"
-" and modified."
-msgstr "Dies bedeutet, dass die Software frei eingesetzt, kopiert, weitergegeben, inspiziert und verändert werden darf."
+"This means that the software can be freely run, copied, distributed, studied "
+"and modified."
+msgstr ""
+"Dies bedeutet, dass die Software frei eingesetzt, kopiert, weitergegeben, "
+"inspiziert und verändert werden darf."
 
 #: src/gs-details-page.ui:1473
 msgid "Proprietary Software"
@@ -1379,7 +1464,10 @@ msgid ""
 "This means that the software is owned by an individual or a company. There "
 "are often restrictions on its use and its source code cannot usually be "
 "accessed."
-msgstr "Dies bedeutet, dass die Softwarerechte in den Händen einer Person oder eines Unternehmens liegen. Die Nutzung ist oftmals beschränkt und der Quellcode ist normalerweise nicht zugänglich."
+msgstr ""
+"Dies bedeutet, dass die Softwarerechte in den Händen einer Person oder eines "
+"Unternehmens liegen. Die Nutzung ist oftmals beschränkt und der Quellcode "
+"ist normalerweise nicht zugänglich."
 
 #: src/gs-details-page.ui:1535
 msgid "Unknown Software License"
@@ -1463,8 +1551,7 @@ msgstr "In der Anwendungsliste gibt es ungespeicherte Änderungen."
 msgid "Use verbose logging"
 msgstr "Ausführliche Protokollierung aktivieren"
 
-#. TRANSLATORS: program name, an application to add and remove software
-#. repositories
+#. TRANSLATORS: program name, an application to add and remove software repositories
 #: src/gs-editor.c:1119
 msgid "GNOME Software Banner Designer"
 msgstr "GNOME Software Banner-Designer"
@@ -1493,8 +1580,7 @@ msgstr "Zusammenfassung"
 msgid "Editor’s Pick"
 msgstr "Unsere Empfehlungen"
 
-#. This check button controls whether the application’s banner appears in the
-#. “Featured” category
+#. This check button controls whether the application’s banner appears in the “Featured” category
 #: src/gs-editor.ui:397
 msgid "Category Featured"
 msgstr "Vorstellungskategorie"
@@ -1576,16 +1662,19 @@ msgstr "auf der Internetseite"
 #: src/gs-extras-page.c:333
 #, c-format
 msgid "No applications are available that provide the file %s."
-msgstr "Es sind keine Anwendungen verfügbar, welche die Datei %s bereitstellen."
+msgstr ""
+"Es sind keine Anwendungen verfügbar, welche die Datei %s bereitstellen."
 
 #. TRANSLATORS: first %s is the codec name, and second %s is a
 #. * hyperlink with the "on the website" text
 #: src/gs-extras-page.c:337 src/gs-extras-page.c:348 src/gs-extras-page.c:359
 #, c-format
 msgid ""
-"Information about %s, as well as options for how to get missing applications"
-" might be found %s."
-msgstr "Informationen über %s sowie Möglichkeiten, fehlende Anwendungen zu erhalten, finden Sie %s."
+"Information about %s, as well as options for how to get missing applications "
+"might be found %s."
+msgstr ""
+"Informationen über %s sowie Möglichkeiten, fehlende Anwendungen zu erhalten, "
+"finden Sie %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1608,14 +1697,18 @@ msgstr "%s ist nicht verfügbar."
 msgid ""
 "Information about %s, as well as options for how to get an application that "
 "can support this format might be found %s."
-msgstr "Informationen über %s sowie Möglichkeiten, eine Anwendung zu finden, die dieses Format wiedergeben kann, finden Sie %s."
+msgstr ""
+"Informationen über %s sowie Möglichkeiten, eine Anwendung zu finden, die "
+"dieses Format wiedergeben kann, finden Sie %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
 #: src/gs-extras-page.c:377
 #, c-format
 msgid "No fonts are available for the %s script support."
-msgstr "Es sind keine Schriftarten für die Unterstützung des %s-Schriftsystems verfügbar."
+msgstr ""
+"Es sind keine Schriftarten für die Unterstützung des %s-Schriftsystems "
+"verfügbar."
 
 #. TRANSLATORS: first %s is the codec name, and second %s is a
 #. * hyperlink with the "on the website" text
@@ -1624,11 +1717,13 @@ msgstr "Es sind keine Schriftarten für die Unterstützung des %s-Schriftsystems
 msgid ""
 "Information about %s, as well as options for how to get additional fonts "
 "might be found %s."
-msgstr "Informationen über %s sowie Möglichkeiten, zusätzliche Schriften zu erhalten, finden Sie %s."
+msgstr ""
+"Informationen über %s sowie Möglichkeiten, zusätzliche Schriften zu "
+"erhalten, finden Sie %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
-#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1426
+#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1430
 #, c-format
 msgid "No addon codecs are available for the %s format."
 msgstr "Es sind keine zusätzlichen Codecs für das Format %s verfügbar."
@@ -1640,14 +1735,17 @@ msgstr "Es sind keine zusätzlichen Codecs für das Format %s verfügbar."
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format might be found %s."
-msgstr "Informationen über %s sowie Möglichkeiten, einen Codec zu erhalten, der dieses Format wiedergeben kann, finden Sie %s."
+msgstr ""
+"Informationen über %s sowie Möglichkeiten, einen Codec zu erhalten, der "
+"dieses Format wiedergeben kann, finden Sie %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
 #: src/gs-extras-page.c:399
 #, c-format
 msgid "No Plasma resources are available for %s support."
-msgstr "Es sind keine Plasma-Ressourcen für die Unterstützung von %s verfügbar."
+msgstr ""
+"Es sind keine Plasma-Ressourcen für die Unterstützung von %s verfügbar."
 
 #. TRANSLATORS: first %s is the codec name, and second %s is a
 #. * hyperlink with the "on the website" text
@@ -1656,7 +1754,9 @@ msgstr "Es sind keine Plasma-Ressourcen für die Unterstützung von %s verfügba
 msgid ""
 "Information about %s, as well as options for how to get additional Plasma "
 "resources might be found %s."
-msgstr "Informationen über %s sowie Möglichkeiten, zusätzliche Plasma-Ressourcen zu erhalten, finden Sie %s."
+msgstr ""
+"Informationen über %s sowie Möglichkeiten, zusätzliche Plasma-Ressourcen zu "
+"erhalten, finden Sie %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1672,15 +1772,16 @@ msgstr "Es sind keine Druckertreiber für %s verfügbar."
 msgid ""
 "Information about %s, as well as options for how to get a driver that "
 "supports this printer might be found %s."
-msgstr "Informationen über %s sowie Möglichkeiten, einen Treiber zu erhalten, der diesen Drucker unterstützt, finden Sie %s."
+msgstr ""
+"Informationen über %s sowie Möglichkeiten, einen Treiber zu erhalten, der "
+"diesen Drucker unterstützt, finden Sie %s."
 
 #. TRANSLATORS: hyperlink title
 #: src/gs-extras-page.c:459
 msgid "this website"
 msgstr "diese Internetseite"
 
-#. TRANSLATORS: no codecs were found. First %s will be replaced by actual
-#. codec name(s), second %s is a link titled "this website"
+#. TRANSLATORS: no codecs were found. First %s will be replaced by actual codec name(s), second %s is a link titled "this website"
 #: src/gs-extras-page.c:463
 #, c-format
 msgid ""
@@ -1689,8 +1790,12 @@ msgid ""
 msgid_plural ""
 "Unfortunately, the %s you were searching for could not be found. Please see "
 "%s for more information."
-msgstr[0] "%s wurde unglücklicherweise nicht gefunden. Besuchen Sie %s für weitere Informationen."
-msgstr[1] "%s wurden unglücklicherweise nicht gefunden. Besuchen Sie %s für weitere Informationen."
+msgstr[0] ""
+"%s wurde unglücklicherweise nicht gefunden. Besuchen Sie %s für weitere "
+"Informationen."
+msgstr[1] ""
+"%s wurden unglücklicherweise nicht gefunden. Besuchen Sie %s für weitere "
+"Informationen."
 
 #: src/gs-extras-page.c:535 src/gs-extras-page.c:591 src/gs-extras-page.c:630
 msgid "Failed to find any search results"
@@ -1715,10 +1820,13 @@ msgstr "Willkommen zu GNOME-Software"
 
 #: src/gs-first-run-dialog.ui:66
 msgid ""
-"Software lets you install all the software you need, all from one place. See"
-" our recommendations, browse the categories, or search for the applications "
+"Software lets you install all the software you need, all from one place. See "
+"our recommendations, browse the categories, or search for the applications "
 "you want."
-msgstr "Software ermöglicht es Ihnen, gewünschte Software zu installieren. Schauen Sie sich unsere Empfehlungen an, durchsuchen Sie Kategorien und suchen Sie nach gewünschten Anwendungen."
+msgstr ""
+"Software ermöglicht es Ihnen, gewünschte Software zu installieren. Schauen "
+"Sie sich unsere Empfehlungen an, durchsuchen Sie Kategorien und suchen Sie "
+"nach gewünschten Anwendungen."
 
 #: src/gs-first-run-dialog.ui:85
 msgid "_Let’s Go Shopping"
@@ -1868,13 +1976,16 @@ msgstr "Empfohlene Anwendungen zur Produktivität"
 #: src/gs-overview-page.c:974
 msgid ""
 "Provides access to additional software, including web browsers and games."
-msgstr "Ermöglicht den Zugriff auf zusätzliche Software wie Internet-Browser oder Spiele."
+msgstr ""
+"Ermöglicht den Zugriff auf zusätzliche Software wie Internet-Browser oder "
+"Spiele."
 
 #. TRANSLATORS: this is the proprietary info bar
 #: src/gs-overview-page.c:978
-msgid ""
-"Proprietary software has restrictions on use and access to source code."
-msgstr "Proprietäre Software unterliegt Einschränkungen bezüglich Verwendung und Zugriff auf den Quellcode."
+msgid "Proprietary software has restrictions on use and access to source code."
+msgstr ""
+"Proprietäre Software unterliegt Einschränkungen bezüglich Verwendung und "
+"Zugriff auf den Quellcode."
 
 #. TRANSLATORS: this is the clickable
 #. * link on the proprietary info bar
@@ -1903,14 +2014,12 @@ msgstr "Vorgestellte Anwendung"
 msgid "Categories"
 msgstr "Kategorien"
 
-#. Translators: This is a heading for software which has been featured
-#. ('picked') by the distribution.
+#. Translators: This is a heading for software which has been featured ('picked') by the distribution.
 #: src/gs-overview-page.ui:315
 msgid "Editor’s Picks"
 msgstr "Unsere Empfehlungen"
 
-#. Translators: This is a heading for software which has been recently
-#. released upstream.
+#. Translators: This is a heading for software which has been recently released upstream.
 #: src/gs-overview-page.ui:359
 msgid "Recent Releases"
 msgstr "Letzte Veröffentlichungen"
@@ -1957,7 +2066,9 @@ msgstr "Soll die Quelle %s wirklich entfernt werden?"
 msgid ""
 "All applications from %s will be removed, and you will have to re-install "
 "the source to use them again."
-msgstr "Alle Anwendungen von %s werden entfernt. Sie müssen die Quellen erneut installieren, um diese wieder nutzen zu können."
+msgstr ""
+"Alle Anwendungen von %s werden entfernt. Sie müssen die Quellen erneut "
+"installieren, um diese wieder nutzen zu können."
 
 #. TRANSLATORS: this is a prompt message, and '%s' is an
 #. * application summary, e.g. 'GNOME Clocks'
@@ -1970,14 +2081,18 @@ msgstr "Soll %s wirklich entfernt werden?"
 #: src/gs-page.c:684
 #, c-format
 msgid "%s will be removed, and you will have to install it to use it again."
-msgstr "%s wird entfernt und muss erneut installiert werden, um genutzt werden zu können."
+msgstr ""
+"%s wird entfernt und muss erneut installiert werden, um genutzt werden zu "
+"können."
 
-#: lib/gs-plugin-loader.c:1429
+#: lib/gs-plugin-loader.c:1433
 #, c-format
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format can be found on the website."
-msgstr "Informationen über %s sowie Möglichkeiten, einen Codec zu erhalten, der dieses Format wiedergeben kann, finden Sie auf der Internet-Seite."
+msgstr ""
+"Informationen über %s sowie Möglichkeiten, einen Codec zu erhalten, der "
+"dieses Format wiedergeben kann, finden Sie auf der Internet-Seite."
 
 #: lib/gs-price.c:111
 #, c-format
@@ -2036,7 +2151,10 @@ msgstr "%s %f"
 msgid ""
 "Some of the currently installed software is not compatible with %s. If you "
 "continue, the following will be automatically removed during the upgrade:"
-msgstr "Einige der aktuell installierten Software ist nicht mit %s kompatibel. Wenn Sie fortfahren, wird die folgende automatisch während der Systemaktualisierung entfernt:"
+msgstr ""
+"Einige der aktuell installierten Software ist nicht mit %s kompatibel. Wenn "
+"Sie fortfahren, wird die folgende automatisch während der "
+"Systemaktualisierung entfernt:"
 
 #: src/gs-removal-dialog.ui:27
 msgid "Incompatible Software"
@@ -2106,8 +2224,7 @@ msgstr "Die Beschreibung ist zu kurz"
 msgid "The description is too long"
 msgstr "Die Beschreibung ist zu lang"
 
-#. Translators: Title of the dialog box where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Title of the dialog box where the users can write and publish their opinions about the apps.
 #: src/gs-review-dialog.ui:11
 msgid "Post Review"
 msgstr "Rezension abschicken"
@@ -2125,7 +2242,9 @@ msgstr "Bewertung"
 msgid ""
 "Give a short summary of your review, for example: “Great app, would "
 "recommend”."
-msgstr "Geben Sie eine kurze Zusammenfassung für Ihre Rezension, z.B. »Großartiges Programm, klare Empfehlung«."
+msgstr ""
+"Geben Sie eine kurze Zusammenfassung für Ihre Rezension, z.B. »Großartiges "
+"Programm, klare Empfehlung«."
 
 #. Translators: This is where the users enter their opinions about the apps.
 #: src/gs-review-dialog.ui:199
@@ -2135,7 +2254,8 @@ msgstr "Rezension"
 
 #: src/gs-review-dialog.ui:215
 msgid "What do you think of the app? Try to give reasons for your views."
-msgstr "Was halten Sie von dieser Anwendung? Versuchen Sie Ihre Meinung zu begründen."
+msgstr ""
+"Was halten Sie von dieser Anwendung? Versuchen Sie Ihre Meinung zu begründen."
 
 #. Translators: A label for the total number of reviews.
 #: src/gs-review-histogram.ui:413
@@ -2145,14 +2265,18 @@ msgstr "Gesamtzahl der Rezensionen"
 #. TRANSLATORS: we explain what the action is going to do
 #: src/gs-review-row.c:234
 msgid "You can report reviews for abusive, rude, or discriminatory behavior."
-msgstr "Sie können Rezensionen wegen abfälligem Verhalten, Diskriminierung oder Missbrauch melden."
+msgstr ""
+"Sie können Rezensionen wegen abfälligem Verhalten, Diskriminierung oder "
+"Missbrauch melden."
 
 #. TRANSLATORS: we ask the user if they really want to do this
 #: src/gs-review-row.c:239
 msgid ""
 "Once reported, a review will be hidden until it has been checked by an "
 "administrator."
-msgstr "Sobald eine Rezension gemeldet wurde, wird sie solange verdeckt bleiben, bis sie von einem Administrator geprüft worden ist."
+msgstr ""
+"Sobald eine Rezension gemeldet wurde, wird sie solange verdeckt bleiben, bis "
+"sie von einem Administrator geprüft worden ist."
 
 #. TRANSLATORS: window title when
 #. * reporting a user-submitted review
@@ -2167,8 +2291,7 @@ msgstr "Rezension melden?"
 msgid "Report"
 msgstr "Melden"
 
-#. Translators: Users can express their opinions about other users' opinions
-#. about the apps.
+#. Translators: Users can express their opinions about other users' opinions about the apps.
 #: src/gs-review-row.ui:112
 msgid "Was this review useful to you?"
 msgstr "War diese Rezension hilfreich für Sie?"
@@ -2257,169 +2380,190 @@ msgstr "Keine Anwendung gefunden"
 #. TRANSLATORS: this is part of the in-app notification,
 #. * where the %s is a multi-word localised app name
 #. * e.g. 'Getting things GNOME!"
-#: src/gs-shell.c:846 src/gs-shell.c:851 src/gs-shell.c:866 src/gs-shell.c:870
+#: src/gs-shell.c:847 src/gs-shell.c:852 src/gs-shell.c:867 src/gs-shell.c:871
 #, c-format
 msgid "“%s”"
 msgstr "»%s«"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:898
+#: src/gs-shell.c:899
 #, c-format
 msgid "Unable to download firmware updates from %s"
 msgstr "Fehler beim Herunterladen von Firmware-Aktualisierungen von %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:904
+#: src/gs-shell.c:905
 #, c-format
 msgid "Unable to download updates from %s"
 msgstr "Herunterladen von Aktualisierungen von %s nicht möglich"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:911
+#: src/gs-shell.c:912
 msgid "Unable to download updates"
 msgstr "Herunterladen von Aktualisierungen nicht möglich"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:916
+#: src/gs-shell.c:917
 msgid ""
-"Unable to download updates: internet access was required but wasn’t "
-"available"
-msgstr "Herunterladen von Aktualisierungen nicht möglich: Internet-Zugriff war erforderlich, jedoch nicht verfügbar."
+"Unable to download updates: internet access was required but wasn’t available"
+msgstr ""
+"Herunterladen von Aktualisierungen nicht möglich: Internet-Zugriff war "
+"erforderlich, jedoch nicht verfügbar."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:925
+#: src/gs-shell.c:926
 #, c-format
 msgid "Unable to download updates from %s: not enough disk space"
-msgstr "Herunterladen von Aktualisierungen von %s nicht möglich: Nicht genug freier Speicherplatz verfügbar"
+msgstr ""
+"Herunterladen von Aktualisierungen von %s nicht möglich: Nicht genug freier "
+"Speicherplatz verfügbar"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:930
+#: src/gs-shell.c:931
 msgid "Unable to download updates: not enough disk space"
-msgstr "Herunterladen von Aktualisierungen nicht möglich: Es war nicht genug freier Speicherplatz vorhanden."
+msgstr ""
+"Herunterladen von Aktualisierungen nicht möglich: Es war nicht genug freier "
+"Speicherplatz vorhanden."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:938
+#: src/gs-shell.c:939
 msgid "Unable to download updates: authentication was required"
-msgstr "Herunterladen von Aktualisierungen nicht möglich: Anmeldedaten werden zur Legitimierung benötigt"
+msgstr ""
+"Herunterladen von Aktualisierungen nicht möglich: Anmeldedaten werden zur "
+"Legitimierung benötigt"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:943
+#: src/gs-shell.c:944
 msgid "Unable to download updates: authentication was invalid"
-msgstr "Herunterladen von Aktualisierungen nicht möglich: Legitimierung war nicht erfolgreich"
+msgstr ""
+"Herunterladen von Aktualisierungen nicht möglich: Legitimierung war nicht "
+"erfolgreich"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:948
+#: src/gs-shell.c:949
 msgid ""
 "Unable to download updates: you do not have permission to install software"
-msgstr "Herunterladen von Aktualisierungen nicht möglich: Keine ausreichenden Benutzerrechte um Anwendungen zu installieren"
+msgstr ""
+"Herunterladen von Aktualisierungen nicht möglich: Keine ausreichenden "
+"Benutzerrechte um Anwendungen zu installieren"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:955
+#: src/gs-shell.c:956
 msgid "Unable to get list of updates"
 msgstr "Aktualisierungsliste konnte nicht aktualisiert werden"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the application name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1001
+#: src/gs-shell.c:1002
 #, c-format
 msgid "Unable to install %s as download failed from %s"
-msgstr "Installation von %s nicht möglich, weil das Herunterladen von %s fehlgeschlagen ist"
+msgstr ""
+"Installation von %s nicht möglich, weil das Herunterladen von %s "
+"fehlgeschlagen ist"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1007
+#: src/gs-shell.c:1008
 #, c-format
 msgid "Unable to install %s as download failed"
-msgstr "Installation von %s nicht möglich, weil das Herunterladen fehlgeschlagen war"
+msgstr ""
+"Installation von %s nicht möglich, weil das Herunterladen fehlgeschlagen war"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1019
+#: src/gs-shell.c:1020
 #, c-format
 msgid "Unable to install %s as runtime %s not available"
-msgstr "Installation von %s nicht möglich, weil die Laufzeit %s nicht verfügbar ist"
+msgstr ""
+"Installation von %s nicht möglich, weil die Laufzeit %s nicht verfügbar ist"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1025
+#: src/gs-shell.c:1026
 #, c-format
 msgid "Unable to install %s as not supported"
 msgstr "Installation von %s nicht möglich, weil es nicht unterstützt wird"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1032
+#: src/gs-shell.c:1033
 msgid "Unable to install: internet access was required but wasn’t available"
-msgstr "Installation fehlgeschlagen: Internet-Zugriff war erforderlich, jedoch nicht verfügbar."
+msgstr ""
+"Installation fehlgeschlagen: Internet-Zugriff war erforderlich, jedoch nicht "
+"verfügbar."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1038
+#: src/gs-shell.c:1039
 msgid "Unable to install: the application has an invalid format"
 msgstr "Installation nicht möglich: Die Anwendung hat ein ungültiges Format"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1043
+#: src/gs-shell.c:1044
 #, c-format
 msgid "Unable to install %s: not enough disk space"
-msgstr "Installation von %s fehlgeschlagen: Es war nicht genug freier Speicherplatz vorhanden."
+msgstr ""
+"Installation von %s fehlgeschlagen: Es war nicht genug freier Speicherplatz "
+"vorhanden."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1051
+#: src/gs-shell.c:1052
 #, c-format
 msgid "Unable to install %s: authentication was required"
 msgstr "Installation von %s nicht möglich: Legitimierung notwendig"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1058
+#: src/gs-shell.c:1059
 #, c-format
 msgid "Unable to install %s: authentication was invalid"
 msgstr "Installation von %s nicht möglich: Legitimierung fehlgeschlagen"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1065
+#: src/gs-shell.c:1066
 #, c-format
 msgid "Unable to install %s: you do not have permission to install software"
-msgstr "Installation von %s nicht möglich: Keine ausreichenden Benutzerrechte um Anwendungen zu installieren"
+msgstr ""
+"Installation von %s nicht möglich: Keine ausreichenden Benutzerrechte um "
+"Anwendungen zu installieren"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the name of the authentication service,
 #. * e.g. "Ubuntu One"
-#: src/gs-shell.c:1078
+#: src/gs-shell.c:1079
 #, c-format
 msgid "Your %s account has been suspended."
 msgstr "Das Konto %s wurde deaktiviert."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1082
+#: src/gs-shell.c:1083
 msgid "It is not possible to install software until this has been resolved."
 msgstr "Installation von Software nicht möglich, bis das Problem gelöst ist."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the clickable link (e.g.
 #. * "http://example.com/what-did-i-do-wrong/")
-#: src/gs-shell.c:1093
+#: src/gs-shell.c:1094
 #, c-format
 msgid "For more information, visit %s."
 msgstr "Besuchen Sie %s für weitere Informationen."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1102
+#: src/gs-shell.c:1103
 #, c-format
 msgid "Unable to install %s: AC power is required"
 msgstr "Installation von %s nicht möglich: Netzanschluss notwendig"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1111
+#: src/gs-shell.c:1112
 #, c-format
 msgid "Unable to install %s"
 msgstr "Installation von %s nicht möglich"
@@ -2428,61 +2572,68 @@ msgstr "Installation von %s nicht möglich"
 #. * where the first %s is the app name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1157
+#: src/gs-shell.c:1158
 #, c-format
 msgid "Unable to update %s from %s"
 msgstr "Aktualisierung von %s auf %s nicht möglich"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1163
+#: src/gs-shell.c:1164
 #, c-format
 msgid "Unable to update %s as download failed"
-msgstr "Aktualisierung von %s nicht möglich, weil das Herunterladen fehl schlug"
+msgstr ""
+"Aktualisierung von %s nicht möglich, weil das Herunterladen fehl schlug"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1169
+#: src/gs-shell.c:1170
 msgid "Unable to update: internet access was required but wasn’t available"
-msgstr "Aktualisierung fehlgeschlagen: Internet-Zugriff war erforderlich, jedoch nicht verfügbar."
+msgstr ""
+"Aktualisierung fehlgeschlagen: Internet-Zugriff war erforderlich, jedoch "
+"nicht verfügbar."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1177
+#: src/gs-shell.c:1178
 #, c-format
 msgid "Unable to update %s: not enough disk space"
-msgstr "Aktualisierung von %s fehlgeschlagen: Es war nicht genug freier Speicherplatz vorhanden."
+msgstr ""
+"Aktualisierung von %s fehlgeschlagen: Es war nicht genug freier "
+"Speicherplatz vorhanden."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1186
+#: src/gs-shell.c:1187
 #, c-format
 msgid "Unable to update %s: authentication was required"
 msgstr "Aktualisierung von %s nicht möglich: Legitimierung notwendig"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1193
+#: src/gs-shell.c:1194
 #, c-format
 msgid "Unable to update %s: authentication was invalid"
 msgstr "Aktualisierung von %s nicht möglich: Legitimierung fehlgeschlagen"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1200
+#: src/gs-shell.c:1201
 #, c-format
 msgid "Unable to update %s: you do not have permission to update software"
-msgstr "Aktualisierung von %s nicht möglich: Keine ausreichenden Benutzerrechte um Aktualisierugen zu installieren"
+msgstr ""
+"Aktualisierung von %s nicht möglich: Keine ausreichenden Benutzerrechte um "
+"Aktualisierugen zu installieren"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1208
+#: src/gs-shell.c:1209
 #, c-format
 msgid "Unable to update %s: AC power is required"
 msgstr "Aktualisierung von %s nicht möglich: Netzanschluss notwendig"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1217
+#: src/gs-shell.c:1218
 #, c-format
 msgid "Unable to update %s"
 msgstr "Aktualisierung von %s fehlgeschlagen"
@@ -2490,96 +2641,106 @@ msgstr "Aktualisierung von %s fehlgeschlagen"
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the distro name (e.g. "Fedora 25") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1262
+#: src/gs-shell.c:1263
 #, c-format
 msgid "Unable to upgrade to %s from %s"
 msgstr "Systemaktualisierung von %s auf %s nicht möglich"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the app name (e.g. "GIMP")
-#: src/gs-shell.c:1267
+#: src/gs-shell.c:1268
 #, c-format
 msgid "Unable to upgrade to %s as download failed"
-msgstr "Systemaktualisierung auf %s nicht möglich, weil das Herunterladen fehl schlug"
+msgstr ""
+"Systemaktualisierung auf %s nicht möglich, weil das Herunterladen fehl schlug"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1274
+#: src/gs-shell.c:1275
 msgid "Unable to upgrade: internet access was required but wasn’t available"
-msgstr "Systemaktualisierung fehlgeschlagen: Internet-Zugriff war erforderlich, jedoch nicht verfügbar."
+msgstr ""
+"Systemaktualisierung fehlgeschlagen: Internet-Zugriff war erforderlich, "
+"jedoch nicht verfügbar."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1282
+#: src/gs-shell.c:1283
 #, c-format
 msgid "Unable to upgrade to %s: not enough disk space"
-msgstr "Systemaktualisierung auf %s fehlgeschlagen: Es war nicht genug freier Speicherplatz vorhanden."
+msgstr ""
+"Systemaktualisierung auf %s fehlgeschlagen: Es war nicht genug freier "
+"Speicherplatz vorhanden."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1291
+#: src/gs-shell.c:1292
 #, c-format
 msgid "Unable to upgrade to %s: authentication was required"
 msgstr "Systemaktualisierung auf %s nicht möglich: Legitimierung notwendig"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1298
+#: src/gs-shell.c:1299
 #, c-format
 msgid "Unable to upgrade to %s: authentication was invalid"
-msgstr "Systemaktualisierung auf %s nicht möglich: Legitimierung fehlgeschlagen"
+msgstr ""
+"Systemaktualisierung auf %s nicht möglich: Legitimierung fehlgeschlagen"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1305
+#: src/gs-shell.c:1306
 #, c-format
 msgid "Unable to upgrade to %s: you do not have permission to upgrade"
-msgstr "Systemaktualisierung auf %s nicht möglich: Keine ausreichenden Benutzerrechte um Anwendungen zu installieren"
+msgstr ""
+"Systemaktualisierung auf %s nicht möglich: Keine ausreichenden "
+"Benutzerrechte um Anwendungen zu installieren"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1312
+#: src/gs-shell.c:1313
 #, c-format
 msgid "Unable to upgrade to %s: AC power is required"
 msgstr "Systemaktualisierung auf %s nicht möglich: Netzanschluss notwendig"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1321
+#: src/gs-shell.c:1322
 #, c-format
 msgid "Unable to upgrade to %s"
 msgstr "Systemaktualisierung auf %s nicht möglich"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1363
+#: src/gs-shell.c:1364
 #, c-format
 msgid "Unable to remove %s: authentication was required"
 msgstr "Entfernen von %s nicht möglich: Legitimierung notwendig"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1369
+#: src/gs-shell.c:1370
 #, c-format
 msgid "Unable to remove %s: authentication was invalid"
 msgstr "Entfernen von %s nicht möglich: Legitimierung fehlgeschlagen"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1375
+#: src/gs-shell.c:1376
 #, c-format
 msgid "Unable to remove %s: you do not have permission to remove software"
-msgstr "Entfernen von %s nicht möglich: Keine ausreichenden Benutzerrechte, um Anwendungen zu entfernen"
+msgstr ""
+"Entfernen von %s nicht möglich: Keine ausreichenden Benutzerrechte, um "
+"Anwendungen zu entfernen"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1382
+#: src/gs-shell.c:1383
 #, c-format
 msgid "Unable to remove %s: AC power is required"
 msgstr "Entfernen von %s nicht möglich: Netzanschluss notwendig"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1391
+#: src/gs-shell.c:1392
 #, c-format
 msgid "Unable to remove %s"
 msgstr "Entfernen von %s nicht möglich"
@@ -2588,48 +2749,52 @@ msgstr "Entfernen von %s nicht möglich"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1437
+#: src/gs-shell.c:1438
 #, c-format
 msgid "Unable to launch %s: %s is not installed"
 msgstr "Starten von %s fehlgeschlagen: %s ist nicht installiert"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1444 src/gs-shell.c:1492 src/gs-shell.c:1540
+#: src/gs-shell.c:1445 src/gs-shell.c:1493 src/gs-shell.c:1541
 msgid "Not enough disk space — free up some space and try again"
-msgstr "Es ist nicht genug freier Speicher vorhanden. Bitte schaffen Sie ein bisschen Platz und versuchen Sie es anschließend erneut."
+msgstr ""
+"Es ist nicht genug freier Speicher vorhanden. Bitte schaffen Sie ein "
+"bisschen Platz und versuchen Sie es anschließend erneut."
 
 #. TRANSLATORS: we failed to get a proper error code
-#: src/gs-shell.c:1452 src/gs-shell.c:1500 src/gs-shell.c:1567
+#: src/gs-shell.c:1453 src/gs-shell.c:1501 src/gs-shell.c:1568
 msgid "Sorry, something went wrong"
 msgstr "Hoppla! Etwas ist schief gegangen."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1487
+#: src/gs-shell.c:1488
 msgid "Failed to install file: authentication failed"
 msgstr "Installation der Datei schlug fehl: Legitimierung fehlgeschlagen"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1534
+#: src/gs-shell.c:1535
 #, c-format
 msgid "Unable to contact %s"
 msgstr "%s kann nicht kontaktiert werden"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1549
+#: src/gs-shell.c:1550
 #, c-format
 msgid "%s needs to be restarted to use new plugins."
 msgstr "%s muss zur Einbindung der Erweiterungen neu gestartet werden."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1554
+#: src/gs-shell.c:1555
 msgid "This application needs to be restarted to use new plugins."
-msgstr "Diese Anwendung muss neu gestartet werden, damit die neuen Erweiterungen benutzt werden können."
+msgstr ""
+"Diese Anwendung muss neu gestartet werden, damit die neuen Erweiterungen "
+"benutzt werden können."
 
 #. TRANSLATORS: need to be connected to the AC power
-#: src/gs-shell.c:1561
+#: src/gs-shell.c:1562
 msgid "AC power is required"
 msgstr "Netzanschluss benötigt"
 
@@ -2637,7 +2802,9 @@ msgstr "Netzanschluss benötigt"
 #. has no software installed from it.
 #: src/gs-sources-dialog.c:98
 msgid "No applications or addons installed; other software might still be"
-msgstr "Es wurden keine Anwendungen oder Erweiterungen installiert. Andere Programme möglicherweise schon"
+msgstr ""
+"Es wurden keine Anwendungen oder Erweiterungen installiert. Andere Programme "
+"möglicherweise schon"
 
 #. TRANSLATORS: This string is used to construct the 'X applications
 #. installed' sentence, describing a software source.
@@ -2691,7 +2858,9 @@ msgstr[1] "%s und %s wurden installiert"
 #. TRANSLATORS: nonfree software
 #: src/gs-sources-dialog.c:257
 msgid "Typically has restrictions on use and access to source code."
-msgstr "Unterliegt üblicherweise Einschränkungen bezüglich Verwendung und Zugriff auf den Quellcode."
+msgstr ""
+"Unterliegt üblicherweise Einschränkungen bezüglich Verwendung und Zugriff "
+"auf den Quellcode."
 
 #. TRANSLATORS: list header
 #: src/gs-sources-dialog.c:278
@@ -2716,7 +2885,10 @@ msgstr "das Betriebssystem"
 msgid ""
 "Software sources can be downloaded from the internet. They give you access "
 "to additional software that is not provided by %s."
-msgstr "Software-Quellen können aus dem Internet heruntergeladen werden. Sie gewähren Zugriff auf zusätzliche Programme, die sonst nicht über %s angeboten werden."
+msgstr ""
+"Software-Quellen können aus dem Internet heruntergeladen werden. Sie "
+"gewähren Zugriff auf zusätzliche Programme, die sonst nicht über %s "
+"angeboten werden."
 
 #: src/gs-sources-dialog.ui:155
 msgid "Additional Sources"
@@ -2725,7 +2897,9 @@ msgstr "Zusätzliche Quellen"
 #: src/gs-sources-dialog.ui:175
 msgid ""
 "Removing a source will also remove any software you have installed from it."
-msgstr "Beim Entfernen einer Quelle wird ebenfalls alle Software entfernt, die Sie von dieser installiert haben."
+msgstr ""
+"Beim Entfernen einer Quelle wird ebenfalls alle Software entfernt, die Sie "
+"von dieser installiert haben."
 
 #: src/gs-sources-dialog.ui:260
 msgid "No software installed from this source"
@@ -2820,7 +2994,8 @@ msgstr "Sicherheitsaktualisierungen stehen aus"
 
 #: src/gs-update-monitor.c:89
 msgid "It is recommended that you install important updates now"
-msgstr "Es wird empfohlen, dass Sie wichtige Aktualisierungen sofort installieren"
+msgstr ""
+"Es wird empfohlen, dass Sie wichtige Aktualisierungen sofort installieren"
 
 #: src/gs-update-monitor.c:92
 msgid "Restart & Install"
@@ -2832,7 +3007,9 @@ msgstr "Software-Aktualisierungen sind verfügbar"
 
 #: src/gs-update-monitor.c:97
 msgid "Important OS and application updates are ready to be installed"
-msgstr "Wichtige Betriebssystemaktualisierungen und Anwendungsaktualisierungen stehen zur Installation bereit"
+msgstr ""
+"Wichtige Betriebssystemaktualisierungen und Anwendungsaktualisierungen "
+"stehen zur Installation bereit"
 
 #. TRANSLATORS: button text
 #: src/gs-update-monitor.c:100 src/gs-updates-page.c:775
@@ -2851,7 +3028,9 @@ msgstr "Betriebssystemaktualisierungen sind nicht verfügbar"
 #. TRANSLATORS: this is the message dialog for the distro EOL notice
 #: src/gs-update-monitor.c:257
 msgid "Upgrade to continue receiving security updates."
-msgstr "Aktualisieren Sie Ihr System, um weiterhin Sicherheitsaktualisierungen zu erhalten."
+msgstr ""
+"Aktualisieren Sie Ihr System, um weiterhin Sicherheitsaktualisierungen zu "
+"erhalten."
 
 #. TRANSLATORS: this is a distro upgrade, the replacement would be the
 #. * distro name, e.g. 'Fedora'
@@ -2873,7 +3052,8 @@ msgstr "Software-Aktualisierungen fehlgeschlagen"
 #. TRANSLATORS: message when we offline updates have failed
 #: src/gs-update-monitor.c:612
 msgid "An important OS update failed to be installed."
-msgstr "Eine wichtige Betriebssystemaktualisierung konnte nicht installiert werden."
+msgstr ""
+"Eine wichtige Betriebssystemaktualisierung konnte nicht installiert werden."
 
 #: src/gs-update-monitor.c:613
 msgid "Show Details"
@@ -2923,29 +3103,38 @@ msgstr "Die Aktualisierung wurde abgebrochen."
 #. * something with no network available
 #: src/gs-update-monitor.c:714
 msgid ""
-"Internet access was required but wasn’t available. Please make sure that you"
-" have internet access and try again."
-msgstr "Internetzugang war erforderlich, aber nicht verfügbar. Bitte stellen Sie sicher, dass ein Internetzugang vorhanden ist und versuchen Sie es erneut."
+"Internet access was required but wasn’t available. Please make sure that you "
+"have internet access and try again."
+msgstr ""
+"Internetzugang war erforderlich, aber nicht verfügbar. Bitte stellen Sie "
+"sicher, dass ein Internetzugang vorhanden ist und versuchen Sie es erneut."
 
 #. TRANSLATORS: if the package is not signed correctly
 #: src/gs-update-monitor.c:720
 msgid ""
 "There were security issues with the update. Please consult your software "
 "provider for more details."
-msgstr "Es gab ein Sicherheitsproblem mit der Aktualisierung. Bitte wenden Sie sich an den Autor bzw. Hersteller des Programms für weitere Einzelheiten."
+msgstr ""
+"Es gab ein Sicherheitsproblem mit der Aktualisierung. Bitte wenden Sie sich "
+"an den Autor bzw. Hersteller des Programms für weitere Einzelheiten."
 
 #. TRANSLATORS: we ran out of disk space
 #: src/gs-update-monitor.c:726
 msgid ""
 "There wasn’t enough disk space. Please free up some space and try again."
-msgstr "Es ist nicht genug freier Speicher vorhanden. Bitte schaffen Sie ein bisschen Platz und versuchen Sie es anschließend erneut."
+msgstr ""
+"Es ist nicht genug freier Speicher vorhanden. Bitte schaffen Sie ein "
+"bisschen Platz und versuchen Sie es anschließend erneut."
 
 #. TRANSLATORS: We didn't handle the error type
 #: src/gs-update-monitor.c:731
 msgid ""
 "We’re sorry: the update failed to install. Please wait for another update "
 "and try again. If the problem persists, contact your software provider."
-msgstr "Leider konnte die Aktualisierung nicht installiert werden. Bitte warten Sie auf eine neue Aktualisierung und versuchen Sie es erneut. Sollte das Problem bestehen bleiben, treten Sie bitte mit dem Autor/Hersteller in Kontakt."
+msgstr ""
+"Leider konnte die Aktualisierung nicht installiert werden. Bitte warten Sie "
+"auf eine neue Aktualisierung und versuchen Sie es erneut. Sollte das Problem "
+"bestehen bleiben, treten Sie bitte mit dem Autor/Hersteller in Kontakt."
 
 #. TRANSLATORS: Time in 24h format
 #: src/gs-updates-page.c:297
@@ -3125,7 +3314,9 @@ msgstr "Kosten könnten anfallen"
 msgid ""
 "Checking for updates while using mobile broadband could cause you to incur "
 "charges."
-msgstr "Ein Suchen nach Aktualisierungen über mobiles Breitband kann Ihnen Kosten verursachen."
+msgstr ""
+"Ein Suchen nach Aktualisierungen über mobiles Breitband kann Ihnen Kosten "
+"verursachen."
 
 #. TRANSLATORS: this is a link to the
 #. * control-center network panel
@@ -3142,7 +3333,8 @@ msgstr "Kein Netzwerk"
 #. * to do the updates check
 #: src/gs-updates-page.c:1433
 msgid "Internet access is required to check for updates."
-msgstr "Für die Suche nach Aktualisierungen ist Zugriff auf das Internet notwendig."
+msgstr ""
+"Für die Suche nach Aktualisierungen ist Zugriff auf das Internet notwendig."
 
 #: src/gs-updates-page.c:1819
 msgid "Restart & _Install"
@@ -3164,7 +3356,9 @@ msgstr "Die Software ist aktuell"
 msgid ""
 "Checking for updates when using mobile broadband could cause you to incur "
 "charges"
-msgstr "Ein Suchen nach Aktualisierungen über mobiles Breitband kann Ihnen Kosten verursachen"
+msgstr ""
+"Ein Suchen nach Aktualisierungen über mobiles Breitband kann Ihnen Kosten "
+"verursachen"
 
 #: src/gs-updates-page.ui:257
 msgid "_Check Anyway"
@@ -3209,7 +3403,9 @@ msgstr "%s %s ist bereit zur Installation"
 
 #: src/gs-upgrade-banner.ui:32
 msgid "A major upgrade, with new features and added polish."
-msgstr "Eine größere Aktualisierung mit neuen Funktionsmerkmalen und überarbeiteter Oberfläche."
+msgstr ""
+"Eine größere Aktualisierung mit neuen Funktionsmerkmalen und überarbeiteter "
+"Oberfläche."
 
 #: src/gs-upgrade-banner.ui:52
 msgid "_Learn More"
@@ -3218,7 +3414,8 @@ msgstr "Mehr er_fahren"
 #: src/gs-upgrade-banner.ui:98
 msgid ""
 "It is recommended that you back up your data and files before upgrading."
-msgstr "Es wird empfohlen, dass Sie Ihre Daten sichern, bevor Sie aktualisieren."
+msgstr ""
+"Es wird empfohlen, dass Sie Ihre Daten sichern, bevor Sie aktualisieren."
 
 #: src/gs-upgrade-banner.ui:116
 msgid "_Download"
@@ -3229,22 +3426,27 @@ msgid "App Center"
 msgstr "App-Center"
 
 #: src/org.gnome.Software.desktop.in:4
+msgid "More Apps"
+msgstr "Weitere Programme"
+
+#: src/org.gnome.Software.desktop.in:5
 msgid "Add, remove or update software on this computer"
 msgstr "Software auf diesem Rechner hinzufügen, entfernen oder aktualisieren"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
-#: src/org.gnome.Software.desktop.in:6
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: src/org.gnome.Software.desktop.in:7
 #: src/org.gnome.Software.Editor.desktop.in:6
 msgid "org.gnome.Software"
 msgstr "org.gnome.Software"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
-#: src/org.gnome.Software.desktop.in:12
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: src/org.gnome.Software.desktop.in:13
 msgid ""
-"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;"
-msgstr "Aktualisierungen;Systemktualisierung;Quellen;Einstellungen;Installieren;Entfernen;Programm;Software;App;Store;Anwendung;Update;"
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;"
+msgstr ""
+"Aktualisierungen;Systemktualisierung;Quellen;Einstellungen;Installieren;"
+"Entfernen;Programm;Software;App;Store;Anwendung;Update;"
 
 #: src/org.gnome.Software.Editor.desktop.in:3
 msgid "Banner Designer"
@@ -3254,8 +3456,7 @@ msgstr "Banner-Designer"
 msgid "Design the featured banners for GNOME Software"
 msgstr "Vorgestellte Banner für GNOME Software entwerfen"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: src/org.gnome.Software.Editor.desktop.in:13
 msgid "AppStream;Software;App;"
 msgstr "AppStream;Software;App;"
@@ -3525,100 +3726,111 @@ msgctxt "Menu of Communication & News"
 msgid "Web Browsers"
 msgstr "Internet-Browser"
 
-#: plugins/core/gs-desktop-common.c:247
-msgctxt "Menu of Reference"
-msgid "All"
-msgstr "Alle"
-
-#: plugins/core/gs-desktop-common.c:250
-msgctxt "Menu of Reference"
-msgid "Featured"
-msgstr "Vorgestellt"
-
-#: plugins/core/gs-desktop-common.c:253
-msgctxt "Menu of Reference"
-msgid "Art"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:256
-msgctxt "Menu of Reference"
-msgid "Biography"
-msgstr "Geographie"
-
-#: plugins/core/gs-desktop-common.c:259
-msgctxt "Menu of Reference"
-msgid "Comics"
-msgstr "Comics"
-
-#: plugins/core/gs-desktop-common.c:262
-msgctxt "Menu of Reference"
-msgid "Fiction"
-msgstr "Fiktion"
-
-#: plugins/core/gs-desktop-common.c:265
-msgctxt "Menu of Reference"
-msgid "Health"
-msgstr "Gesundheit"
-
-#: plugins/core/gs-desktop-common.c:268
-msgctxt "Menu of Reference"
-msgid "History"
-msgstr "Geschichte"
-
-#: plugins/core/gs-desktop-common.c:271
-msgctxt "Menu of Reference"
-msgid "Lifestyle"
-msgstr "Lifestyle"
-
-#: plugins/core/gs-desktop-common.c:274
+#: plugins/core/gs-desktop-common.c:242
 msgctxt "Menu of Communication & News"
 msgid "News"
 msgstr "Neuigkeiten"
 
+#: plugins/core/gs-desktop-common.c:251
+msgctxt "Menu of Reference"
+msgid "All"
+msgstr "Alle"
+
+#: plugins/core/gs-desktop-common.c:254
+msgctxt "Menu of Reference"
+msgid "Featured"
+msgstr "Vorgestellt"
+
+#: plugins/core/gs-desktop-common.c:257
+msgctxt "Menu of Reference"
+msgid "Art"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:260
+msgctxt "Menu of Reference"
+msgid "Biography"
+msgstr "Geographie"
+
+#: plugins/core/gs-desktop-common.c:263
+msgctxt "Menu of Reference"
+msgid "Comics"
+msgstr "Comics"
+
+#: plugins/core/gs-desktop-common.c:266
+msgctxt "Menu of Reference"
+msgid "Feed"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:269
+msgctxt "Menu of Reference"
+msgid "Fiction"
+msgstr "Fiktion"
+
+#: plugins/core/gs-desktop-common.c:272
+msgctxt "Menu of Reference"
+msgid "Health"
+msgstr "Gesundheit"
+
+#: plugins/core/gs-desktop-common.c:275
+msgctxt "Menu of Reference"
+msgid "History"
+msgstr "Geschichte"
+
 #: plugins/core/gs-desktop-common.c:278
+msgctxt "Menu of Reference"
+msgid "Lifestyle"
+msgstr "Lifestyle"
+
+#: plugins/core/gs-desktop-common.c:281
+#, fuzzy
+msgctxt "Menu of Reference"
+msgid "News"
+msgstr "Neuigkeiten"
+
+#: plugins/core/gs-desktop-common.c:284
 msgctxt "Menu of Reference"
 msgid "Politics"
 msgstr "Politik"
 
-#: plugins/core/gs-desktop-common.c:281
+#: plugins/core/gs-desktop-common.c:287
 msgctxt "Menu of Reference"
 msgid "Sports"
 msgstr "Sport"
 
 #. TRANSLATORS: this is the menu spec main category for Learning
-#: plugins/core/gs-desktop-common.c:291
+#: plugins/core/gs-desktop-common.c:297
 msgid "Learning"
 msgstr "Lernen"
 
 #. TRANSLATORS: this is the menu spec main category for Game
-#: plugins/core/gs-desktop-common.c:294
+#: plugins/core/gs-desktop-common.c:300
 msgid "Games"
 msgstr "Spiele"
 
 #. TRANSLATORS: this is the menu spec main category for Multimedia
-#: plugins/core/gs-desktop-common.c:297
+#: plugins/core/gs-desktop-common.c:303
 msgid "Multimedia"
 msgstr "Multimedia"
 
 #. TRANSLATORS: this is the menu spec main category for Work
-#: plugins/core/gs-desktop-common.c:300
+#: plugins/core/gs-desktop-common.c:306
 msgid "Work"
 msgstr "Arbeiten"
 
 #. TRANSLATORS: this is the menu spec main category for Reference
-#: plugins/core/gs-desktop-common.c:303
+#: plugins/core/gs-desktop-common.c:309
 msgid "Reference & News"
 msgstr "Nachschlagewerke & Nachrichten"
 
 #. TRANSLATORS: this is the menu spec main category for Utilities
-#: plugins/core/gs-desktop-common.c:306
+#: plugins/core/gs-desktop-common.c:312
 msgid "Utilities"
 msgstr "Zubehör"
 
 #. TRANSLATORS: this is the menu spec main category for Dev Tools; it
 #. * should be a relatively short label; as an example, in Portuguese and
 #. * Spanish the direct translation of "Programming" (noun) is used
-#: plugins/core/gs-desktop-common.c:311
+#: plugins/core/gs-desktop-common.c:317
 msgid "Dev Tools"
 msgstr "Entwicklungswerkzeuge"
 
@@ -3644,16 +3856,16 @@ msgstr "Beinhaltet Leistungs-, Stabilitäts- und Sicherheitsverbesserungen."
 msgid "Downloading featured images…"
 msgstr "Vorgestellte Bilder werden heruntergeladen …"
 
-#: plugins/eos/gs-plugin-eos.c:1249
+#: plugins/eos/gs-plugin-eos.c:1233
 #, c-format
 msgid "Could not launch this application."
 msgstr "Das Programm konnte nicht gestartet werden."
 
-#: plugins/eos/gs-plugin-eos.c:1305
+#: plugins/eos/gs-plugin-eos.c:1289
 msgid "Endless Platform"
 msgstr "Endless-Plattform"
 
-#: plugins/eos/gs-plugin-eos.c:1308
+#: plugins/eos/gs-plugin-eos.c:1292
 msgid "Framework for applications"
 msgstr ""
 
@@ -3702,7 +3914,9 @@ msgstr "Systemaktualisierungsinformationen werden heruntergeladen …"
 #. TRANSLATORS: this is a title for Fedora distro upgrades
 #: plugins/fedora-pkgdb-collections/gs-plugin-fedora-pkgdb-collections.c:303
 msgid "Upgrade your Fedora system to the latest features and improvements."
-msgstr "Aktualisieren Sie Ihr Fedora-System, um die neuesten Funktionsmerkmale und Verbesserungen zu erhalten."
+msgstr ""
+"Aktualisieren Sie Ihr Fedora-System, um die neuesten Funktionsmerkmale und "
+"Verbesserungen zu erhalten."
 
 #: plugins/flatpak/org.gnome.Software.Plugin.Flatpak.metainfo.xml.in:6
 msgid "Flatpak Support"
@@ -3710,16 +3924,18 @@ msgstr "Flatpak-Unterstützung"
 
 #: plugins/flatpak/org.gnome.Software.Plugin.Flatpak.metainfo.xml.in:7
 msgid "Flatpak is a framework for desktop applications on Linux"
-msgstr "Flatpak ist eine Laufzeitumgebung für Linux-Desktop-Anwendungen, deren Pakete distributionsunabhängig laufen."
+msgstr ""
+"Flatpak ist eine Laufzeitumgebung für Linux-Desktop-Anwendungen, deren "
+"Pakete distributionsunabhängig laufen."
 
 #. TRANSLATORS: status text when downloading new metadata
-#: plugins/flatpak/gs-flatpak.c:821
+#: plugins/flatpak/gs-flatpak.c:815
 #, c-format
 msgid "Getting flatpak metadata for %s…"
 msgstr "Flatpak-Metadaten für %s werden geholt …"
 
 #. TRANSLATORS: status text when downloading the RuntimeRepo
-#: plugins/flatpak/gs-flatpak.c:2796
+#: plugins/flatpak/gs-flatpak.c:2803
 msgid "Getting runtime source…"
 msgstr "Quelle für Laufzeitumgebungen wird geholt …"
 
@@ -3752,7 +3968,9 @@ msgstr "Unterstützung von Limba"
 
 #: plugins/limba/org.gnome.Software.Plugin.Limba.metainfo.xml.in:7
 msgid "Limba provides developers a way to easily create software bundles"
-msgstr "Limba stellt Entwicklern eine einfache Möglichkeit bereit, Software-Pakete zu erstellen"
+msgstr ""
+"Limba stellt Entwicklern eine einfache Möglichkeit bereit, Software-Pakete "
+"zu erstellen"
 
 #. TRANSLATORS: status text when downloading
 #: plugins/odrs/gs-plugin-odrs.c:205
@@ -3765,7 +3983,9 @@ msgstr "Unterstützung für OpenDesktop-Bewertungen"
 
 #: plugins/odrs/org.gnome.Software.Plugin.Odrs.metainfo.xml.in:7
 msgid "ODRS is a service providing user reviews of applications"
-msgstr "OpenDesktop-Bewertungen (ODRS) ist ein Dienst, der Benutzerbewertungen von Programmen bereitstellt"
+msgstr ""
+"OpenDesktop-Bewertungen (ODRS) ist ein Dienst, der Benutzerbewertungen von "
+"Programmen bereitstellt"
 
 #. TRANSLATORS: status text when downloading
 #: plugins/shell-extensions/gs-plugin-shell-extensions.c:669

--- a/po/es.po
+++ b/po/es.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the gnome-software package.
-# 
+#
 # Translators:
 # Daniel Mustieles <daniel.mustieles@gmail.com>, 2013-2017
 # Daniel Mustieles <daniel.mustieles@gmail.com>, 2013-2017, 2017
@@ -11,14 +11,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-software\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-12 22:31-0700\n"
+"POT-Creation-Date: 2017-11-02 16:28+0100\n"
 "PO-Revision-Date: 2017-10-13 06:28+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
-"Language-Team: Spanish (http://www.transifex.com/endless-mobile-inc/gnome-software/language/es/)\n"
+"Language-Team: Spanish (http://www.transifex.com/endless-mobile-inc/gnome-"
+"software/language/es/)\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:7
@@ -33,7 +34,9 @@ msgstr "Gestor de aplicaciones para GNOME"
 msgid ""
 "Software allows you to find and install new applications and system "
 "extensions and remove existing installed applications."
-msgstr "Software le permite buscar e instalar aplicaciones nuevas y extensiones del sistema y quitar aplicaciones instaladas."
+msgstr ""
+"Software le permite buscar e instalar aplicaciones nuevas y extensiones del "
+"sistema y quitar aplicaciones instaladas."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:14
 msgid ""
@@ -41,7 +44,12 @@ msgid ""
 "descriptions and multiple screenshots per application. Applications can be "
 "found either through browsing the list of categories or by searching. It "
 "also allows you to update your system using an offline update."
-msgstr "GNOME Software muestra aplicaciones destacadas y populares con descripciones útiles y varias capturas de pantalla para cada aplicación. Las aplicaciones se pueden encontrar a navegando por la lista de categorías o buscando. También le permite actualizar su sistema mediante una actualización en modo desconectado."
+msgstr ""
+"GNOME Software muestra aplicaciones destacadas y populares con descripciones "
+"útiles y varias capturas de pantalla para cada aplicación. Las aplicaciones "
+"se pueden encontrar a navegando por la lista de categorías o buscando. "
+"También le permite actualizar su sistema mediante una actualización en modo "
+"desconectado."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:25
 msgid "Overview panel"
@@ -75,7 +83,9 @@ msgstr "Una lista de proyectos compatibles"
 msgid ""
 "This is a list of compatible projects we should show such as GNOME, KDE and "
 "XFCE."
-msgstr "Esta es una lista completa de proyectos compatibles que se deben mostrar, tales como GNOME, KDE y XFCE."
+msgstr ""
+"Esta es una lista completa de proyectos compatibles que se deben mostrar, "
+"tales como GNOME, KDE y XFCE."
 
 #: data/org.gnome.software.gschema.xml:10
 msgid "Whether to manage updates in GNOME Software"
@@ -85,7 +95,9 @@ msgstr "Indica si se deben gestionar las actualizaciones en GNOME Software"
 msgid ""
 "If disabled, GNOME Software will hide the updates panel and not perform any "
 "automatic updates actions."
-msgstr "Si está desactivada, GNOME Software ocultará el panel de actualizaciones y no realizará ninguna acción de actualización automática."
+msgstr ""
+"Si está desactivada, GNOME Software ocultará el panel de actualizaciones y "
+"no realizará ninguna acción de actualización automática."
 
 #: data/org.gnome.software.gschema.xml:15
 msgid "Whether to automatically download updates"
@@ -93,9 +105,12 @@ msgstr "Indica si se deben descargar las actualizaciones automáticamente"
 
 #: data/org.gnome.software.gschema.xml:16
 msgid ""
-"If enabled, GNOME Software automatically downloads updates in the background"
-" and prompts the user to install them when ready."
-msgstr "Si está activada, Gnome Software descarga actualizaciones automáticamente en segundo plano y pregunta al usuario si las puede instalar cuando están listas."
+"If enabled, GNOME Software automatically downloads updates in the background "
+"and prompts the user to install them when ready."
+msgstr ""
+"Si está activada, Gnome Software descarga actualizaciones automáticamente en "
+"segundo plano y pregunta al usuario si las puede instalar cuando están "
+"listas."
 
 #: data/org.gnome.software.gschema.xml:20
 msgid "Whether to automatically refresh when on a metered connection"
@@ -106,7 +121,11 @@ msgid ""
 "If enabled, GNOME Software automatically refreshes in the background even "
 "when using a metered connection (eventually downloading some metadata, "
 "checking for updates, etc., which may incur in costs for the user)."
-msgstr "Si está activada, GNOME Software actualiza automáticamente en segundo plano incluso al usar una conexión medida (descargando eventualmente algunos metadatos, comprobando si hay actualizaciones, etc., lo que puede acarrear costes al usuario)."
+msgstr ""
+"Si está activada, GNOME Software actualiza automáticamente en segundo plano "
+"incluso al usar una conexión medida (descargando eventualmente algunos "
+"metadatos, comprobando si hay actualizaciones, etc., lo que puede acarrear "
+"costes al usuario)."
 
 #: data/org.gnome.software.gschema.xml:25
 msgid "Whether it’s the very first run of GNOME Software"
@@ -118,17 +137,23 @@ msgstr "Mostrar puntuación de estrellas junto a las aplicaciones"
 
 #: data/org.gnome.software.gschema.xml:33
 msgid "Filter applications based on the default branch set for the remote"
-msgstr "Filtrar aplicaciones basándose en el conjunto de ramas predeterminadas de la ubicación remota"
+msgstr ""
+"Filtrar aplicaciones basándose en el conjunto de ramas predeterminadas de la "
+"ubicación remota"
 
 #: data/org.gnome.software.gschema.xml:37
 msgid "Non-free applications show a warning dialog before install"
-msgstr "Las aplicaciones no libres muestran un diálogo de advertencia antes de instalarse"
+msgstr ""
+"Las aplicaciones no libres muestran un diálogo de advertencia antes de "
+"instalarse"
 
 #: data/org.gnome.software.gschema.xml:38
 msgid ""
-"When non-free applications are installed a warning dialog can be shown. This"
-" controls if that dialog is suppressed."
-msgstr "Cuando se instalan aplicaciones no libres, se puede mostrar un diálogo de advertencia. Esto controla si se suprime este diálogo."
+"When non-free applications are installed a warning dialog can be shown. This "
+"controls if that dialog is suppressed."
+msgstr ""
+"Cuando se instalan aplicaciones no libres, se puede mostrar un diálogo de "
+"advertencia. Esto controla si se suprime este diálogo."
 
 #: data/org.gnome.software.gschema.xml:42
 msgid "A list of popular applications"
@@ -136,7 +161,8 @@ msgstr "Una lista de aplicaciones populares"
 
 #: data/org.gnome.software.gschema.xml:43
 msgid "A list of applications to use, overriding the system defined ones."
-msgstr "Una lista de aplicaciones que usar, omitiendo las definidas por el sistema."
+msgstr ""
+"Una lista de aplicaciones que usar, omitiendo las definidas por el sistema."
 
 #: data/org.gnome.software.gschema.xml:47
 msgid "The list of extra sources that have been previously enabled"
@@ -146,7 +172,9 @@ msgstr "La lista de fuentes adicionales que se han activado previamente"
 msgid ""
 "The list of sources that have been previously enabled when installing third-"
 "party applications."
-msgstr "La lista de fuentes que se han activado previamente al instalar aplicaciones de terceras partes."
+msgstr ""
+"La lista de fuentes que se han activado previamente al instalar aplicaciones "
+"de terceras partes."
 
 #: data/org.gnome.software.gschema.xml:52
 msgid "The last update check timestamp"
@@ -158,7 +186,9 @@ msgstr "La marca de tiempo de la última notificación de actualización"
 
 #: data/org.gnome.software.gschema.xml:60
 msgid "The timestamp of the first security update, cleared after update"
-msgstr "La marca de tiempo de la primera actualización de seguridad, eliminada después de actualizar"
+msgstr ""
+"La marca de tiempo de la primera actualización de seguridad, eliminada "
+"después de actualizar"
 
 #: data/org.gnome.software.gschema.xml:64
 msgid "The last update timestamp"
@@ -166,14 +196,20 @@ msgstr "La marca de tiempo de la última actualización"
 
 #: data/org.gnome.software.gschema.xml:68
 msgid "The age in seconds to verify the upstream screenshot is still valid"
-msgstr "La edad en segundos para verificar si la captura de pantalla oficial sigue siendo válida"
+msgstr ""
+"La edad en segundos para verificar si la captura de pantalla oficial sigue "
+"siendo válida"
 
 #: data/org.gnome.software.gschema.xml:69
 msgid ""
 "Choosing a larger value will mean less round-trips to the remote server but "
-"updates to the screenshots may take longer to show to the user. A value of 0"
-" means to never check the server if the image already exists in the cache."
-msgstr "Elegir un valor más grande implica menos consultas al servidor remoto, pero las actualizaciones de las capturas de pantalla pueden tardar más en mostrarse al usuario. El valor 0 implica no comprobar nunca el servidor remoto si la imagen ya existe en la caché."
+"updates to the screenshots may take longer to show to the user. A value of 0 "
+"means to never check the server if the image already exists in the cache."
+msgstr ""
+"Elegir un valor más grande implica menos consultas al servidor remoto, pero "
+"las actualizaciones de las capturas de pantalla pueden tardar más en "
+"mostrarse al usuario. El valor 0 implica no comprobar nunca el servidor "
+"remoto si la imagen ya existe en la caché."
 
 #: data/org.gnome.software.gschema.xml:78
 msgid "The server to use for application reviews"
@@ -189,7 +225,8 @@ msgstr "Las opiniones con menos karma que este número no se mostrarán."
 
 #: data/org.gnome.software.gschema.xml:87
 msgid "A list of official sources that should not be considered 3rd party"
-msgstr "Una lista de fuentes oficiales que no se deben considerar terceras partes"
+msgstr ""
+"Una lista de fuentes oficiales que no se deben considerar terceras partes"
 
 #: data/org.gnome.software.gschema.xml:91
 msgid "A list of official sources that should be considered free software"
@@ -197,14 +234,16 @@ msgstr "Una lista de fuentes oficiales que se deben considerar software libre"
 
 #: data/org.gnome.software.gschema.xml:95
 msgid ""
-"The licence URL to use when an application should be considered free "
-"software"
-msgstr "El URL de la licencia que usar cuando se deba considerar que una aplicación es software libre"
+"The licence URL to use when an application should be considered free software"
+msgstr ""
+"El URL de la licencia que usar cuando se deba considerar que una aplicación "
+"es software libre"
 
 #: data/org.gnome.software.gschema.xml:99
-msgid ""
-"Install bundled applications for all users on the system where possible"
-msgstr "Instalar paquetes de aplicaciones para todos los usuarios del sistema cuando sea posible"
+msgid "Install bundled applications for all users on the system where possible"
+msgstr ""
+"Instalar paquetes de aplicaciones para todos los usuarios del sistema cuando "
+"sea posible"
 
 #: data/org.gnome.software.gschema.xml:103
 msgid "Show the folder management UI"
@@ -220,7 +259,9 @@ msgstr "Ofrece actualizaciones para publicaciones preliminares"
 
 #: data/org.gnome.software.gschema.xml:115
 msgid "Show some UI elements informing the user that an app is non-free"
-msgstr "Mostrar algunos elementos de la IU que informen al usuario que la aplicación no es libre"
+msgstr ""
+"Mostrar algunos elementos de la IU que informen al usuario que la aplicación "
+"no es libre"
 
 #: data/org.gnome.software.gschema.xml:119
 msgid "Show the prompt to install nonfree software sources"
@@ -232,7 +273,8 @@ msgstr "Mostrar software no libre en los resultados de búsqueda"
 
 #: data/org.gnome.software.gschema.xml:127
 msgid "Show the installed size for apps in the list of installed applications"
-msgstr "Mostrar el tamaño correspondiente en la lista de aplicaciones instaladas"
+msgstr ""
+"Mostrar el tamaño correspondiente en la lista de aplicaciones instaladas"
 
 #: data/org.gnome.software.gschema.xml:131
 msgid "The URI that explains nonfree and proprietary software"
@@ -240,17 +282,22 @@ msgstr "El URI que explica el software propietario y el no libre"
 
 #: data/org.gnome.software.gschema.xml:135
 msgid "A list of non-free sources that can be optionally enabled"
-msgstr "Una lista de fuentes no libres que se pueden activar de manera opcional"
+msgstr ""
+"Una lista de fuentes no libres que se pueden activar de manera opcional"
 
 #: data/org.gnome.software.gschema.xml:139
 msgid ""
 "A list of URLs pointing to appstream files that will be downloaded into an "
 "app-info folder"
-msgstr "Una lista de URL que apuntan a archivos «appstream» que se descargarán en la carpeta de información de la aplicación"
+msgstr ""
+"Una lista de URL que apuntan a archivos «appstream» que se descargarán en la "
+"carpeta de información de la aplicación"
 
 #: data/org.gnome.software.gschema.xml:143
 msgid "Install the AppStream files to a system-wide location for all users"
-msgstr "Instalar los archivos «appstream» en una ubicación del sistema para todos los usuarios"
+msgstr ""
+"Instalar los archivos «appstream» en una ubicación del sistema para todos "
+"los usuarios"
 
 #: data/org.gnome.software.gschema.xml:147
 msgid "Sorts the apps shown in the overview in alphabetical order"
@@ -260,7 +307,9 @@ msgstr "Ordena los programas mostrados en el resumen en orden alfabético"
 msgid ""
 "Overrides the name of the \"Featured\" entry in the side-filter (category "
 "list)"
-msgstr "Anula el nombre de la entrada \"Destacados\" en el filtro lateral (lista de categorías)"
+msgstr ""
+"Anula el nombre de la entrada \"Destacados\" en el filtro lateral (lista de "
+"categorías)"
 
 #: src/gnome-software-local-file.desktop.in:3
 msgid "Software Install"
@@ -270,8 +319,7 @@ msgstr "Instalar software"
 msgid "Install selected software on the system"
 msgstr "Instalar el software seleccionado en el sistema"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 #: src/gnome-software-local-file.desktop.in:10
 msgid "system-software-install"
 msgstr "system-software-install"
@@ -298,14 +346,12 @@ msgstr "Retroceder"
 msgid "_All"
 msgstr "_Todo"
 
-#. Translators: A label for a button to show only software which is already
-#. installed.
+#. Translators: A label for a button to show only software which is already installed.
 #: src/gnome-software.ui:104
 msgid "_Installed"
 msgstr "_Instalado"
 
-#. Translators: A label for a button to show only updates which are available
-#. to install.
+#. Translators: A label for a button to show only updates which are available to install.
 #: src/gnome-software.ui:155
 msgid "_Updates"
 msgstr "_Actualizaciones"
@@ -353,7 +399,7 @@ msgstr "Instalado"
 
 #. TRANSLATORS: this is a button next to the search results that
 #. * shows the status of an application being installed
-#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:443
+#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:439
 msgid "Installing"
 msgstr "Instalando"
 
@@ -368,7 +414,7 @@ msgid "Folder Name"
 msgstr "Nombre de la carpeta"
 
 #: src/gs-app-folder-dialog.c:321 src/gs-app-folder-dialog.ui:16
-#: src/gs-details-page.c:383 src/gs-details-page.ui:342 src/gs-editor.c:623
+#: src/gs-details-page.c:379 src/gs-details-page.ui:342 src/gs-editor.c:623
 #: src/gs-editor.c:655 src/gs-installed-page.c:609 src/gs-removal-dialog.ui:33
 #: src/gs-review-dialog.ui:23 src/gs-upgrade-banner.ui:131
 msgid "_Cancel"
@@ -383,90 +429,94 @@ msgid "Add to Application Folder"
 msgstr "Añadir a la carpeta de aplicaciones"
 
 #. TRANSLATORS: this is a command line option
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "Start up mode: either ‘updates’, ‘updated’, ‘installed’ or ‘overview’"
-msgstr "Modo de inicio, puede ser «actualizaciones», «actualizados», «instalados» o «vista general»"
+msgstr ""
+"Modo de inicio, puede ser «actualizaciones», «actualizados», «instalados» o "
+"«vista general»"
 
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "MODE"
 msgstr "MODO"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "Search for applications"
 msgstr "Buscar aplicaciones"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "SEARCH"
 msgstr "BUSCAR"
 
-#: src/gs-application.c:105
+#: src/gs-application.c:133
 msgid "Show application details (using application ID)"
 msgstr "Mostrar los detalles de la aplicación (usando el ID de la aplicación)"
 
-#: src/gs-application.c:105 src/gs-application.c:109
+#: src/gs-application.c:133 src/gs-application.c:137
 msgid "ID"
 msgstr "ID"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "Show application details (using package name)"
 msgstr "Mostrar los detalles de la aplicación (usando el nombre del paquete)"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "PKGNAME"
 msgstr "PAQUETE"
 
-#: src/gs-application.c:109
+#: src/gs-application.c:137
 msgid "Install the application (using application ID)"
 msgstr "Instalar la aplicación (usando el ID de la aplicación)"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "Open a local package file"
 msgstr "Abrir un archivo de paquete local"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "FILENAME"
 msgstr "ARCHIVO"
 
-#: src/gs-application.c:113
+#: src/gs-application.c:141
 msgid ""
 "The kind of interaction expected for this action: either ‘none’, ‘notify’, "
 "or ‘full’"
-msgstr "El tipo de interacción esperada para esta acción: puede ser «none», «notify» o «full»"
+msgstr ""
+"El tipo de interacción esperada para esta acción: puede ser «none», «notify» "
+"o «full»"
 
-#: src/gs-application.c:116
+#: src/gs-application.c:144
 msgid "Show verbose debugging information"
 msgstr "Mostrar información de depuración detallada"
 
-#: src/gs-application.c:118
+#: src/gs-application.c:146
 msgid "Show profiling information for the service"
 msgstr "Mostrar información del perfil para el servicio"
 
-#: src/gs-application.c:120
+#: src/gs-application.c:148
 msgid "Quit the running instance"
 msgstr "Salir de la instancia en ejecución"
 
-#: src/gs-application.c:122
+#: src/gs-application.c:150
 msgid "Prefer local file sources to AppStream"
 msgstr "Preferir las fuentes de archivos locales a las de AppStream"
 
-#: src/gs-application.c:124
+#: src/gs-application.c:152
 msgid "Show version number"
 msgstr "Mostrar el número de versión"
 
-#: src/gs-application.c:325
+#: src/gs-application.c:358
 msgid "translator-credits"
 msgstr "Daniel Mustieles <daniel.mustieles@gmail.com>, 2013-2016"
 
 #. TRANSLATORS: this is the title of the about window, e.g.
 #. * 'About Software' or 'About Application Installer' where the %s is
 #. * the application name chosen by the distro
-#: src/gs-application.c:332
+#: src/gs-application.c:365
 #, c-format
 msgid "About %s"
 msgstr "Acerca de %s"
 
 #. TRANSLATORS: well, we seem to think so, anyway
-#: src/gs-application.c:336
+#: src/gs-application.c:369
 msgid "A nice way to manage the software on your system."
 msgstr "Una buena manera de gestionar el software en su sistema."
 
@@ -558,7 +608,8 @@ msgstr "Iniciar sesión automáticamente la próxima vez"
 
 #: src/gs-auth-dialog.ui:210
 msgid "Enter your one-time pin for two-factor authentication."
-msgstr "Introduzca su pin de un solo uso para la autenticación de dos factores."
+msgstr ""
+"Introduzca su pin de un solo uso para la autenticación de dos factores."
 
 #: src/gs-auth-dialog.ui:223
 msgid "PIN"
@@ -581,7 +632,7 @@ msgid "All"
 msgstr "Todo"
 
 #. TRANSLATORS: this is a subcategory of featured apps
-#: lib/gs-category.c:202 src/gs-shell.c:2180
+#: lib/gs-category.c:202 src/gs-shell.c:2181
 msgid "Featured"
 msgstr "Destacado"
 
@@ -591,9 +642,11 @@ msgstr "Configuración de la extensión"
 
 #: src/gs-category-page.ui:110
 msgid ""
-"Extensions are used at your own risk. If you have any system problems, it is"
-" recommended to disable them."
-msgstr "Las extensiones se usan bajo su responsabilidad. Si tiene problemas en el sistema, es recomendable desactivarlas."
+"Extensions are used at your own risk. If you have any system problems, it is "
+"recommended to disable them."
+msgstr ""
+"Las extensiones se usan bajo su responsabilidad. Si tiene problemas en el "
+"sistema, es recomendable desactivarlas."
 
 #. TRANSLATORS: the user isn't reading the question
 #: lib/gs-cmd.c:205
@@ -616,7 +669,9 @@ msgstr "Se han instalado las actualizaciones del SO"
 #. * have been successfully installed
 #: src/gs-common.c:138
 msgid "Recently installed updates are available to review"
-msgstr "Las actualizaciones instaladas recientemente están disponibles para su revisión"
+msgstr ""
+"Las actualizaciones instaladas recientemente están disponibles para su "
+"revisión"
 
 #. TRANSLATORS: this is the summary of a notification that an application
 #. * has been successfully installed
@@ -649,13 +704,15 @@ msgstr "¿Activar la fuente de software de terceros?"
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
 #. * 2. Software source name, e.g. fedora-optional
+#.
 #: src/gs-common.c:232
 #, c-format
 msgid ""
 "%s is not <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
-"source_software\">free and open source software</a>, and is provided by "
-"“%s”."
-msgstr "%s no es <a href=\"https://en.wikipedia.org/wiki/Free_and_open-source_software\">software libre</a>, lo proporciona «%s»."
+"source_software\">free and open source software</a>, and is provided by “%s”."
+msgstr ""
+"%s no es <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
+"source_software\">software libre</a>, lo proporciona «%s»."
 
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
@@ -668,7 +725,8 @@ msgstr "%s proporcionado por «%s»."
 #. TRANSLATORS: a software source is a repo
 #: src/gs-common.c:252
 msgid "This software source must be enabled to continue installation."
-msgstr "Esta fuente de software debe estar activada para continuar la instalación."
+msgstr ""
+"Esta fuente de software debe estar activada para continuar la instalación."
 
 #. TRANSLATORS: Laws are geographical, urgh...
 #: src/gs-common.c:262
@@ -730,12 +788,14 @@ msgstr "Sin violencia fantástica"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:90
 msgid "Characters in unsafe situations easily distinguishable from reality"
-msgstr "Personajes en situaciones no seguras distinguibles fácilmente de la realidad"
+msgstr ""
+"Personajes en situaciones no seguras distinguibles fácilmente de la realidad"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:93
 msgid "Characters in aggressive conflict easily distinguishable from reality"
-msgstr "Personajes en conflictos agresivos distinguibles fácilmente de la realidad"
+msgstr ""
+"Personajes en conflictos agresivos distinguibles fácilmente de la realidad"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:96
@@ -940,12 +1000,14 @@ msgstr "Venta de productos"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:216
 msgid "Explicit references to specific brands or trademarked products"
-msgstr "Referencias explícitas a marcas concretas o productos de marcas registradas"
+msgstr ""
+"Referencias explícitas a marcas concretas o productos de marcas registradas"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:219
 msgid "Players are encouraged to purchase specific real-world items"
-msgstr "Se incita a los jugadores a comprar determinados elementos del mundo real"
+msgstr ""
+"Se incita a los jugadores a comprar determinados elementos del mundo real"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:222
@@ -990,7 +1052,8 @@ msgstr "Interacciones de jugador a jugador del juego sin funcionalidad de chat"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:246
 msgid "Player-to-player preset interactions without chat functionality"
-msgstr "Interacciones de jugador a jugador preestablecidas sin funcionalidad de chat"
+msgstr ""
+"Interacciones de jugador a jugador preestablecidas sin funcionalidad de chat"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:249
@@ -1010,12 +1073,15 @@ msgstr "Funcionalidad de sonido o vídeo sin controlar entre jugadores"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:258
 msgid "No sharing of social network usernames or email addresses"
-msgstr "No comparte en redes sociales de nombres de usuario o direcciones de correo-e"
+msgstr ""
+"No comparte en redes sociales de nombres de usuario o direcciones de correo-e"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:261
 msgid "Sharing social network usernames or email addresses"
-msgstr "Compartición en redes sociales de nombres de usuario o direcciones de correo-e"
+msgstr ""
+"Compartición en redes sociales de nombres de usuario o direcciones de correo-"
+"e"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:264
@@ -1037,14 +1103,12 @@ msgstr "No comparte la ubicación física con otros usuarios"
 msgid "Sharing physical location to other users"
 msgstr "Compartición de la ubicación física con otros usuarios"
 
-#. TRANSLATORS: this is a what we use in notifications if the app's name is
-#. unknown
+#. TRANSLATORS: this is a what we use in notifications if the app's name is unknown
 #: src/gs-dbus-helper.c:294
 msgid "An application"
 msgstr "Una aplicación"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. MIME types.
+#. TRANSLATORS: this is a notification displayed when an app needs additional MIME types.
 #: src/gs-dbus-helper.c:300
 #, c-format
 msgid "%s is requesting additional file format support."
@@ -1055,8 +1119,7 @@ msgstr "%s necesita soporte para formatos de archivos adicionales."
 msgid "Additional MIME Types Required"
 msgstr "Se necesitan tipos MIME adicionales"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. fonts.
+#. TRANSLATORS: this is a notification displayed when an app needs additional fonts.
 #: src/gs-dbus-helper.c:306
 #, c-format
 msgid "%s is requesting additional fonts."
@@ -1067,8 +1130,7 @@ msgstr "%s necesita tipografías adicionales."
 msgid "Additional Fonts Required"
 msgstr "Se necesitan tipografías adicionales"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. codecs.
+#. TRANSLATORS: this is a notification displayed when an app needs additional codecs.
 #: src/gs-dbus-helper.c:312
 #, c-format
 msgid "%s is requesting additional multimedia codecs."
@@ -1079,8 +1141,7 @@ msgstr "%s necesita codificadores multimedia adicionales."
 msgid "Additional Multimedia Codecs Required"
 msgstr "Se necesitan codificadores multimedia adicionales"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. printer drivers.
+#. TRANSLATORS: this is a notification displayed when an app needs additional printer drivers.
 #: src/gs-dbus-helper.c:318
 #, c-format
 msgid "%s is requesting additional printer drivers."
@@ -1091,8 +1152,7 @@ msgstr "%s necesita controladores de impresora adicionales."
 msgid "Additional Printer Drivers Required"
 msgstr "Se necesita controladores de impresora adicionales"
 
-#. TRANSLATORS: this is a notification displayed when an app wants to install
-#. additional packages.
+#. TRANSLATORS: this is a notification displayed when an app wants to install additional packages.
 #: src/gs-dbus-helper.c:324
 #, c-format
 msgid "%s is requesting additional packages."
@@ -1112,14 +1172,14 @@ msgstr "Buscar en Software"
 #. * can be installed
 #. TRANSLATORS: button text in the header when firmware
 #. * can be live-installed
-#: src/gs-details-page.c:281 src/gs-details-page.c:312
-#: src/gs-details-page.ui:206 src/gs-upgrade-banner.ui:146
+#: src/gs-details-page.c:280 src/gs-details-page.c:310
+#: src/gs-details-page.ui:237 src/gs-upgrade-banner.ui:146
 msgid "_Install"
 msgstr "_Instalar"
 
 #. TRANSLATORS: button text in the header when an application
 #. * can be live-updated
-#: src/gs-details-page.c:316
+#: src/gs-details-page.c:314
 msgid "_Update"
 msgstr "_Actualizar"
 
@@ -1127,67 +1187,69 @@ msgstr "_Actualizar"
 #. * be installed.
 #. * The ellipsis indicates that further steps are required,
 #. * e.g. enabling software sources or the like
-#: src/gs-details-page.c:330
+#: src/gs-details-page.c:326
 msgid "_Install…"
 msgstr "_Instalar…"
 
 #. TRANSLATORS: button text in the header when an application can be erased
-#: src/gs-details-page.c:377 src/gs-details-page.ui:547
+#: src/gs-details-page.c:373 src/gs-details-page.ui:547
 msgid "_Uninstall"
 msgstr "_Desinstalar"
 
-#: src/gs-details-page.c:438 src/gs-sources-dialog.c:513
+#: src/gs-details-page.c:434 src/gs-sources-dialog.c:513
 msgid "Removing…"
 msgstr "Quitando…"
 
 #. TRANSLATORS: this is the warning box
-#: src/gs-details-page.c:748
+#: src/gs-details-page.c:744
 msgid ""
 "This application can only be used when there is an active internet "
 "connection."
-msgstr "Esta aplicación sólo se puede usar cuando existe una conexión activa a Internet."
+msgstr ""
+"Esta aplicación sólo se puede usar cuando existe una conexión activa a "
+"Internet."
 
 #. TRANSLATORS: this is where the version is not known
-#: src/gs-details-page.c:892
+#: src/gs-details-page.c:888
 msgctxt "version"
 msgid "Unknown"
 msgstr "Desconocida"
 
 #. TRANSLATORS: this is where we don't know the origin of the
 #. * application
-#: src/gs-details-page.c:971
+#: src/gs-details-page.c:967
 msgctxt "origin"
 msgid "Unknown"
 msgstr "Desconocido"
 
 #. TRANSLATORS: we need a remote server to process
-#: src/gs-details-page.c:1378
+#: src/gs-details-page.c:1374
 msgid "You need internet access to write a review"
 msgstr "Necesita acceso a Internet para escribir una reseña"
 
-#: src/gs-details-page.c:1507
+#: src/gs-details-page.c:1503
 #, c-format
 msgid "Unable to find “%s”"
 msgstr "No se pudo encontrar «%s»"
 
 #. TRANSLATORS: see the wikipedia page
-#: src/gs-details-page.c:2087
+#: src/gs-details-page.c:2083
 msgid "Public domain"
 msgstr "Dominio público"
 
 #. TRANSLATORS: see GNU page
-#: src/gs-details-page.c:2103 src/gs-details-page.ui:1397
+#: src/gs-details-page.c:2099 src/gs-details-page.ui:1397
 msgid "Free Software"
 msgstr "Software libre"
 
 #. TRANSLATORS: for the free software popover
-#: src/gs-details-page.c:2160
+#: src/gs-details-page.c:2156
 msgid "Users are bound by the following license:"
 msgid_plural "Users are bound by the following licenses:"
 msgstr[0] "Los usuarios están limitados por la siguiente licencia:"
 msgstr[1] "Los usuarios están limitados por las siguientes licencias:"
 
-#: src/gs-details-page.c:2176 src/gs-details-page.ui:1506
+#: src/gs-details-page.c:2172 src/gs-details-page.ui:1506
 msgid "More information"
 msgstr "Más información"
 
@@ -1195,15 +1257,13 @@ msgstr "Más información"
 msgid "Details page"
 msgstr "Página de detalles"
 
-#. Translators: A label for a button to add a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:228
+#. Translators: A label for a button to add a shortcut to the selected application.
+#: src/gs-details-page.ui:209
 msgid "_Add to Desktop"
 msgstr "_Agregar al escritorio"
 
-#. Translators: A label for a button to remove a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:245
+#. Translators: A label for a button to remove a shortcut to the selected application.
+#: src/gs-details-page.ui:226
 msgid "_Remove from Desktop"
 msgstr "_Quitar del escritorio"
 
@@ -1224,7 +1284,9 @@ msgstr "Fuente de software incluída"
 msgid ""
 "This application includes a software source which provides updates, as well "
 "as access to other software."
-msgstr "Esta aplicación incluye una fuente de software que proporciona actualizaciones, así como acceso a otro software."
+msgstr ""
+"Esta aplicación incluye una fuente de software que proporciona "
+"actualizaciones, así como acceso a otro software."
 
 #: src/gs-details-page.ui:500
 msgid "No Software Source Included"
@@ -1234,16 +1296,18 @@ msgstr "Ninguna fuente de software incluída"
 msgid ""
 "This application does not include a software source. It will not be updated "
 "with new versions."
-msgstr "Esta aplicación no incluye una fuente de software. No se actualizará con versiones nuevas."
+msgstr ""
+"Esta aplicación no incluye una fuente de software. No se actualizará con "
+"versiones nuevas."
 
 #: src/gs-details-page.ui:515
 msgid ""
 "This software is already provided by your distribution and should not be "
 "replaced."
-msgstr "Este software ya lo proporciona su distribución y no se debe reemplazar."
+msgstr ""
+"Este software ya lo proporciona su distribución y no se debe reemplazar."
 
-#. Translators: a repository file used for installing software has been
-#. discovered.
+#. Translators: a repository file used for installing software has been discovered.
 #: src/gs-details-page.ui:528
 msgid "Software Source Identified"
 msgstr "Fuente de software identificada"
@@ -1252,7 +1316,9 @@ msgstr "Fuente de software identificada"
 msgid ""
 "Adding this software source will give you access to additional software and "
 "upgrades."
-msgstr "Añadir esta fuente de software le dará acceso a software y actualizaciones adicionales."
+msgstr ""
+"Añadir esta fuente de software le dará acceso a software y actualizaciones "
+"adicionales."
 
 #: src/gs-details-page.ui:530
 msgid "Only use software sources that you trust."
@@ -1344,14 +1410,12 @@ msgstr "Complementos"
 msgid "Selected add-ons will be installed with the application."
 msgstr "Los complementos seleccionados se instalarán con la aplicación."
 
-#. Translators: Header of the section with other users' opinions about the
-#. app.
+#. Translators: Header of the section with other users' opinions about the app.
 #: src/gs-details-page.ui:1233
 msgid "Reviews"
 msgstr "Opiniones"
 
-#. Translators: Button opening a dialog where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Button opening a dialog where the users can write and publish their opinions about the apps.
 #: src/gs-details-page.ui:1249
 msgid "_Write a Review"
 msgstr "_Escribir una opinión"
@@ -1363,9 +1427,11 @@ msgstr "_Mostrar más"
 
 #: src/gs-details-page.ui:1414
 msgid ""
-"This means that the software can be freely run, copied, distributed, studied"
-" and modified."
-msgstr "Esto significa que el software se puede ejecutar, copiar, distribuir, estudiar y modificar libremente."
+"This means that the software can be freely run, copied, distributed, studied "
+"and modified."
+msgstr ""
+"Esto significa que el software se puede ejecutar, copiar, distribuir, "
+"estudiar y modificar libremente."
 
 #: src/gs-details-page.ui:1473
 msgid "Proprietary Software"
@@ -1376,7 +1442,10 @@ msgid ""
 "This means that the software is owned by an individual or a company. There "
 "are often restrictions on its use and its source code cannot usually be "
 "accessed."
-msgstr "Esto significa que el software es propiedad de una persona individual o una empresa. A menudo hay restricciones en su uso y normalmente no se puede acceder a su código fuente."
+msgstr ""
+"Esto significa que el software es propiedad de una persona individual o una "
+"empresa. A menudo hay restricciones en su uso y normalmente no se puede "
+"acceder a su código fuente."
 
 #: src/gs-details-page.ui:1535
 msgid "Unknown Software License"
@@ -1460,8 +1529,7 @@ msgstr "La lista de aplicaciones tiene cambios sin guardar."
 msgid "Use verbose logging"
 msgstr "Usar registro detallado"
 
-#. TRANSLATORS: program name, an application to add and remove software
-#. repositories
+#. TRANSLATORS: program name, an application to add and remove software repositories
 #: src/gs-editor.c:1119
 msgid "GNOME Software Banner Designer"
 msgstr "Diseñador de banners de software de GNOME"
@@ -1490,8 +1558,7 @@ msgstr "Resumen"
 msgid "Editor’s Pick"
 msgstr "Selecciones de los editores"
 
-#. This check button controls whether the application’s banner appears in the
-#. “Featured” category
+#. This check button controls whether the application’s banner appears in the “Featured” category
 #: src/gs-editor.ui:397
 msgid "Category Featured"
 msgstr "Categoría destacada"
@@ -1580,9 +1647,11 @@ msgstr "No hay aplicaciones disponibles que proporcionen el archivo %s."
 #: src/gs-extras-page.c:337 src/gs-extras-page.c:348 src/gs-extras-page.c:359
 #, c-format
 msgid ""
-"Information about %s, as well as options for how to get missing applications"
-" might be found %s."
-msgstr "La información sobre %s, así como opciones sobre cómo obtener las aplicaciones que faltan se puede encontrar en %s."
+"Information about %s, as well as options for how to get missing applications "
+"might be found %s."
+msgstr ""
+"La información sobre %s, así como opciones sobre cómo obtener las "
+"aplicaciones que faltan se puede encontrar en %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1605,7 +1674,9 @@ msgstr "%s no está disponible."
 msgid ""
 "Information about %s, as well as options for how to get an application that "
 "can support this format might be found %s."
-msgstr "La información sobre %s, así como opciones sobre cómo obtener una aplicación que pueda soportar este formato se puede encontrar en %s."
+msgstr ""
+"La información sobre %s, así como opciones sobre cómo obtener una aplicación "
+"que pueda soportar este formato se puede encontrar en %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1621,11 +1692,13 @@ msgstr "No hay tipografías disponibles para el soporte del script %s."
 msgid ""
 "Information about %s, as well as options for how to get additional fonts "
 "might be found %s."
-msgstr "La información sobre %s, así como opciones sobre cómo obtener tipografías adicionales se puede encontrar en %s."
+msgstr ""
+"La información sobre %s, así como opciones sobre cómo obtener tipografías "
+"adicionales se puede encontrar en %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
-#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1426
+#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1430
 #, c-format
 msgid "No addon codecs are available for the %s format."
 msgstr "No hay códecs disponibles para el formato %s."
@@ -1637,7 +1710,9 @@ msgstr "No hay códecs disponibles para el formato %s."
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format might be found %s."
-msgstr "La información sobre %s, así como opciones sobre cómo obtener un códec que pueda reproducir este formato se puede encontrar en %s."
+msgstr ""
+"La información sobre %s, así como opciones sobre cómo obtener un códec que "
+"pueda reproducir este formato se puede encontrar en %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1653,7 +1728,9 @@ msgstr "No hay recursos de Plasma disponibles para soportar %s."
 msgid ""
 "Information about %s, as well as options for how to get additional Plasma "
 "resources might be found %s."
-msgstr "La información sobre %s, así como opciones sobre cómo obtener recursos de Plasma adicionales se puede encontrar en %s."
+msgstr ""
+"La información sobre %s, así como opciones sobre cómo obtener recursos de "
+"Plasma adicionales se puede encontrar en %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1669,15 +1746,16 @@ msgstr "No hay controladores de impresora disponibles para %s."
 msgid ""
 "Information about %s, as well as options for how to get a driver that "
 "supports this printer might be found %s."
-msgstr "La información sobre %s, así como opciones sobre cómo obtener un controlador que soporte esta impresora se puede encontrar en %s."
+msgstr ""
+"La información sobre %s, así como opciones sobre cómo obtener un controlador "
+"que soporte esta impresora se puede encontrar en %s."
 
 #. TRANSLATORS: hyperlink title
 #: src/gs-extras-page.c:459
 msgid "this website"
 msgstr "esta página web"
 
-#. TRANSLATORS: no codecs were found. First %s will be replaced by actual
-#. codec name(s), second %s is a link titled "this website"
+#. TRANSLATORS: no codecs were found. First %s will be replaced by actual codec name(s), second %s is a link titled "this website"
 #: src/gs-extras-page.c:463
 #, c-format
 msgid ""
@@ -1686,8 +1764,12 @@ msgid ""
 msgid_plural ""
 "Unfortunately, the %s you were searching for could not be found. Please see "
 "%s for more information."
-msgstr[0] "El codificador %s que estaba buscando no se ha podido encontrar. Consulte %s para obtener más información."
-msgstr[1] "Los codificadores %s que estaba buscando no se ha podido encontrar. Consulte %s para obtener más información."
+msgstr[0] ""
+"El codificador %s que estaba buscando no se ha podido encontrar. Consulte %s "
+"para obtener más información."
+msgstr[1] ""
+"Los codificadores %s que estaba buscando no se ha podido encontrar. Consulte "
+"%s para obtener más información."
 
 #: src/gs-extras-page.c:535 src/gs-extras-page.c:591 src/gs-extras-page.c:630
 msgid "Failed to find any search results"
@@ -1712,10 +1794,13 @@ msgstr "Bienvenido/a a Software"
 
 #: src/gs-first-run-dialog.ui:66
 msgid ""
-"Software lets you install all the software you need, all from one place. See"
-" our recommendations, browse the categories, or search for the applications "
+"Software lets you install all the software you need, all from one place. See "
+"our recommendations, browse the categories, or search for the applications "
 "you want."
-msgstr "Software le permite instalar todo el software que necesite desde un único lugar. Vea las recomendaciones, explore las categorías o busque las aplicaciones que quiere."
+msgstr ""
+"Software le permite instalar todo el software que necesite desde un único "
+"lugar. Vea las recomendaciones, explore las categorías o busque las "
+"aplicaciones que quiere."
 
 #: src/gs-first-run-dialog.ui:85
 msgid "_Let’s Go Shopping"
@@ -1865,13 +1950,14 @@ msgstr "Aplicaciones de productividad recomendadas"
 #: src/gs-overview-page.c:974
 msgid ""
 "Provides access to additional software, including web browsers and games."
-msgstr "Proporciona acceso a software adicional, incluyendo navegadores web y juegos."
+msgstr ""
+"Proporciona acceso a software adicional, incluyendo navegadores web y juegos."
 
 #. TRANSLATORS: this is the proprietary info bar
 #: src/gs-overview-page.c:978
-msgid ""
-"Proprietary software has restrictions on use and access to source code."
-msgstr "El software propietario tiene restricciones de uso y acceso al código fuente."
+msgid "Proprietary software has restrictions on use and access to source code."
+msgstr ""
+"El software propietario tiene restricciones de uso y acceso al código fuente."
 
 #. TRANSLATORS: this is the clickable
 #. * link on the proprietary info bar
@@ -1900,14 +1986,12 @@ msgstr "Aplicación destacada"
 msgid "Categories"
 msgstr "Categorías"
 
-#. Translators: This is a heading for software which has been featured
-#. ('picked') by the distribution.
+#. Translators: This is a heading for software which has been featured ('picked') by the distribution.
 #: src/gs-overview-page.ui:315
 msgid "Editor’s Picks"
 msgstr "Selecciones de los editores"
 
-#. Translators: This is a heading for software which has been recently
-#. released upstream.
+#. Translators: This is a heading for software which has been recently released upstream.
 #: src/gs-overview-page.ui:359
 msgid "Recent Releases"
 msgstr "Publicaciones recientes"
@@ -1954,7 +2038,9 @@ msgstr "¿Está seguro de querer quitar el recurso %s?"
 msgid ""
 "All applications from %s will be removed, and you will have to re-install "
 "the source to use them again."
-msgstr "Se quitarán todas las aplicaciones de %s y deberá volver a instalar la fuente para poder usarla de nuevo."
+msgstr ""
+"Se quitarán todas las aplicaciones de %s y deberá volver a instalar la "
+"fuente para poder usarla de nuevo."
 
 #. TRANSLATORS: this is a prompt message, and '%s' is an
 #. * application summary, e.g. 'GNOME Clocks'
@@ -1969,12 +2055,14 @@ msgstr "¿Está seguro de querer quitar %s?"
 msgid "%s will be removed, and you will have to install it to use it again."
 msgstr "Se quitará %s y deberá volver a instalarlo para poder usarlo de nuevo."
 
-#: lib/gs-plugin-loader.c:1429
+#: lib/gs-plugin-loader.c:1433
 #, c-format
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format can be found on the website."
-msgstr "En la página web se puede encontrar información sobre %s, así como opciones sobre cómo obtener un códec que pueda reproducir este formato."
+msgstr ""
+"En la página web se puede encontrar información sobre %s, así como opciones "
+"sobre cómo obtener un códec que pueda reproducir este formato."
 
 #: lib/gs-price.c:111
 #, c-format
@@ -2033,7 +2121,9 @@ msgstr "%s %f"
 msgid ""
 "Some of the currently installed software is not compatible with %s. If you "
 "continue, the following will be automatically removed during the upgrade:"
-msgstr "Alguno de los programas instalados no es compatible con %s. Si continúa, los siguientes paquetes se eliminarán automáticamente durante la actualización:"
+msgstr ""
+"Alguno de los programas instalados no es compatible con %s. Si continúa, los "
+"siguientes paquetes se eliminarán automáticamente durante la actualización:"
 
 #: src/gs-removal-dialog.ui:27
 msgid "Incompatible Software"
@@ -2103,8 +2193,7 @@ msgstr "La descripción es demasiado corta"
 msgid "The description is too long"
 msgstr "La descripción es demasiado larga"
 
-#. Translators: Title of the dialog box where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Title of the dialog box where the users can write and publish their opinions about the apps.
 #: src/gs-review-dialog.ui:11
 msgid "Post Review"
 msgstr "Publicar revisión"
@@ -2122,7 +2211,9 @@ msgstr "Puntuación"
 msgid ""
 "Give a short summary of your review, for example: “Great app, would "
 "recommend”."
-msgstr "Haga un pequeño resumen de su opinión, por ejemplo: «Una aplicación muy buena, recomendada»."
+msgstr ""
+"Haga un pequeño resumen de su opinión, por ejemplo: «Una aplicación muy "
+"buena, recomendada»."
 
 #. Translators: This is where the users enter their opinions about the apps.
 #: src/gs-review-dialog.ui:199
@@ -2132,7 +2223,8 @@ msgstr "Opinión"
 
 #: src/gs-review-dialog.ui:215
 msgid "What do you think of the app? Try to give reasons for your views."
-msgstr "¿Qué piensa sobre la aplicación? Intente dar una explicación a sus opiniones."
+msgstr ""
+"¿Qué piensa sobre la aplicación? Intente dar una explicación a sus opiniones."
 
 #. Translators: A label for the total number of reviews.
 #: src/gs-review-histogram.ui:413
@@ -2142,14 +2234,18 @@ msgstr "puntuación total"
 #. TRANSLATORS: we explain what the action is going to do
 #: src/gs-review-row.c:234
 msgid "You can report reviews for abusive, rude, or discriminatory behavior."
-msgstr "Puede enviar opiniones sobre comportamientos abusivos, groseros o discriminatorios."
+msgstr ""
+"Puede enviar opiniones sobre comportamientos abusivos, groseros o "
+"discriminatorios."
 
 #. TRANSLATORS: we ask the user if they really want to do this
 #: src/gs-review-row.c:239
 msgid ""
 "Once reported, a review will be hidden until it has been checked by an "
 "administrator."
-msgstr "Una vez enviada, la opinión se ocultará hasta que un administrador la haya verificado."
+msgstr ""
+"Una vez enviada, la opinión se ocultará hasta que un administrador la haya "
+"verificado."
 
 #. TRANSLATORS: window title when
 #. * reporting a user-submitted review
@@ -2164,8 +2260,7 @@ msgstr "¿Publicar revisión?"
 msgid "Report"
 msgstr "Publicar"
 
-#. Translators: Users can express their opinions about other users' opinions
-#. about the apps.
+#. Translators: Users can express their opinions about other users' opinions about the apps.
 #: src/gs-review-row.ui:112
 msgid "Was this review useful to you?"
 msgstr "¿Le ha resultado útil esta opinión?"
@@ -2254,81 +2349,88 @@ msgstr "No se han encontrado aplicaciones"
 #. TRANSLATORS: this is part of the in-app notification,
 #. * where the %s is a multi-word localised app name
 #. * e.g. 'Getting things GNOME!"
-#: src/gs-shell.c:846 src/gs-shell.c:851 src/gs-shell.c:866 src/gs-shell.c:870
+#: src/gs-shell.c:847 src/gs-shell.c:852 src/gs-shell.c:867 src/gs-shell.c:871
 #, c-format
 msgid "“%s”"
 msgstr "«%s»"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:898
+#: src/gs-shell.c:899
 #, c-format
 msgid "Unable to download firmware updates from %s"
 msgstr "No se pueden descargar las actualizaciones de «firmware» desde %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:904
+#: src/gs-shell.c:905
 #, c-format
 msgid "Unable to download updates from %s"
 msgstr "No se pueden descargar actualizaciones desde %s"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:911
+#: src/gs-shell.c:912
 msgid "Unable to download updates"
 msgstr "No se pueden descargar las actualizaciones"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:916
+#: src/gs-shell.c:917
 msgid ""
-"Unable to download updates: internet access was required but wasn’t "
-"available"
-msgstr "No se pueden descargar las actualizaciones: se necesita acceso a Internet, pero no está disponible"
+"Unable to download updates: internet access was required but wasn’t available"
+msgstr ""
+"No se pueden descargar las actualizaciones: se necesita acceso a Internet, "
+"pero no está disponible"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:925
+#: src/gs-shell.c:926
 #, c-format
 msgid "Unable to download updates from %s: not enough disk space"
-msgstr "No se pueden descargar actualizaciones de %s: no hay espacio suficiente en disco"
+msgstr ""
+"No se pueden descargar actualizaciones de %s: no hay espacio suficiente en "
+"disco"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:930
+#: src/gs-shell.c:931
 msgid "Unable to download updates: not enough disk space"
-msgstr "No se pueden descargar las actualizaciones: no hay suficiente espacio en disco"
+msgstr ""
+"No se pueden descargar las actualizaciones: no hay suficiente espacio en "
+"disco"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:938
+#: src/gs-shell.c:939
 msgid "Unable to download updates: authentication was required"
 msgstr "No se pueden descargar actualizaciones: se necesita autenticación"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:943
+#: src/gs-shell.c:944
 msgid "Unable to download updates: authentication was invalid"
 msgstr "No se pueden descargar actualizaciones: la autenticación no es válida"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:948
+#: src/gs-shell.c:949
 msgid ""
 "Unable to download updates: you do not have permission to install software"
-msgstr "No se pueden descargar actualizaciones: no tiene permisos para instalar software"
+msgstr ""
+"No se pueden descargar actualizaciones: no tiene permisos para instalar "
+"software"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:955
+#: src/gs-shell.c:956
 msgid "Unable to get list of updates"
 msgstr "No se puede obtener la lista de actualizaciones"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the application name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1001
+#: src/gs-shell.c:1002
 #, c-format
 msgid "Unable to install %s as download failed from %s"
 msgstr "No se puede instalar %s ya que ha fallado la descarga de %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1007
+#: src/gs-shell.c:1008
 #, c-format
 msgid "Unable to install %s as download failed"
 msgstr "No se puede instalar %s ya que ha fallado la descarga"
@@ -2337,51 +2439,54 @@ msgstr "No se puede instalar %s ya que ha fallado la descarga"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1019
+#: src/gs-shell.c:1020
 #, c-format
 msgid "Unable to install %s as runtime %s not available"
-msgstr "No se puede instalar %s ya que la rutina de tiempo de ejecución %s no está disponible"
+msgstr ""
+"No se puede instalar %s ya que la rutina de tiempo de ejecución %s no está "
+"disponible"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1025
+#: src/gs-shell.c:1026
 #, c-format
 msgid "Unable to install %s as not supported"
 msgstr "No se puede instalar %s ya que no está soportado"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1032
+#: src/gs-shell.c:1033
 msgid "Unable to install: internet access was required but wasn’t available"
-msgstr "No se puede instalar: se necesita acceso a Internet, pero no está disponible"
+msgstr ""
+"No se puede instalar: se necesita acceso a Internet, pero no está disponible"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1038
+#: src/gs-shell.c:1039
 msgid "Unable to install: the application has an invalid format"
 msgstr "No se puede instalar %s: la aplicación no tiene un formato válido"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1043
+#: src/gs-shell.c:1044
 #, c-format
 msgid "Unable to install %s: not enough disk space"
 msgstr "No se puede instalar %s: no hay suficiente espacio en disco."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1051
+#: src/gs-shell.c:1052
 #, c-format
 msgid "Unable to install %s: authentication was required"
 msgstr "No se puede instalar %s: se necesita autorización"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1058
+#: src/gs-shell.c:1059
 #, c-format
 msgid "Unable to install %s: authentication was invalid"
 msgstr "No se puede instalar %s: la autenticación no es válida"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1065
+#: src/gs-shell.c:1066
 #, c-format
 msgid "Unable to install %s: you do not have permission to install software"
 msgstr "No se puede instalar %s: no tiene permisos para instalar software"
@@ -2389,34 +2494,34 @@ msgstr "No se puede instalar %s: no tiene permisos para instalar software"
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the name of the authentication service,
 #. * e.g. "Ubuntu One"
-#: src/gs-shell.c:1078
+#: src/gs-shell.c:1079
 #, c-format
 msgid "Your %s account has been suspended."
 msgstr "Su cuenta %s se ha suspendido."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1082
+#: src/gs-shell.c:1083
 msgid "It is not possible to install software until this has been resolved."
 msgstr "No es posible instalar software hasta que esto se haya resuelto."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the clickable link (e.g.
 #. * "http://example.com/what-did-i-do-wrong/")
-#: src/gs-shell.c:1093
+#: src/gs-shell.c:1094
 #, c-format
 msgid "For more information, visit %s."
 msgstr "Para obtener más información, visite %s."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1102
+#: src/gs-shell.c:1103
 #, c-format
 msgid "Unable to install %s: AC power is required"
 msgstr "No se puede instalar %s: se necesita conexión a la alimentación"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1111
+#: src/gs-shell.c:1112
 #, c-format
 msgid "Unable to install %s"
 msgstr "No se puede instalar %s"
@@ -2425,61 +2530,63 @@ msgstr "No se puede instalar %s"
 #. * where the first %s is the app name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1157
+#: src/gs-shell.c:1158
 #, c-format
 msgid "Unable to update %s from %s"
 msgstr "No se puede actualizar %s desde %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1163
+#: src/gs-shell.c:1164
 #, c-format
 msgid "Unable to update %s as download failed"
 msgstr "No se puede actualizar %s "
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1169
+#: src/gs-shell.c:1170
 msgid "Unable to update: internet access was required but wasn’t available"
-msgstr "No se puede actualizar: se necesita acceso a Internet, pero no está disponible"
+msgstr ""
+"No se puede actualizar: se necesita acceso a Internet, pero no está "
+"disponible"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1177
+#: src/gs-shell.c:1178
 #, c-format
 msgid "Unable to update %s: not enough disk space"
 msgstr "No se puede actualizar %s: no hay suficiente espacio en disco."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1186
+#: src/gs-shell.c:1187
 #, c-format
 msgid "Unable to update %s: authentication was required"
 msgstr "No se puede actualizar %s: se necesita autenticación"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1193
+#: src/gs-shell.c:1194
 #, c-format
 msgid "Unable to update %s: authentication was invalid"
 msgstr "No se puede actualizar %s: la autenticación no es válida"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1200
+#: src/gs-shell.c:1201
 #, c-format
 msgid "Unable to update %s: you do not have permission to update software"
 msgstr "No se puede actualizar %s: no tiene permisos para actualizar software"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1208
+#: src/gs-shell.c:1209
 #, c-format
 msgid "Unable to update %s: AC power is required"
 msgstr "No se puede actualizar %s: se necesita conexión a la alimentación"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1217
+#: src/gs-shell.c:1218
 #, c-format
 msgid "Unable to update %s"
 msgstr "No se puede actualizar %s"
@@ -2487,96 +2594,98 @@ msgstr "No se puede actualizar %s"
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the distro name (e.g. "Fedora 25") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1262
+#: src/gs-shell.c:1263
 #, c-format
 msgid "Unable to upgrade to %s from %s"
 msgstr "No se puede actualizar a %s desde %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the app name (e.g. "GIMP")
-#: src/gs-shell.c:1267
+#: src/gs-shell.c:1268
 #, c-format
 msgid "Unable to upgrade to %s as download failed"
 msgstr "No se puede actualizar a %s ya que falló la descarga"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1274
+#: src/gs-shell.c:1275
 msgid "Unable to upgrade: internet access was required but wasn’t available"
-msgstr "No se puede actualizar: se necesita acceso a Internet, pero no está disponible"
+msgstr ""
+"No se puede actualizar: se necesita acceso a Internet, pero no está "
+"disponible"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1282
+#: src/gs-shell.c:1283
 #, c-format
 msgid "Unable to upgrade to %s: not enough disk space"
 msgstr "No se puede actualizar %s: no hay suficiente espacio en disco"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1291
+#: src/gs-shell.c:1292
 #, c-format
 msgid "Unable to upgrade to %s: authentication was required"
 msgstr "No se puede actualizar a %s: se necesita autenticación"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1298
+#: src/gs-shell.c:1299
 #, c-format
 msgid "Unable to upgrade to %s: authentication was invalid"
 msgstr "No se puede actualizar a %s: la autenticación no es válida"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1305
+#: src/gs-shell.c:1306
 #, c-format
 msgid "Unable to upgrade to %s: you do not have permission to upgrade"
 msgstr "No se puede actualizar a %s: no tiene permiso para actualizar"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1312
+#: src/gs-shell.c:1313
 #, c-format
 msgid "Unable to upgrade to %s: AC power is required"
 msgstr "No se puede actualizar a %s: se necesita conexión a la alimentación"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1321
+#: src/gs-shell.c:1322
 #, c-format
 msgid "Unable to upgrade to %s"
 msgstr "No se puede actualizar a %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1363
+#: src/gs-shell.c:1364
 #, c-format
 msgid "Unable to remove %s: authentication was required"
 msgstr "No se puede quitar %s: se necesita autenticación"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1369
+#: src/gs-shell.c:1370
 #, c-format
 msgid "Unable to remove %s: authentication was invalid"
 msgstr "No se puede quitar %s: la autenticación no es válida"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1375
+#: src/gs-shell.c:1376
 #, c-format
 msgid "Unable to remove %s: you do not have permission to remove software"
 msgstr "No se puede quitar %s: no tiene permisos para quitar software"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1382
+#: src/gs-shell.c:1383
 #, c-format
 msgid "Unable to remove %s: AC power is required"
 msgstr "No se puede quitar %s: se necesita conexión a la alimentación"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1391
+#: src/gs-shell.c:1392
 #, c-format
 msgid "Unable to remove %s"
 msgstr "No se puede quitar «%s»"
@@ -2585,48 +2694,50 @@ msgstr "No se puede quitar «%s»"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1437
+#: src/gs-shell.c:1438
 #, c-format
 msgid "Unable to launch %s: %s is not installed"
 msgstr "No se puede lanzar %s: %s no está instalado"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1444 src/gs-shell.c:1492 src/gs-shell.c:1540
+#: src/gs-shell.c:1445 src/gs-shell.c:1493 src/gs-shell.c:1541
 msgid "Not enough disk space — free up some space and try again"
-msgstr "No hay suficiente espacio en disco. Libere algo de espacio e inténtelo de nuevo."
+msgstr ""
+"No hay suficiente espacio en disco. Libere algo de espacio e inténtelo de "
+"nuevo."
 
 #. TRANSLATORS: we failed to get a proper error code
-#: src/gs-shell.c:1452 src/gs-shell.c:1500 src/gs-shell.c:1567
+#: src/gs-shell.c:1453 src/gs-shell.c:1501 src/gs-shell.c:1568
 msgid "Sorry, something went wrong"
 msgstr "Algo salió mal"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1487
+#: src/gs-shell.c:1488
 msgid "Failed to install file: authentication failed"
 msgstr "Falló al instalar el archivo: falló la autenticación"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1534
+#: src/gs-shell.c:1535
 #, c-format
 msgid "Unable to contact %s"
 msgstr "No se puede contactar con %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1549
+#: src/gs-shell.c:1550
 #, c-format
 msgid "%s needs to be restarted to use new plugins."
 msgstr "Se debe reiniciar %s para usar los complementos nuevos."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1554
+#: src/gs-shell.c:1555
 msgid "This application needs to be restarted to use new plugins."
 msgstr "Se debe reiniciar esta aplicación para usar los nuevos complementos."
 
 #. TRANSLATORS: need to be connected to the AC power
-#: src/gs-shell.c:1561
+#: src/gs-shell.c:1562
 msgid "AC power is required"
 msgstr "Se necesita conexión a la alimentación"
 
@@ -2634,7 +2745,9 @@ msgstr "Se necesita conexión a la alimentación"
 #. has no software installed from it.
 #: src/gs-sources-dialog.c:98
 msgid "No applications or addons installed; other software might still be"
-msgstr "No hay aplicaciones ni complementos instalados. Es posible que todavía haya otro software"
+msgstr ""
+"No hay aplicaciones ni complementos instalados. Es posible que todavía haya "
+"otro software"
 
 #. TRANSLATORS: This string is used to construct the 'X applications
 #. installed' sentence, describing a software source.
@@ -2713,7 +2826,9 @@ msgstr "el sistema operativo"
 msgid ""
 "Software sources can be downloaded from the internet. They give you access "
 "to additional software that is not provided by %s."
-msgstr "Las fuentes de software se pueden descargar de Internet. Esto le da acceso a software adicional no proporcionado por %s."
+msgstr ""
+"Las fuentes de software se pueden descargar de Internet. Esto le da acceso a "
+"software adicional no proporcionado por %s."
 
 #: src/gs-sources-dialog.ui:155
 msgid "Additional Sources"
@@ -2722,7 +2837,9 @@ msgstr "Fuentes adicionales"
 #: src/gs-sources-dialog.ui:175
 msgid ""
 "Removing a source will also remove any software you have installed from it."
-msgstr "Quitar una fuente también quitará cualquier software que haya instalado desde ella."
+msgstr ""
+"Quitar una fuente también quitará cualquier software que haya instalado "
+"desde ella."
 
 #: src/gs-sources-dialog.ui:260
 msgid "No software installed from this source"
@@ -2829,7 +2946,9 @@ msgstr "Actualizaciones de software disponibles"
 
 #: src/gs-update-monitor.c:97
 msgid "Important OS and application updates are ready to be installed"
-msgstr "Las actualizaciones importantes del sistema y de aplicaciones están listas para instalarse"
+msgstr ""
+"Las actualizaciones importantes del sistema y de aplicaciones están listas "
+"para instalarse"
 
 #. TRANSLATORS: button text
 #: src/gs-update-monitor.c:100 src/gs-updates-page.c:775
@@ -2920,29 +3039,37 @@ msgstr "Se canceló la actualización."
 #. * something with no network available
 #: src/gs-update-monitor.c:714
 msgid ""
-"Internet access was required but wasn’t available. Please make sure that you"
-" have internet access and try again."
-msgstr "La conexión a Internet no está disponible. Asegúrese de que tiene acceso a Internet e inténtelo de nuevo."
+"Internet access was required but wasn’t available. Please make sure that you "
+"have internet access and try again."
+msgstr ""
+"La conexión a Internet no está disponible. Asegúrese de que tiene acceso a "
+"Internet e inténtelo de nuevo."
 
 #. TRANSLATORS: if the package is not signed correctly
 #: src/gs-update-monitor.c:720
 msgid ""
 "There were security issues with the update. Please consult your software "
 "provider for more details."
-msgstr "Ha ocurrido un problema de seguridad con la actualización. Consulte a su proveedor de software para obtener más detalles."
+msgstr ""
+"Ha ocurrido un problema de seguridad con la actualización. Consulte a su "
+"proveedor de software para obtener más detalles."
 
 #. TRANSLATORS: we ran out of disk space
 #: src/gs-update-monitor.c:726
 msgid ""
 "There wasn’t enough disk space. Please free up some space and try again."
-msgstr "No hay suficiente espacio en disco. Libere algo de espacio e inténtelo de nuevo."
+msgstr ""
+"No hay suficiente espacio en disco. Libere algo de espacio e inténtelo de "
+"nuevo."
 
 #. TRANSLATORS: We didn't handle the error type
 #: src/gs-update-monitor.c:731
 msgid ""
 "We’re sorry: the update failed to install. Please wait for another update "
 "and try again. If the problem persists, contact your software provider."
-msgstr "La actualización no pudo instalarse. Espere a otra actualización e inténtelo de nuevo. Si el problema persiste, contacte a su proveedor de software."
+msgstr ""
+"La actualización no pudo instalarse. Espere a otra actualización e inténtelo "
+"de nuevo. Si el problema persiste, contacte a su proveedor de software."
 
 #. TRANSLATORS: Time in 24h format
 #: src/gs-updates-page.c:297
@@ -3122,7 +3249,9 @@ msgstr "Puede conllevar gastos adicionales"
 msgid ""
 "Checking for updates while using mobile broadband could cause you to incur "
 "charges."
-msgstr "Comprobar si hay actualizaciones usando banda ancha móvil puede conllevar gastos adicionales."
+msgstr ""
+"Comprobar si hay actualizaciones usando banda ancha móvil puede conllevar "
+"gastos adicionales."
 
 #. TRANSLATORS: this is a link to the
 #. * control-center network panel
@@ -3161,7 +3290,9 @@ msgstr "El software está actualizado"
 msgid ""
 "Checking for updates when using mobile broadband could cause you to incur "
 "charges"
-msgstr "Comprobar si hay actualizaciones usando banda ancha móvil puede conllevar gastos adicionales"
+msgstr ""
+"Comprobar si hay actualizaciones usando banda ancha móvil puede conllevar "
+"gastos adicionales"
 
 #: src/gs-updates-page.ui:257
 msgid "_Check Anyway"
@@ -3226,22 +3357,27 @@ msgid "App Center"
 msgstr "Centro de programas"
 
 #: src/org.gnome.Software.desktop.in:4
+msgid "More Apps"
+msgstr "Más programas"
+
+#: src/org.gnome.Software.desktop.in:5
 msgid "Add, remove or update software on this computer"
 msgstr "Añadir, quitar o actualizar software en este equipo"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
-#: src/org.gnome.Software.desktop.in:6
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: src/org.gnome.Software.desktop.in:7
 #: src/org.gnome.Software.Editor.desktop.in:6
 msgid "org.gnome.Software"
 msgstr "org.gnome.Software"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
-#: src/org.gnome.Software.desktop.in:12
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: src/org.gnome.Software.desktop.in:13
 msgid ""
-"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;"
-msgstr "Actualizaciones;Actualizar;Fuentes;Repositorios:Preferencias;Instalar;Desinstalar;Programa;Software;App;Almacén;"
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;"
+msgstr ""
+"Actualizaciones;Actualizar;Fuentes;Repositorios:Preferencias;Instalar;"
+"Desinstalar;Programa;Software;App;Almacén;"
 
 #: src/org.gnome.Software.Editor.desktop.in:3
 msgid "Banner Designer"
@@ -3251,8 +3387,7 @@ msgstr "Diseñador de banner"
 msgid "Design the featured banners for GNOME Software"
 msgstr "Diseñar los banners destacados para GNOME Software"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: src/org.gnome.Software.Editor.desktop.in:13
 msgid "AppStream;Software;App;"
 msgstr "AppStream;Software;App;aplicación;aplicaciones;"
@@ -3522,100 +3657,111 @@ msgctxt "Menu of Communication & News"
 msgid "Web Browsers"
 msgstr "Navegadores web"
 
-#: plugins/core/gs-desktop-common.c:247
-msgctxt "Menu of Reference"
-msgid "All"
-msgstr "Todo"
-
-#: plugins/core/gs-desktop-common.c:250
-msgctxt "Menu of Reference"
-msgid "Featured"
-msgstr "Destacado"
-
-#: plugins/core/gs-desktop-common.c:253
-msgctxt "Menu of Reference"
-msgid "Art"
-msgstr "Arte"
-
-#: plugins/core/gs-desktop-common.c:256
-msgctxt "Menu of Reference"
-msgid "Biography"
-msgstr "Biografía"
-
-#: plugins/core/gs-desktop-common.c:259
-msgctxt "Menu of Reference"
-msgid "Comics"
-msgstr "Cómics"
-
-#: plugins/core/gs-desktop-common.c:262
-msgctxt "Menu of Reference"
-msgid "Fiction"
-msgstr "Ficción"
-
-#: plugins/core/gs-desktop-common.c:265
-msgctxt "Menu of Reference"
-msgid "Health"
-msgstr "Salud"
-
-#: plugins/core/gs-desktop-common.c:268
-msgctxt "Menu of Reference"
-msgid "History"
-msgstr "Historia"
-
-#: plugins/core/gs-desktop-common.c:271
-msgctxt "Menu of Reference"
-msgid "Lifestyle"
-msgstr "Estilo de vida"
-
-#: plugins/core/gs-desktop-common.c:274
+#: plugins/core/gs-desktop-common.c:242
 msgctxt "Menu of Communication & News"
 msgid "News"
 msgstr "Noticias"
 
+#: plugins/core/gs-desktop-common.c:251
+msgctxt "Menu of Reference"
+msgid "All"
+msgstr "Todo"
+
+#: plugins/core/gs-desktop-common.c:254
+msgctxt "Menu of Reference"
+msgid "Featured"
+msgstr "Destacado"
+
+#: plugins/core/gs-desktop-common.c:257
+msgctxt "Menu of Reference"
+msgid "Art"
+msgstr "Arte"
+
+#: plugins/core/gs-desktop-common.c:260
+msgctxt "Menu of Reference"
+msgid "Biography"
+msgstr "Biografía"
+
+#: plugins/core/gs-desktop-common.c:263
+msgctxt "Menu of Reference"
+msgid "Comics"
+msgstr "Cómics"
+
+#: plugins/core/gs-desktop-common.c:266
+msgctxt "Menu of Reference"
+msgid "Feed"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:269
+msgctxt "Menu of Reference"
+msgid "Fiction"
+msgstr "Ficción"
+
+#: plugins/core/gs-desktop-common.c:272
+msgctxt "Menu of Reference"
+msgid "Health"
+msgstr "Salud"
+
+#: plugins/core/gs-desktop-common.c:275
+msgctxt "Menu of Reference"
+msgid "History"
+msgstr "Historia"
+
 #: plugins/core/gs-desktop-common.c:278
+msgctxt "Menu of Reference"
+msgid "Lifestyle"
+msgstr "Estilo de vida"
+
+#: plugins/core/gs-desktop-common.c:281
+#, fuzzy
+msgctxt "Menu of Reference"
+msgid "News"
+msgstr "Noticias"
+
+#: plugins/core/gs-desktop-common.c:284
 msgctxt "Menu of Reference"
 msgid "Politics"
 msgstr "Política"
 
-#: plugins/core/gs-desktop-common.c:281
+#: plugins/core/gs-desktop-common.c:287
 msgctxt "Menu of Reference"
 msgid "Sports"
 msgstr "Deportes"
 
 #. TRANSLATORS: this is the menu spec main category for Learning
-#: plugins/core/gs-desktop-common.c:291
+#: plugins/core/gs-desktop-common.c:297
 msgid "Learning"
 msgstr "Aprendizaje"
 
 #. TRANSLATORS: this is the menu spec main category for Game
-#: plugins/core/gs-desktop-common.c:294
+#: plugins/core/gs-desktop-common.c:300
 msgid "Games"
 msgstr "Juegos"
 
 #. TRANSLATORS: this is the menu spec main category for Multimedia
-#: plugins/core/gs-desktop-common.c:297
+#: plugins/core/gs-desktop-common.c:303
 msgid "Multimedia"
 msgstr "Multimedia"
 
 #. TRANSLATORS: this is the menu spec main category for Work
-#: plugins/core/gs-desktop-common.c:300
+#: plugins/core/gs-desktop-common.c:306
 msgid "Work"
 msgstr "Trabajo"
 
 #. TRANSLATORS: this is the menu spec main category for Reference
-#: plugins/core/gs-desktop-common.c:303
+#: plugins/core/gs-desktop-common.c:309
 msgid "Reference & News"
 msgstr "Información y noticias"
 
 #. TRANSLATORS: this is the menu spec main category for Utilities
-#: plugins/core/gs-desktop-common.c:306
+#: plugins/core/gs-desktop-common.c:312
 msgid "Utilities"
 msgstr "Utilidades"
 
 #. TRANSLATORS: this is the menu spec main category for Dev Tools; it
 #. * should be a relatively short label; as an example, in Portuguese and
 #. * Spanish the direct translation of "Programming" (noun) is used
-#: plugins/core/gs-desktop-common.c:311
+#: plugins/core/gs-desktop-common.c:317
 msgid "Dev Tools"
 msgstr "Programación"
 
@@ -3641,16 +3787,16 @@ msgstr "Incluye mejoras en el rendimiento, la estabilidad y la seguridad."
 msgid "Downloading featured images…"
 msgstr "Descargando imágenes destacadas…"
 
-#: plugins/eos/gs-plugin-eos.c:1249
+#: plugins/eos/gs-plugin-eos.c:1233
 #, c-format
 msgid "Could not launch this application."
 msgstr "No se pudo iniciar este programa."
 
-#: plugins/eos/gs-plugin-eos.c:1305
+#: plugins/eos/gs-plugin-eos.c:1289
 msgid "Endless Platform"
 msgstr "Plataforma Endless"
 
-#: plugins/eos/gs-plugin-eos.c:1308
+#: plugins/eos/gs-plugin-eos.c:1292
 msgid "Framework for applications"
 msgstr "Infraestructura para programas"
 
@@ -3707,16 +3853,17 @@ msgstr "Soporte de Flatpak"
 
 #: plugins/flatpak/org.gnome.Software.Plugin.Flatpak.metainfo.xml.in:7
 msgid "Flatpak is a framework for desktop applications on Linux"
-msgstr "Flatpak es un entorno de desarrollo para aplicaciones de escritorio en Linux"
+msgstr ""
+"Flatpak es un entorno de desarrollo para aplicaciones de escritorio en Linux"
 
 #. TRANSLATORS: status text when downloading new metadata
-#: plugins/flatpak/gs-flatpak.c:821
+#: plugins/flatpak/gs-flatpak.c:815
 #, c-format
 msgid "Getting flatpak metadata for %s…"
 msgstr "Obteniendo metadatos flatpak para %s…"
 
 #. TRANSLATORS: status text when downloading the RuntimeRepo
-#: plugins/flatpak/gs-flatpak.c:2796
+#: plugins/flatpak/gs-flatpak.c:2803
 msgid "Getting runtime source…"
 msgstr "Obteniendo fuente en tiempo de ejecución…"
 
@@ -3749,7 +3896,9 @@ msgstr "Soporte de Limbba"
 
 #: plugins/limba/org.gnome.Software.Plugin.Limba.metainfo.xml.in:7
 msgid "Limba provides developers a way to easily create software bundles"
-msgstr "Limba proporciona a desarrolladores una manera sencilla de crear paquetes de software"
+msgstr ""
+"Limba proporciona a desarrolladores una manera sencilla de crear paquetes de "
+"software"
 
 #. TRANSLATORS: status text when downloading
 #: plugins/odrs/gs-plugin-odrs.c:205
@@ -3762,7 +3911,8 @@ msgstr "Open Desktop Ratings Support"
 
 #: plugins/odrs/org.gnome.Software.Plugin.Odrs.metainfo.xml.in:7
 msgid "ODRS is a service providing user reviews of applications"
-msgstr "ODRS es un servicio que proporciona opiniones de usuarios sobre apicaciones"
+msgstr ""
+"ODRS es un servicio que proporciona opiniones de usuarios sobre apicaciones"
 
 #. TRANSLATORS: status text when downloading
 #: plugins/shell-extensions/gs-plugin-shell-extensions.c:669

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,21 +1,22 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the gnome-software package.
-# 
+#
 # Translators:
 # Roddy Shuler <roddy@endlessm.com>, 2016-2017
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-software\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-12 22:31-0700\n"
+"POT-Creation-Date: 2017-11-02 16:28+0100\n"
 "PO-Revision-Date: 2017-10-16 20:45+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
-"Language-Team: French (http://www.transifex.com/endless-mobile-inc/gnome-software/language/fr/)\n"
+"Language-Team: French (http://www.transifex.com/endless-mobile-inc/gnome-"
+"software/language/fr/)\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:7
@@ -30,7 +31,10 @@ msgstr "Gestionnaire d’applications pour GNOME"
 msgid ""
 "Software allows you to find and install new applications and system "
 "extensions and remove existing installed applications."
-msgstr "Logiciels sert à rechercher et installer de nouvelles applications et extensions du système, ainsi qu’à supprimer celles qui sont installées sur votre ordinateur."
+msgstr ""
+"Logiciels sert à rechercher et installer de nouvelles applications et "
+"extensions du système, ainsi qu’à supprimer celles qui sont installées sur "
+"votre ordinateur."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:14
 msgid ""
@@ -38,7 +42,12 @@ msgid ""
 "descriptions and multiple screenshots per application. Applications can be "
 "found either through browsing the list of categories or by searching. It "
 "also allows you to update your system using an offline update."
-msgstr "Logiciels de GNOME présente une vitrine d’applications connues à l’aide de descriptions utiles et de plusieurs captures d’écran pour chacune d’elle. Vous pouvez rechercher des logiciels soit en consultant la liste des catégories, soit en interrogeant le moteur de recherche. Logiciels permet aussi de mettre à jour votre système hors ligne."
+msgstr ""
+"Logiciels de GNOME présente une vitrine d’applications connues à l’aide de "
+"descriptions utiles et de plusieurs captures d’écran pour chacune d’elle. "
+"Vous pouvez rechercher des logiciels soit en consultant la liste des "
+"catégories, soit en interrogeant le moteur de recherche. Logiciels permet "
+"aussi de mettre à jour votre système hors ligne."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:25
 msgid "Overview panel"
@@ -72,7 +81,9 @@ msgstr "Une liste de projets compatibles"
 msgid ""
 "This is a list of compatible projects we should show such as GNOME, KDE and "
 "XFCE."
-msgstr "Voici une liste de projets compatibles à afficher, tels que GNOME, KDE ou XFCE."
+msgstr ""
+"Voici une liste de projets compatibles à afficher, tels que GNOME, KDE ou "
+"XFCE."
 
 #: data/org.gnome.software.gschema.xml:10
 msgid "Whether to manage updates in GNOME Software"
@@ -82,7 +93,9 @@ msgstr "Indique la façon de gérer les mises à jour de Logiciels de GNOME"
 msgid ""
 "If disabled, GNOME Software will hide the updates panel and not perform any "
 "automatic updates actions."
-msgstr "Si désactivé, Logiciels de GNOME masque le panneau des mises à jour et n’effectue aucune mise à jour automatique."
+msgstr ""
+"Si désactivé, Logiciels de GNOME masque le panneau des mises à jour et "
+"n’effectue aucune mise à jour automatique."
 
 #: data/org.gnome.software.gschema.xml:15
 msgid "Whether to automatically download updates"
@@ -90,20 +103,28 @@ msgstr "Indique s’il faut télécharger automatiquement les mises à jour"
 
 #: data/org.gnome.software.gschema.xml:16
 msgid ""
-"If enabled, GNOME Software automatically downloads updates in the background"
-" and prompts the user to install them when ready."
-msgstr "Si activé, Logiciels de GNOME télécharge automatiquement les mises à jour en arrière-plan et propose à l’utilisateur de les installer une fois celles-ci téléchargées."
+"If enabled, GNOME Software automatically downloads updates in the background "
+"and prompts the user to install them when ready."
+msgstr ""
+"Si activé, Logiciels de GNOME télécharge automatiquement les mises à jour en "
+"arrière-plan et propose à l’utilisateur de les installer une fois celles-ci "
+"téléchargées."
 
 #: data/org.gnome.software.gschema.xml:20
 msgid "Whether to automatically refresh when on a metered connection"
-msgstr "Indique s’il faut réactualiser automatiquement sur les connexions payantes"
+msgstr ""
+"Indique s’il faut réactualiser automatiquement sur les connexions payantes"
 
 #: data/org.gnome.software.gschema.xml:21
 msgid ""
 "If enabled, GNOME Software automatically refreshes in the background even "
 "when using a metered connection (eventually downloading some metadata, "
 "checking for updates, etc., which may incur in costs for the user)."
-msgstr "Si activé, Logiciels de GNOME réactualise automatiquement en arrière-plan même sur les connexions payantes (avec comme conséquence le téléchargement de métadonnées, de mises à jour ou autres avec un coût potentiel pour l’utilisateur)."
+msgstr ""
+"Si activé, Logiciels de GNOME réactualise automatiquement en arrière-plan "
+"même sur les connexions payantes (avec comme conséquence le téléchargement "
+"de métadonnées, de mises à jour ou autres avec un coût potentiel pour "
+"l’utilisateur)."
 
 #: data/org.gnome.software.gschema.xml:25
 msgid "Whether it’s the very first run of GNOME Software"
@@ -115,17 +136,22 @@ msgstr "Afficher les notes à coté des applications"
 
 #: data/org.gnome.software.gschema.xml:33
 msgid "Filter applications based on the default branch set for the remote"
-msgstr "Filtrer les applications en fonction de la branche définie par défaut pour les distants"
+msgstr ""
+"Filtrer les applications en fonction de la branche définie par défaut pour "
+"les distants"
 
 #: data/org.gnome.software.gschema.xml:37
 msgid "Non-free applications show a warning dialog before install"
-msgstr "Les application non-libres affichent un avertissement avant installation"
+msgstr ""
+"Les application non-libres affichent un avertissement avant installation"
 
 #: data/org.gnome.software.gschema.xml:38
 msgid ""
-"When non-free applications are installed a warning dialog can be shown. This"
-" controls if that dialog is suppressed."
-msgstr "Quand les applications non-libres sont installées, un avertissement peut être affiché. Ceci contrôle cet affichage."
+"When non-free applications are installed a warning dialog can be shown. This "
+"controls if that dialog is suppressed."
+msgstr ""
+"Quand les applications non-libres sont installées, un avertissement peut "
+"être affiché. Ceci contrôle cet affichage."
 
 #: data/org.gnome.software.gschema.xml:42
 msgid "A list of popular applications"
@@ -133,7 +159,9 @@ msgstr "Une liste d’applications populaires"
 
 #: data/org.gnome.software.gschema.xml:43
 msgid "A list of applications to use, overriding the system defined ones."
-msgstr "Une liste d’applications à utiliser, passant outre celles définies par le système."
+msgstr ""
+"Une liste d’applications à utiliser, passant outre celles définies par le "
+"système."
 
 #: data/org.gnome.software.gschema.xml:47
 msgid "The list of extra sources that have been previously enabled"
@@ -143,7 +171,9 @@ msgstr "La liste des sources supplémentaires qui ont été précédemment activ
 msgid ""
 "The list of sources that have been previously enabled when installing third-"
 "party applications."
-msgstr "La liste des sources ayant été précédemment activées lors de l’installation d’applications tierces."
+msgstr ""
+"La liste des sources ayant été précédemment activées lors de l’installation "
+"d’applications tierces."
 
 #: data/org.gnome.software.gschema.xml:52
 msgid "The last update check timestamp"
@@ -155,7 +185,8 @@ msgstr "L’horodatage de la dernière notification de mise à jour"
 
 #: data/org.gnome.software.gschema.xml:60
 msgid "The timestamp of the first security update, cleared after update"
-msgstr "L’horodatage de la première mise à jour de sécurité, effacé après mise à jour"
+msgstr ""
+"L’horodatage de la première mise à jour de sécurité, effacé après mise à jour"
 
 #: data/org.gnome.software.gschema.xml:64
 msgid "The last update timestamp"
@@ -163,14 +194,20 @@ msgstr "L’horodatage de la dernière mise à jour"
 
 #: data/org.gnome.software.gschema.xml:68
 msgid "The age in seconds to verify the upstream screenshot is still valid"
-msgstr "La durée, en secondes, pour vérifier que la capture d’écran en amont est encore valide"
+msgstr ""
+"La durée, en secondes, pour vérifier que la capture d’écran en amont est "
+"encore valide"
 
 #: data/org.gnome.software.gschema.xml:69
 msgid ""
 "Choosing a larger value will mean less round-trips to the remote server but "
-"updates to the screenshots may take longer to show to the user. A value of 0"
-" means to never check the server if the image already exists in the cache."
-msgstr "Le choix d’une valeur plus grande donne moins d’aller-retours vers le serveur distant, mais les mises à jour des captures d’écran sont plus lentes à arriver. Une valeur de 0 conduit à ne jamais interroger le serveur s’il y a déjà une image dans le cache."
+"updates to the screenshots may take longer to show to the user. A value of 0 "
+"means to never check the server if the image already exists in the cache."
+msgstr ""
+"Le choix d’une valeur plus grande donne moins d’aller-retours vers le "
+"serveur distant, mais les mises à jour des captures d’écran sont plus lentes "
+"à arriver. Une valeur de 0 conduit à ne jamais interroger le serveur s’il y "
+"a déjà une image dans le cache."
 
 #: data/org.gnome.software.gschema.xml:78
 msgid "The server to use for application reviews"
@@ -182,26 +219,33 @@ msgstr "Le score minimum pour les appréciations"
 
 #: data/org.gnome.software.gschema.xml:83
 msgid "Reviews with karma less than this number will not be shown."
-msgstr "Les appréciations dont le score est inférieur à cette valeur seront masquées."
+msgstr ""
+"Les appréciations dont le score est inférieur à cette valeur seront masquées."
 
 #: data/org.gnome.software.gschema.xml:87
 msgid "A list of official sources that should not be considered 3rd party"
-msgstr "Une liste de sources officielles qui ne doivent pas être considérées comme tierces parties"
+msgstr ""
+"Une liste de sources officielles qui ne doivent pas être considérées comme "
+"tierces parties"
 
 #: data/org.gnome.software.gschema.xml:91
 msgid "A list of official sources that should be considered free software"
-msgstr "Une liste des sources officielles qui ne doivent pas être considérées comme des logiciels libres"
+msgstr ""
+"Une liste des sources officielles qui ne doivent pas être considérées comme "
+"des logiciels libres"
 
 #: data/org.gnome.software.gschema.xml:95
 msgid ""
-"The licence URL to use when an application should be considered free "
-"software"
-msgstr "L’URL de la licence à utiliser lorsqu’une application doit être considérée comme un logiciel libre"
+"The licence URL to use when an application should be considered free software"
+msgstr ""
+"L’URL de la licence à utiliser lorsqu’une application doit être considérée "
+"comme un logiciel libre"
 
 #: data/org.gnome.software.gschema.xml:99
-msgid ""
-"Install bundled applications for all users on the system where possible"
-msgstr "Installe si possible les applications enveloppées sur le système pour tous les utilisateurs"
+msgid "Install bundled applications for all users on the system where possible"
+msgstr ""
+"Installe si possible les applications enveloppées sur le système pour tous "
+"les utilisateurs"
 
 #: data/org.gnome.software.gschema.xml:103
 msgid "Show the folder management UI"
@@ -217,11 +261,15 @@ msgstr "Propose des mises à niveau pour les versions à l’essai"
 
 #: data/org.gnome.software.gschema.xml:115
 msgid "Show some UI elements informing the user that an app is non-free"
-msgstr "Affiche quelques éléments d’interface montrant à l’utilisateur qu’une application est non-libre"
+msgstr ""
+"Affiche quelques éléments d’interface montrant à l’utilisateur qu’une "
+"application est non-libre"
 
 #: data/org.gnome.software.gschema.xml:119
 msgid "Show the prompt to install nonfree software sources"
-msgstr "Affiche l’invite de commandes pour installer les sources logicielles non-libres"
+msgstr ""
+"Affiche l’invite de commandes pour installer les sources logicielles non-"
+"libres"
 
 #: data/org.gnome.software.gschema.xml:123
 msgid "Show non-free software in search results"
@@ -229,35 +277,47 @@ msgstr "Affiche les logiciels non-libres dans les résultats de la recherche"
 
 #: data/org.gnome.software.gschema.xml:127
 msgid "Show the installed size for apps in the list of installed applications"
-msgstr "Affiche leur taille d’installation dans la liste des applications installées"
+msgstr ""
+"Affiche leur taille d’installation dans la liste des applications installées"
 
 #: data/org.gnome.software.gschema.xml:131
 msgid "The URI that explains nonfree and proprietary software"
-msgstr "L’URI qui fournit une explication sur les logiciels propriétaires et non-libres"
+msgstr ""
+"L’URI qui fournit une explication sur les logiciels propriétaires et non-"
+"libres"
 
 #: data/org.gnome.software.gschema.xml:135
 msgid "A list of non-free sources that can be optionally enabled"
-msgstr "Une liste des sources non-libres qui peuvent être activées optionnellement"
+msgstr ""
+"Une liste des sources non-libres qui peuvent être activées optionnellement"
 
 #: data/org.gnome.software.gschema.xml:139
 msgid ""
 "A list of URLs pointing to appstream files that will be downloaded into an "
 "app-info folder"
-msgstr "Une liste d’URLs pointant vers les fichiers du flux de l’application qui seront téléchargés dans un dossier d’informations"
+msgstr ""
+"Une liste d’URLs pointant vers les fichiers du flux de l’application qui "
+"seront téléchargés dans un dossier d’informations"
 
 #: data/org.gnome.software.gschema.xml:143
 msgid "Install the AppStream files to a system-wide location for all users"
-msgstr "Installe les fichiers AppStream sur un emplacement de l’ensemble du système pour tous les utilisateurs"
+msgstr ""
+"Installe les fichiers AppStream sur un emplacement de l’ensemble du système "
+"pour tous les utilisateurs"
 
 #: data/org.gnome.software.gschema.xml:147
 msgid "Sorts the apps shown in the overview in alphabetical order"
-msgstr "Classe les applications affichées dans la vue d'ensemble par ordre alphabétique"
+msgstr ""
+"Classe les applications affichées dans la vue d'ensemble par ordre "
+"alphabétique"
 
 #: data/org.gnome.software.gschema.xml:151
 msgid ""
 "Overrides the name of the \"Featured\" entry in the side-filter (category "
 "list)"
-msgstr "Passe outre le nom de l'entrée « Mis en avant » dans le filtre latéral (liste des catégories)"
+msgstr ""
+"Passe outre le nom de l'entrée « Mis en avant » dans le filtre latéral "
+"(liste des catégories)"
 
 #: src/gnome-software-local-file.desktop.in:3
 msgid "Software Install"
@@ -267,8 +327,7 @@ msgstr "Installation de l’application"
 msgid "Install selected software on the system"
 msgstr "Installer l’application sélectionnée sur le système"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 #: src/gnome-software-local-file.desktop.in:10
 msgid "system-software-install"
 msgstr "system-software-install"
@@ -295,14 +354,12 @@ msgstr "Retourner en arrière"
 msgid "_All"
 msgstr "_Tout"
 
-#. Translators: A label for a button to show only software which is already
-#. installed.
+#. Translators: A label for a button to show only software which is already installed.
 #: src/gnome-software.ui:104
 msgid "_Installed"
 msgstr "_Installées"
 
-#. Translators: A label for a button to show only updates which are available
-#. to install.
+#. Translators: A label for a button to show only updates which are available to install.
 #: src/gnome-software.ui:155
 msgid "_Updates"
 msgstr "Mi_ses à jour"
@@ -350,7 +407,7 @@ msgstr "Installée"
 
 #. TRANSLATORS: this is a button next to the search results that
 #. * shows the status of an application being installed
-#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:443
+#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:439
 msgid "Installing"
 msgstr "Installation en cours"
 
@@ -365,7 +422,7 @@ msgid "Folder Name"
 msgstr "Nom du dossier"
 
 #: src/gs-app-folder-dialog.c:321 src/gs-app-folder-dialog.ui:16
-#: src/gs-details-page.c:383 src/gs-details-page.ui:342 src/gs-editor.c:623
+#: src/gs-details-page.c:379 src/gs-details-page.ui:342 src/gs-editor.c:623
 #: src/gs-editor.c:655 src/gs-installed-page.c:609 src/gs-removal-dialog.ui:33
 #: src/gs-review-dialog.ui:23 src/gs-upgrade-banner.ui:131
 msgid "_Cancel"
@@ -380,90 +437,96 @@ msgid "Add to Application Folder"
 msgstr "Ajouter au dossier Applications"
 
 #. TRANSLATORS: this is a command line option
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "Start up mode: either ‘updates’, ‘updated’, ‘installed’ or ‘overview’"
-msgstr "Mode de démarrage : peut être « updates » (mises à jour), « updated » (à jour), « installed » (installées) ou « overview » (vue d’ensemble)"
+msgstr ""
+"Mode de démarrage : peut être « updates » (mises à jour), « updated » (à "
+"jour), « installed » (installées) ou « overview » (vue d’ensemble)"
 
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "MODE"
 msgstr "MODE"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "Search for applications"
 msgstr "Rechercher des applications"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "SEARCH"
 msgstr "RECHERCHER"
 
-#: src/gs-application.c:105
+#: src/gs-application.c:133
 msgid "Show application details (using application ID)"
 msgstr "Afficher les détails de l’application (à partir de son identifiant)"
 
-#: src/gs-application.c:105 src/gs-application.c:109
+#: src/gs-application.c:133 src/gs-application.c:137
 msgid "ID"
 msgstr "ID"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "Show application details (using package name)"
 msgstr "Afficher les détails de l’application (à partir de son nom de paquet)"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "PKGNAME"
 msgstr "NOMDEPAQUET"
 
-#: src/gs-application.c:109
+#: src/gs-application.c:137
 msgid "Install the application (using application ID)"
 msgstr "Installer l’application (à partir de son identifiant)"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "Open a local package file"
 msgstr "Ouvrir le fichier d’un paquet local"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "FILENAME"
 msgstr "NOMDEFICHIER"
 
-#: src/gs-application.c:113
+#: src/gs-application.c:141
 msgid ""
 "The kind of interaction expected for this action: either ‘none’, ‘notify’, "
 "or ‘full’"
-msgstr "Le type d’interaction attendue ici : soit « none » (aucune), « notify » (notifier), ou « full » (toutes)"
+msgstr ""
+"Le type d’interaction attendue ici : soit « none » (aucune), "
+"« notify » (notifier), ou « full » (toutes)"
 
-#: src/gs-application.c:116
+#: src/gs-application.c:144
 msgid "Show verbose debugging information"
 msgstr "Afficher les informations détaillées de débogage"
 
-#: src/gs-application.c:118
+#: src/gs-application.c:146
 msgid "Show profiling information for the service"
 msgstr "Afficher les informations de profilage du service"
 
-#: src/gs-application.c:120
+#: src/gs-application.c:148
 msgid "Quit the running instance"
 msgstr "Quitter la session en cours"
 
-#: src/gs-application.c:122
+#: src/gs-application.c:150
 msgid "Prefer local file sources to AppStream"
 msgstr "Préférer les sources des fichiers locaux à AppStream"
 
-#: src/gs-application.c:124
+#: src/gs-application.c:152
 msgid "Show version number"
 msgstr "Afficher le numéro de version"
 
-#: src/gs-application.c:325
+#: src/gs-application.c:358
 msgid "translator-credits"
-msgstr "Alain Lojewski <allomervan@gmail.com>\nGuillaume Bernard <contact.guib@laposte.net>"
+msgstr ""
+"Alain Lojewski <allomervan@gmail.com>\n"
+"Guillaume Bernard <contact.guib@laposte.net>"
 
 #. TRANSLATORS: this is the title of the about window, e.g.
 #. * 'About Software' or 'About Application Installer' where the %s is
 #. * the application name chosen by the distro
-#: src/gs-application.c:332
+#: src/gs-application.c:365
 #, c-format
 msgid "About %s"
 msgstr "À propos de %s"
 
 #. TRANSLATORS: well, we seem to think so, anyway
-#: src/gs-application.c:336
+#: src/gs-application.c:369
 msgid "A nice way to manage the software on your system."
 msgstr "Une façon élégante de gérer les applications de votre système."
 
@@ -578,7 +641,7 @@ msgid "All"
 msgstr "Tout"
 
 #. TRANSLATORS: this is a subcategory of featured apps
-#: lib/gs-category.c:202 src/gs-shell.c:2180
+#: lib/gs-category.c:202 src/gs-shell.c:2181
 msgid "Featured"
 msgstr "Mises en avant"
 
@@ -588,9 +651,11 @@ msgstr "Paramètres des extensions"
 
 #: src/gs-category-page.ui:110
 msgid ""
-"Extensions are used at your own risk. If you have any system problems, it is"
-" recommended to disable them."
-msgstr "Les extensions sont à utiliser à vos propres risques. Si vous constatez des problèmes système, il est recommandé de les désactiver."
+"Extensions are used at your own risk. If you have any system problems, it is "
+"recommended to disable them."
+msgstr ""
+"Les extensions sont à utiliser à vos propres risques. Si vous constatez des "
+"problèmes système, il est recommandé de les désactiver."
 
 #. TRANSLATORS: the user isn't reading the question
 #: lib/gs-cmd.c:205
@@ -646,13 +711,16 @@ msgstr "Activer les sources logicielles tierces ?"
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
 #. * 2. Software source name, e.g. fedora-optional
+#.
 #: src/gs-common.c:232
 #, c-format
 msgid ""
 "%s is not <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
-"source_software\">free and open source software</a>, and is provided by "
-"“%s”."
-msgstr "%s n’est pas un <a href=\"https://fr.wikipedia.org/wiki/Free/Libre_Open_Source_Software\">logiciel libre et ouvert</a> et est distribué par « %s »."
+"source_software\">free and open source software</a>, and is provided by “%s”."
+msgstr ""
+"%s n’est pas un <a href=\"https://fr.wikipedia.org/wiki/Free/"
+"Libre_Open_Source_Software\">logiciel libre et ouvert</a> et est distribué "
+"par « %s »."
 
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
@@ -665,18 +733,23 @@ msgstr "%s est distribué par « %s »."
 #. TRANSLATORS: a software source is a repo
 #: src/gs-common.c:252
 msgid "This software source must be enabled to continue installation."
-msgstr "Cette source de logiciel doit être activée pour continuer l’installation."
+msgstr ""
+"Cette source de logiciel doit être activée pour continuer l’installation."
 
 #. TRANSLATORS: Laws are geographical, urgh...
 #: src/gs-common.c:262
 #, c-format
 msgid "It may be illegal to install or use %s in some countries."
-msgstr "Il peut être contraire à la loi d’installer et d’utiliser %s dans certains pays."
+msgstr ""
+"Il peut être contraire à la loi d’installer et d’utiliser %s dans certains "
+"pays."
 
 #. TRANSLATORS: Laws are geographical, urgh...
 #: src/gs-common.c:268
 msgid "It may be illegal to install or use this codec in some countries."
-msgstr "Il peut être contraire à la loi d’installer et d’utiliser ce codec dans certains pays."
+msgstr ""
+"Il peut être contraire à la loi d’installer et d’utiliser ce codec dans "
+"certains pays."
 
 #. TRANSLATORS: this is button text to not ask about non-free content again
 #: src/gs-common.c:275
@@ -922,7 +995,9 @@ msgstr "Discriminations destinées à blesser émotionnellement"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:207
 msgid "Explicit discrimination based on gender, sexuality, race or religion"
-msgstr "Discriminations explicites basées sur le genre, le sexe, la race ou la religion"
+msgstr ""
+"Discriminations explicites basées sur le genre, le sexe, la race ou la "
+"religion"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:210
@@ -942,7 +1017,8 @@ msgstr "Allusions explicites à des produits de marque spécifique ou déposée"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:219
 msgid "Players are encouraged to purchase specific real-world items"
-msgstr "Les joueurs sont encouragés à acheter des éléments spécifiques du monde réel"
+msgstr ""
+"Les joueurs sont encouragés à acheter des éléments spécifiques du monde réel"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:222
@@ -987,7 +1063,8 @@ msgstr "Actions de jeu entre joueurs sans possibilité de discussion"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:246
 msgid "Player-to-player preset interactions without chat functionality"
-msgstr "Actions de jeu pré-définies entre joueurs sans possibilité de discussion"
+msgstr ""
+"Actions de jeu pré-définies entre joueurs sans possibilité de discussion"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:249
@@ -1007,12 +1084,15 @@ msgstr "Possibilité de discuter ou se voir entre joueurs sans contrôle"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:258
 msgid "No sharing of social network usernames or email addresses"
-msgstr "Aucun partage des noms d’utilisateur de réseaux sociaux ou des adresses courriel"
+msgstr ""
+"Aucun partage des noms d’utilisateur de réseaux sociaux ou des adresses "
+"courriel"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:261
 msgid "Sharing social network usernames or email addresses"
-msgstr "Partage des noms d’utilisateur de réseaux sociaux ou des adresses courriel"
+msgstr ""
+"Partage des noms d’utilisateur de réseaux sociaux ou des adresses courriel"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:264
@@ -1034,14 +1114,12 @@ msgstr "Aucun partage de géolocalisation avec les autres utilisateurs"
 msgid "Sharing physical location to other users"
 msgstr "Partage de géolocalisation avec les autres utilisateurs"
 
-#. TRANSLATORS: this is a what we use in notifications if the app's name is
-#. unknown
+#. TRANSLATORS: this is a what we use in notifications if the app's name is unknown
 #: src/gs-dbus-helper.c:294
 msgid "An application"
 msgstr "Une application"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. MIME types.
+#. TRANSLATORS: this is a notification displayed when an app needs additional MIME types.
 #: src/gs-dbus-helper.c:300
 #, c-format
 msgid "%s is requesting additional file format support."
@@ -1052,8 +1130,7 @@ msgstr "%s demande davantage de prise en charge du format du fichier."
 msgid "Additional MIME Types Required"
 msgstr "Types MIME supplémentaires requis"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. fonts.
+#. TRANSLATORS: this is a notification displayed when an app needs additional fonts.
 #: src/gs-dbus-helper.c:306
 #, c-format
 msgid "%s is requesting additional fonts."
@@ -1064,8 +1141,7 @@ msgstr "%s demande davantage de polices."
 msgid "Additional Fonts Required"
 msgstr "Polices supplémentaires requises"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. codecs.
+#. TRANSLATORS: this is a notification displayed when an app needs additional codecs.
 #: src/gs-dbus-helper.c:312
 #, c-format
 msgid "%s is requesting additional multimedia codecs."
@@ -1076,8 +1152,7 @@ msgstr "%s demande davantage de codecs multimédia."
 msgid "Additional Multimedia Codecs Required"
 msgstr "Codecs multimédia supplémentaires requis"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. printer drivers.
+#. TRANSLATORS: this is a notification displayed when an app needs additional printer drivers.
 #: src/gs-dbus-helper.c:318
 #, c-format
 msgid "%s is requesting additional printer drivers."
@@ -1088,8 +1163,7 @@ msgstr "%s demande davantage de pilotes d’imprimante."
 msgid "Additional Printer Drivers Required"
 msgstr "Pilotes d’imprimante supplémentaires requis"
 
-#. TRANSLATORS: this is a notification displayed when an app wants to install
-#. additional packages.
+#. TRANSLATORS: this is a notification displayed when an app wants to install additional packages.
 #: src/gs-dbus-helper.c:324
 #, c-format
 msgid "%s is requesting additional packages."
@@ -1109,14 +1183,14 @@ msgstr "Démarrer Logiciels"
 #. * can be installed
 #. TRANSLATORS: button text in the header when firmware
 #. * can be live-installed
-#: src/gs-details-page.c:281 src/gs-details-page.c:312
-#: src/gs-details-page.ui:206 src/gs-upgrade-banner.ui:146
+#: src/gs-details-page.c:280 src/gs-details-page.c:310
+#: src/gs-details-page.ui:237 src/gs-upgrade-banner.ui:146
 msgid "_Install"
 msgstr "_Installer"
 
 #. TRANSLATORS: button text in the header when an application
 #. * can be live-updated
-#: src/gs-details-page.c:316
+#: src/gs-details-page.c:314
 msgid "_Update"
 msgstr "Mettre à _jour"
 
@@ -1124,67 +1198,69 @@ msgstr "Mettre à _jour"
 #. * be installed.
 #. * The ellipsis indicates that further steps are required,
 #. * e.g. enabling software sources or the like
-#: src/gs-details-page.c:330
+#: src/gs-details-page.c:326
 msgid "_Install…"
 msgstr "_Installer…"
 
 #. TRANSLATORS: button text in the header when an application can be erased
-#: src/gs-details-page.c:377 src/gs-details-page.ui:547
+#: src/gs-details-page.c:373 src/gs-details-page.ui:547
 msgid "_Uninstall"
 msgstr "_Désinstaller"
 
-#: src/gs-details-page.c:438 src/gs-sources-dialog.c:513
+#: src/gs-details-page.c:434 src/gs-sources-dialog.c:513
 msgid "Removing…"
 msgstr "Suppression en cours…"
 
 #. TRANSLATORS: this is the warning box
-#: src/gs-details-page.c:748
+#: src/gs-details-page.c:744
 msgid ""
 "This application can only be used when there is an active internet "
 "connection."
-msgstr "Cette application ne peut être utilisée qu’avec une connexion Internet active."
+msgstr ""
+"Cette application ne peut être utilisée qu’avec une connexion Internet "
+"active."
 
 #. TRANSLATORS: this is where the version is not known
-#: src/gs-details-page.c:892
+#: src/gs-details-page.c:888
 msgctxt "version"
 msgid "Unknown"
 msgstr "Inconnue"
 
 #. TRANSLATORS: this is where we don't know the origin of the
 #. * application
-#: src/gs-details-page.c:971
+#: src/gs-details-page.c:967
 msgctxt "origin"
 msgid "Unknown"
 msgstr "Inconnue"
 
 #. TRANSLATORS: we need a remote server to process
-#: src/gs-details-page.c:1378
+#: src/gs-details-page.c:1374
 msgid "You need internet access to write a review"
 msgstr "Un accès à Internet est indispensable pour rédiger une évaluation"
 
-#: src/gs-details-page.c:1507
+#: src/gs-details-page.c:1503
 #, c-format
 msgid "Unable to find “%s”"
 msgstr "Impossible de trouver « %s »"
 
 #. TRANSLATORS: see the wikipedia page
-#: src/gs-details-page.c:2087
+#: src/gs-details-page.c:2083
 msgid "Public domain"
 msgstr "Domaine public"
 
 #. TRANSLATORS: see GNU page
-#: src/gs-details-page.c:2103 src/gs-details-page.ui:1397
+#: src/gs-details-page.c:2099 src/gs-details-page.ui:1397
 msgid "Free Software"
 msgstr "Logiciel libre"
 
 #. TRANSLATORS: for the free software popover
-#: src/gs-details-page.c:2160
+#: src/gs-details-page.c:2156
 msgid "Users are bound by the following license:"
 msgid_plural "Users are bound by the following licenses:"
 msgstr[0] "Les utilisateurs sont tenus au respect de cette licence :"
 msgstr[1] "Les utilisateurs sont tenus au respect de ces licences :"
 
-#: src/gs-details-page.c:2176 src/gs-details-page.ui:1506
+#: src/gs-details-page.c:2172 src/gs-details-page.ui:1506
 msgid "More information"
 msgstr "Davantage d’informations"
 
@@ -1192,15 +1268,13 @@ msgstr "Davantage d’informations"
 msgid "Details page"
 msgstr "Page des descriptions"
 
-#. Translators: A label for a button to add a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:228
+#. Translators: A label for a button to add a shortcut to the selected application.
+#: src/gs-details-page.ui:209
 msgid "_Add to Desktop"
 msgstr "_Ajouter au bureau"
 
-#. Translators: A label for a button to remove a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:245
+#. Translators: A label for a button to remove a shortcut to the selected application.
+#: src/gs-details-page.ui:226
 msgid "_Remove from Desktop"
 msgstr "_Supprimer du bureau"
 
@@ -1221,7 +1295,9 @@ msgstr "Source de logiciels incluse"
 msgid ""
 "This application includes a software source which provides updates, as well "
 "as access to other software."
-msgstr "Cette application inclut une source de logiciels qui fournit les mises à jour ainsi que l’accès à d’autres programmes."
+msgstr ""
+"Cette application inclut une source de logiciels qui fournit les mises à "
+"jour ainsi que l’accès à d’autres programmes."
 
 #: src/gs-details-page.ui:500
 msgid "No Software Source Included"
@@ -1231,16 +1307,19 @@ msgstr "Source de logiciels non incluse"
 msgid ""
 "This application does not include a software source. It will not be updated "
 "with new versions."
-msgstr "Cette application n’inclut aucune source de logiciel. Elle ne sera pas mise à jour vers de nouvelles versions."
+msgstr ""
+"Cette application n’inclut aucune source de logiciel. Elle ne sera pas mise "
+"à jour vers de nouvelles versions."
 
 #: src/gs-details-page.ui:515
 msgid ""
 "This software is already provided by your distribution and should not be "
 "replaced."
-msgstr "Cette application fait déjà partie de votre distribution et ne devrait pas être remplacée."
+msgstr ""
+"Cette application fait déjà partie de votre distribution et ne devrait pas "
+"être remplacée."
 
-#. Translators: a repository file used for installing software has been
-#. discovered.
+#. Translators: a repository file used for installing software has been discovered.
 #: src/gs-details-page.ui:528
 msgid "Software Source Identified"
 msgstr "Source de logiciels identifiée"
@@ -1249,11 +1328,14 @@ msgstr "Source de logiciels identifiée"
 msgid ""
 "Adding this software source will give you access to additional software and "
 "upgrades."
-msgstr "Ajouter cette source de logiciels vous donne accès à des logiciels supplémentaires ainsi qu’aux mises à niveau."
+msgstr ""
+"Ajouter cette source de logiciels vous donne accès à des logiciels "
+"supplémentaires ainsi qu’aux mises à niveau."
 
 #: src/gs-details-page.ui:530
 msgid "Only use software sources that you trust."
-msgstr "N’utilisez que les sources de logiciels auxquelles vous faites confiance."
+msgstr ""
+"N’utilisez que les sources de logiciels auxquelles vous faites confiance."
 
 #: src/gs-details-page.ui:562
 msgid "_Donate"
@@ -1341,14 +1423,12 @@ msgstr "Extensions"
 msgid "Selected add-ons will be installed with the application."
 msgstr "Les extensions sélectionnées vont être installées avec l’application."
 
-#. Translators: Header of the section with other users' opinions about the
-#. app.
+#. Translators: Header of the section with other users' opinions about the app.
 #: src/gs-details-page.ui:1233
 msgid "Reviews"
 msgstr "Évaluations"
 
-#. Translators: Button opening a dialog where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Button opening a dialog where the users can write and publish their opinions about the apps.
 #: src/gs-details-page.ui:1249
 msgid "_Write a Review"
 msgstr "_Rédiger une évaluation"
@@ -1360,9 +1440,11 @@ msgstr "_Afficher davantage"
 
 #: src/gs-details-page.ui:1414
 msgid ""
-"This means that the software can be freely run, copied, distributed, studied"
-" and modified."
-msgstr "Cela signifie que le logiciel peut être librement utilisé, copié, distribué, étudié et modifié."
+"This means that the software can be freely run, copied, distributed, studied "
+"and modified."
+msgstr ""
+"Cela signifie que le logiciel peut être librement utilisé, copié, distribué, "
+"étudié et modifié."
 
 #: src/gs-details-page.ui:1473
 msgid "Proprietary Software"
@@ -1373,7 +1455,10 @@ msgid ""
 "This means that the software is owned by an individual or a company. There "
 "are often restrictions on its use and its source code cannot usually be "
 "accessed."
-msgstr "Cela signifie que le logiciel est la propriété d’une personne physique ou morale. Son utilisation est le plus souvent restreinte et son code source habituellement inaccessible."
+msgstr ""
+"Cela signifie que le logiciel est la propriété d’une personne physique ou "
+"morale. Son utilisation est le plus souvent restreinte et son code source "
+"habituellement inaccessible."
 
 #: src/gs-details-page.ui:1535
 msgid "Unknown Software License"
@@ -1457,8 +1542,7 @@ msgstr "La liste d’applications comporte des modifications non enregistrées."
 msgid "Use verbose logging"
 msgstr "Afficher les informations détaillées de débogage"
 
-#. TRANSLATORS: program name, an application to add and remove software
-#. repositories
+#. TRANSLATORS: program name, an application to add and remove software repositories
 #: src/gs-editor.c:1119
 msgid "GNOME Software Banner Designer"
 msgstr "Concepteur de la bannière « Logiciels de GNOME »"
@@ -1487,8 +1571,7 @@ msgstr "Résumé"
 msgid "Editor’s Pick"
 msgstr "Sélection de la distribution"
 
-#. This check button controls whether the application’s banner appears in the
-#. “Featured” category
+#. This check button controls whether the application’s banner appears in the “Featured” category
 #: src/gs-editor.ui:397
 msgid "Category Featured"
 msgstr "Mise en avant de la catégorie"
@@ -1577,9 +1660,11 @@ msgstr "Aucune application disponible pour fournir le fichier %s."
 #: src/gs-extras-page.c:337 src/gs-extras-page.c:348 src/gs-extras-page.c:359
 #, c-format
 msgid ""
-"Information about %s, as well as options for how to get missing applications"
-" might be found %s."
-msgstr "Des informations sur %s, ainsi que des options sur la façon d’obtenir les applications manquantes sont disponibles sur %s."
+"Information about %s, as well as options for how to get missing applications "
+"might be found %s."
+msgstr ""
+"Des informations sur %s, ainsi que des options sur la façon d’obtenir les "
+"applications manquantes sont disponibles sur %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1602,7 +1687,10 @@ msgstr "%s est indisponible."
 msgid ""
 "Information about %s, as well as options for how to get an application that "
 "can support this format might be found %s."
-msgstr "Des informations sur %s, ainsi que des options sur la façon d’obtenir une application susceptible de prendre en charge ce format sont disponibles sur %s."
+msgstr ""
+"Des informations sur %s, ainsi que des options sur la façon d’obtenir une "
+"application susceptible de prendre en charge ce format sont disponibles sur "
+"%s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1618,11 +1706,13 @@ msgstr "Aucune police n’est disponible pour la prise en charge du script %s."
 msgid ""
 "Information about %s, as well as options for how to get additional fonts "
 "might be found %s."
-msgstr "Des informations sur %s, ainsi que des options sur la façon d’obtenir des polices supplémentaires sont disponibles sur %s."
+msgstr ""
+"Des informations sur %s, ainsi que des options sur la façon d’obtenir des "
+"polices supplémentaires sont disponibles sur %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
-#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1426
+#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1430
 #, c-format
 msgid "No addon codecs are available for the %s format."
 msgstr "Aucun codec au format %s n’est disponible pour l’extension."
@@ -1634,14 +1724,17 @@ msgstr "Aucun codec au format %s n’est disponible pour l’extension."
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format might be found %s."
-msgstr "Des informations sur %s, ainsi que des options sur la façon d’obtenir un codec susceptible de lire ce format sont disponibles sur %s."
+msgstr ""
+"Des informations sur %s, ainsi que des options sur la façon d’obtenir un "
+"codec susceptible de lire ce format sont disponibles sur %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
 #: src/gs-extras-page.c:399
 #, c-format
 msgid "No Plasma resources are available for %s support."
-msgstr "Aucune ressource pour plasma n’est disponible pour prendre en charge %s."
+msgstr ""
+"Aucune ressource pour plasma n’est disponible pour prendre en charge %s."
 
 #. TRANSLATORS: first %s is the codec name, and second %s is a
 #. * hyperlink with the "on the website" text
@@ -1650,7 +1743,9 @@ msgstr "Aucune ressource pour plasma n’est disponible pour prendre en charge %
 msgid ""
 "Information about %s, as well as options for how to get additional Plasma "
 "resources might be found %s."
-msgstr "Des informations sur %s, ainsi que des options sur la façon d’obtenir des ressources supplémentaires pour plasma sont disponibles sur %s."
+msgstr ""
+"Des informations sur %s, ainsi que des options sur la façon d’obtenir des "
+"ressources supplémentaires pour plasma sont disponibles sur %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1666,15 +1761,17 @@ msgstr "Aucun pilote d’imprimante n’est disponible pour %s."
 msgid ""
 "Information about %s, as well as options for how to get a driver that "
 "supports this printer might be found %s."
-msgstr "Des informations sur %s, ainsi que des options sur la façon d’obtenir un pilote susceptible de prendre en charge cette imprimante sont disponibles sur %s."
+msgstr ""
+"Des informations sur %s, ainsi que des options sur la façon d’obtenir un "
+"pilote susceptible de prendre en charge cette imprimante sont disponibles "
+"sur %s."
 
 #. TRANSLATORS: hyperlink title
 #: src/gs-extras-page.c:459
 msgid "this website"
 msgstr "ce site Web"
 
-#. TRANSLATORS: no codecs were found. First %s will be replaced by actual
-#. codec name(s), second %s is a link titled "this website"
+#. TRANSLATORS: no codecs were found. First %s will be replaced by actual codec name(s), second %s is a link titled "this website"
 #: src/gs-extras-page.c:463
 #, c-format
 msgid ""
@@ -1683,8 +1780,12 @@ msgid ""
 msgid_plural ""
 "Unfortunately, the %s you were searching for could not be found. Please see "
 "%s for more information."
-msgstr[0] "Malheureusement, le %s que vous recherchez est introuvable. Veuillez consulter %s pour de plus amples informations."
-msgstr[1] "Malheureusement, les %s que vous recherchez sont introuvables. Veuillez consulter %s pour de plus amples informations."
+msgstr[0] ""
+"Malheureusement, le %s que vous recherchez est introuvable. Veuillez "
+"consulter %s pour de plus amples informations."
+msgstr[1] ""
+"Malheureusement, les %s que vous recherchez sont introuvables. Veuillez "
+"consulter %s pour de plus amples informations."
 
 #: src/gs-extras-page.c:535 src/gs-extras-page.c:591 src/gs-extras-page.c:630
 msgid "Failed to find any search results"
@@ -1709,10 +1810,13 @@ msgstr "Bienvenue dans Logiciels"
 
 #: src/gs-first-run-dialog.ui:66
 msgid ""
-"Software lets you install all the software you need, all from one place. See"
-" our recommendations, browse the categories, or search for the applications "
+"Software lets you install all the software you need, all from one place. See "
+"our recommendations, browse the categories, or search for the applications "
 "you want."
-msgstr "Logiciels vous permet d’installer toutes les applications dont vous avez besoin à partir d’un seul endroit. Consultez nos recommandations, les catégories, ou recherchez les applications qui vous intéressent."
+msgstr ""
+"Logiciels vous permet d’installer toutes les applications dont vous avez "
+"besoin à partir d’un seul endroit. Consultez nos recommandations, les "
+"catégories, ou recherchez les applications qui vous intéressent."
 
 #: src/gs-first-run-dialog.ui:85
 msgid "_Let’s Go Shopping"
@@ -1862,13 +1966,16 @@ msgstr "Applications de bureautique recommandées"
 #: src/gs-overview-page.c:974
 msgid ""
 "Provides access to additional software, including web browsers and games."
-msgstr "Fournit l’accès à des logiciels supplémentaires, dont des navigateurs Web et des jeux."
+msgstr ""
+"Fournit l’accès à des logiciels supplémentaires, dont des navigateurs Web et "
+"des jeux."
 
 #. TRANSLATORS: this is the proprietary info bar
 #: src/gs-overview-page.c:978
-msgid ""
-"Proprietary software has restrictions on use and access to source code."
-msgstr "Les logiciels propriétaires ont des restrictions concernant l’utilisation et l’accès au code source."
+msgid "Proprietary software has restrictions on use and access to source code."
+msgstr ""
+"Les logiciels propriétaires ont des restrictions concernant l’utilisation et "
+"l’accès au code source."
 
 #. TRANSLATORS: this is the clickable
 #. * link on the proprietary info bar
@@ -1897,14 +2004,12 @@ msgstr "Application mise en avant"
 msgid "Categories"
 msgstr "Catégories"
 
-#. Translators: This is a heading for software which has been featured
-#. ('picked') by the distribution.
+#. Translators: This is a heading for software which has been featured ('picked') by the distribution.
 #: src/gs-overview-page.ui:315
 msgid "Editor’s Picks"
 msgstr "Sélection de la distribution"
 
-#. Translators: This is a heading for software which has been recently
-#. released upstream.
+#. Translators: This is a heading for software which has been recently released upstream.
 #: src/gs-overview-page.ui:359
 msgid "Recent Releases"
 msgstr "Versions récentes"
@@ -1951,7 +2056,9 @@ msgstr "Êtes-vous sûr de vouloir supprimer la source %s ?"
 msgid ""
 "All applications from %s will be removed, and you will have to re-install "
 "the source to use them again."
-msgstr "Toutes les applications de la source %s vont être supprimées et il vous faudra la réinstaller pour pouvoir utiliser ces logiciels à nouveau."
+msgstr ""
+"Toutes les applications de la source %s vont être supprimées et il vous "
+"faudra la réinstaller pour pouvoir utiliser ces logiciels à nouveau."
 
 #. TRANSLATORS: this is a prompt message, and '%s' is an
 #. * application summary, e.g. 'GNOME Clocks'
@@ -1964,14 +2071,18 @@ msgstr "Êtes-vous sûr de vouloir supprimer %s ?"
 #: src/gs-page.c:684
 #, c-format
 msgid "%s will be removed, and you will have to install it to use it again."
-msgstr "%s va être supprimée et il vous faudra la réinstaller pour pouvoir l’utiliser à nouveau."
+msgstr ""
+"%s va être supprimée et il vous faudra la réinstaller pour pouvoir "
+"l’utiliser à nouveau."
 
-#: lib/gs-plugin-loader.c:1429
+#: lib/gs-plugin-loader.c:1433
 #, c-format
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format can be found on the website."
-msgstr "Des informations sur %s, ainsi que des possibilités d’obtention d’un codec capable de diffuser ce format sont disponibles sur le site Web."
+msgstr ""
+"Des informations sur %s, ainsi que des possibilités d’obtention d’un codec "
+"capable de diffuser ce format sont disponibles sur le site Web."
 
 #: lib/gs-price.c:111
 #, c-format
@@ -2030,7 +2141,10 @@ msgstr "%s %f"
 msgid ""
 "Some of the currently installed software is not compatible with %s. If you "
 "continue, the following will be automatically removed during the upgrade:"
-msgstr "Certains logiciels actuellement installés sont incompatibles avec %s. Si vous continuez, ceux listés ci-dessous seront automatiquement supprimés pendant la mise à niveau :"
+msgstr ""
+"Certains logiciels actuellement installés sont incompatibles avec %s. Si "
+"vous continuez, ceux listés ci-dessous seront automatiquement supprimés "
+"pendant la mise à niveau :"
 
 #: src/gs-removal-dialog.ui:27
 msgid "Incompatible Software"
@@ -2100,8 +2214,7 @@ msgstr "La description est trop courte"
 msgid "The description is too long"
 msgstr "La description est trop longue"
 
-#. Translators: Title of the dialog box where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Title of the dialog box where the users can write and publish their opinions about the apps.
 #: src/gs-review-dialog.ui:11
 msgid "Post Review"
 msgstr "Envoyer l’appréciation"
@@ -2119,7 +2232,9 @@ msgstr "Évaluation"
 msgid ""
 "Give a short summary of your review, for example: “Great app, would "
 "recommend”."
-msgstr "Donnez un bref résumé de votre appréciation, comme : « Application géniale, je recommande »."
+msgstr ""
+"Donnez un bref résumé de votre appréciation, comme : « Application géniale, "
+"je recommande »."
 
 #. Translators: This is where the users enter their opinions about the apps.
 #: src/gs-review-dialog.ui:199
@@ -2139,14 +2254,18 @@ msgstr "total des évaluations"
 #. TRANSLATORS: we explain what the action is going to do
 #: src/gs-review-row.c:234
 msgid "You can report reviews for abusive, rude, or discriminatory behavior."
-msgstr "Vous pouvez signaler les appréciations abusives, insultantes, ou discriminantes."
+msgstr ""
+"Vous pouvez signaler les appréciations abusives, insultantes, ou "
+"discriminantes."
 
 #. TRANSLATORS: we ask the user if they really want to do this
 #: src/gs-review-row.c:239
 msgid ""
 "Once reported, a review will be hidden until it has been checked by an "
 "administrator."
-msgstr "Une fois envoyée, l’appréciation sera masquée jusqu’à ce que celle-ci ait été vérifiée par un administrateur."
+msgstr ""
+"Une fois envoyée, l’appréciation sera masquée jusqu’à ce que celle-ci ait "
+"été vérifiée par un administrateur."
 
 #. TRANSLATORS: window title when
 #. * reporting a user-submitted review
@@ -2161,8 +2280,7 @@ msgstr "Signaler l’appréciation ?"
 msgid "Report"
 msgstr "Signaler"
 
-#. Translators: Users can express their opinions about other users' opinions
-#. about the apps.
+#. Translators: Users can express their opinions about other users' opinions about the apps.
 #: src/gs-review-row.ui:112
 msgid "Was this review useful to you?"
 msgstr "Est-ce que cette appréciation vous a été utile ?"
@@ -2251,81 +2369,87 @@ msgstr "Aucune application trouvée"
 #. TRANSLATORS: this is part of the in-app notification,
 #. * where the %s is a multi-word localised app name
 #. * e.g. 'Getting things GNOME!"
-#: src/gs-shell.c:846 src/gs-shell.c:851 src/gs-shell.c:866 src/gs-shell.c:870
+#: src/gs-shell.c:847 src/gs-shell.c:852 src/gs-shell.c:867 src/gs-shell.c:871
 #, c-format
 msgid "“%s”"
 msgstr "« %s »"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:898
+#: src/gs-shell.c:899
 #, c-format
 msgid "Unable to download firmware updates from %s"
 msgstr "Impossible de télécharger les mises à jour du micro-logiciel depuis %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:904
+#: src/gs-shell.c:905
 #, c-format
 msgid "Unable to download updates from %s"
 msgstr "Impossible de télécharger les mises à jour depuis %s"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:911
+#: src/gs-shell.c:912
 msgid "Unable to download updates"
 msgstr "Impossible de télécharger les mises à jour"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:916
+#: src/gs-shell.c:917
 msgid ""
-"Unable to download updates: internet access was required but wasn’t "
-"available"
-msgstr "Impossible de télécharger les mises à jour : accès à Internet nécessaire mais indisponible"
+"Unable to download updates: internet access was required but wasn’t available"
+msgstr ""
+"Impossible de télécharger les mises à jour : accès à Internet nécessaire "
+"mais indisponible"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:925
+#: src/gs-shell.c:926
 #, c-format
 msgid "Unable to download updates from %s: not enough disk space"
-msgstr "Impossible de télécharger les mises à jour depuis %s : espace disque insuffisant"
+msgstr ""
+"Impossible de télécharger les mises à jour depuis %s : espace disque "
+"insuffisant"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:930
+#: src/gs-shell.c:931
 msgid "Unable to download updates: not enough disk space"
 msgstr "Impossible de télécharger les mises à jour : espace disque insuffisant"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:938
+#: src/gs-shell.c:939
 msgid "Unable to download updates: authentication was required"
 msgstr "Impossible de télécharger les mises à jour : authentification requise"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:943
+#: src/gs-shell.c:944
 msgid "Unable to download updates: authentication was invalid"
-msgstr "Impossible de télécharger les mises à jour : authentification non valide"
+msgstr ""
+"Impossible de télécharger les mises à jour : authentification non valide"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:948
+#: src/gs-shell.c:949
 msgid ""
 "Unable to download updates: you do not have permission to install software"
-msgstr "Impossible de télécharger les mises à jour : vous n’avez pas la permission d’installer des logiciels"
+msgstr ""
+"Impossible de télécharger les mises à jour : vous n’avez pas la permission "
+"d’installer des logiciels"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:955
+#: src/gs-shell.c:956
 msgid "Unable to get list of updates"
 msgstr "Impossible d’obtenir la liste des mises à jour"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the application name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1001
+#: src/gs-shell.c:1002
 #, c-format
 msgid "Unable to install %s as download failed from %s"
 msgstr "Impossible d’installer %s : le téléchargement depuis %s a échoué"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1007
+#: src/gs-shell.c:1008
 #, c-format
 msgid "Unable to install %s as download failed"
 msgstr "Impossible d’installer %s : le téléchargement a échoué"
@@ -2334,86 +2458,92 @@ msgstr "Impossible d’installer %s : le téléchargement a échoué"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1019
+#: src/gs-shell.c:1020
 #, c-format
 msgid "Unable to install %s as runtime %s not available"
-msgstr "Impossible d’installer %s : l’environnement d’exécution %s n’est pas disponible"
+msgstr ""
+"Impossible d’installer %s : l’environnement d’exécution %s n’est pas "
+"disponible"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1025
+#: src/gs-shell.c:1026
 #, c-format
 msgid "Unable to install %s as not supported"
 msgstr "Impossible d’installer %s : il n’est pas pris en charge"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1032
+#: src/gs-shell.c:1033
 msgid "Unable to install: internet access was required but wasn’t available"
-msgstr "Installation impossible : l’accès à Internet est nécessaire mais indisponible"
+msgstr ""
+"Installation impossible : l’accès à Internet est nécessaire mais indisponible"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1038
+#: src/gs-shell.c:1039
 msgid "Unable to install: the application has an invalid format"
 msgstr "Installation impossible : le format de l’application n’est pas valide"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1043
+#: src/gs-shell.c:1044
 #, c-format
 msgid "Unable to install %s: not enough disk space"
 msgstr "Impossible d’installer %s : il n’y a pas assez d’espace disque"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1051
+#: src/gs-shell.c:1052
 #, c-format
 msgid "Unable to install %s: authentication was required"
 msgstr "Impossible d’installer %s : authentification requise"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1058
+#: src/gs-shell.c:1059
 #, c-format
 msgid "Unable to install %s: authentication was invalid"
 msgstr "Impossible d’installer %s : authentification non valide"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1065
+#: src/gs-shell.c:1066
 #, c-format
 msgid "Unable to install %s: you do not have permission to install software"
-msgstr "Impossible d’installer %s : vous n’avez pas la permission d’installer des logiciels"
+msgstr ""
+"Impossible d’installer %s : vous n’avez pas la permission d’installer des "
+"logiciels"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the name of the authentication service,
 #. * e.g. "Ubuntu One"
-#: src/gs-shell.c:1078
+#: src/gs-shell.c:1079
 #, c-format
 msgid "Your %s account has been suspended."
 msgstr "Votre compte %s est suspendu."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1082
+#: src/gs-shell.c:1083
 msgid "It is not possible to install software until this has been resolved."
-msgstr "Il est impossible d’installer des logiciels tant que cela n’est pas résolu."
+msgstr ""
+"Il est impossible d’installer des logiciels tant que cela n’est pas résolu."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the clickable link (e.g.
 #. * "http://example.com/what-did-i-do-wrong/")
-#: src/gs-shell.c:1093
+#: src/gs-shell.c:1094
 #, c-format
 msgid "For more information, visit %s."
 msgstr "Il y a davantage d’informations ici : %s."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1102
+#: src/gs-shell.c:1103
 #, c-format
 msgid "Unable to install %s: AC power is required"
 msgstr "Impossible d’installer %s : branchez le secteur"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1111
+#: src/gs-shell.c:1112
 #, c-format
 msgid "Unable to install %s"
 msgstr "Impossible d’installer %s"
@@ -2422,61 +2552,65 @@ msgstr "Impossible d’installer %s"
 #. * where the first %s is the app name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1157
+#: src/gs-shell.c:1158
 #, c-format
 msgid "Unable to update %s from %s"
 msgstr "Impossible de mettre à jour %s depuis %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1163
+#: src/gs-shell.c:1164
 #, c-format
 msgid "Unable to update %s as download failed"
 msgstr "Impossible de mettre à jour %s : le téléchargement a échoué"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1169
+#: src/gs-shell.c:1170
 msgid "Unable to update: internet access was required but wasn’t available"
-msgstr "Impossible de mettre à jour : l’accès à Internet est nécessaire mais indisponible"
+msgstr ""
+"Impossible de mettre à jour : l’accès à Internet est nécessaire mais "
+"indisponible"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1177
+#: src/gs-shell.c:1178
 #, c-format
 msgid "Unable to update %s: not enough disk space"
 msgstr "Impossible de mettre à jour %s : il n’y a pas assez d’espace disque"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1186
+#: src/gs-shell.c:1187
 #, c-format
 msgid "Unable to update %s: authentication was required"
 msgstr "Impossible de mettre à jour %s : authentification requise"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1193
+#: src/gs-shell.c:1194
 #, c-format
 msgid "Unable to update %s: authentication was invalid"
 msgstr "Impossible de mettre à jour %s : authentification non valide"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1200
+#: src/gs-shell.c:1201
 #, c-format
 msgid "Unable to update %s: you do not have permission to update software"
-msgstr "Impossible de mettre à jour %s : vous n’avez pas la permission de mettre à jour les logiciels"
+msgstr ""
+"Impossible de mettre à jour %s : vous n’avez pas la permission de mettre à "
+"jour les logiciels"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1208
+#: src/gs-shell.c:1209
 #, c-format
 msgid "Unable to update %s: AC power is required"
 msgstr "Impossible de mettre à jour %s : branchez le secteur"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1217
+#: src/gs-shell.c:1218
 #, c-format
 msgid "Unable to update %s"
 msgstr "Impossible de mettre à jour %s"
@@ -2484,96 +2618,102 @@ msgstr "Impossible de mettre à jour %s"
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the distro name (e.g. "Fedora 25") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1262
+#: src/gs-shell.c:1263
 #, c-format
 msgid "Unable to upgrade to %s from %s"
 msgstr "Impossible de mettre à niveau vers %s depuis %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the app name (e.g. "GIMP")
-#: src/gs-shell.c:1267
+#: src/gs-shell.c:1268
 #, c-format
 msgid "Unable to upgrade to %s as download failed"
 msgstr "Impossible de mettre à niveau vers %s : le téléchargement a échoué"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1274
+#: src/gs-shell.c:1275
 msgid "Unable to upgrade: internet access was required but wasn’t available"
-msgstr "Impossible de mettre à niveau : l’accès à Internet est nécessaire mais indisponible"
+msgstr ""
+"Impossible de mettre à niveau : l’accès à Internet est nécessaire mais "
+"indisponible"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1282
+#: src/gs-shell.c:1283
 #, c-format
 msgid "Unable to upgrade to %s: not enough disk space"
 msgstr "Impossible de mettre à niveau vers %s : espace disque insuffisant"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1291
+#: src/gs-shell.c:1292
 #, c-format
 msgid "Unable to upgrade to %s: authentication was required"
 msgstr "Impossible de mettre à niveau vers %s : authentification requise"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1298
+#: src/gs-shell.c:1299
 #, c-format
 msgid "Unable to upgrade to %s: authentication was invalid"
 msgstr "Impossible de mettre à niveau vers %s : authentification non valide"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1305
+#: src/gs-shell.c:1306
 #, c-format
 msgid "Unable to upgrade to %s: you do not have permission to upgrade"
-msgstr "Impossible de mettre à niveau vers %s : vous n’avez pas la permission d’effectuer la mise à niveau"
+msgstr ""
+"Impossible de mettre à niveau vers %s : vous n’avez pas la permission "
+"d’effectuer la mise à niveau"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1312
+#: src/gs-shell.c:1313
 #, c-format
 msgid "Unable to upgrade to %s: AC power is required"
 msgstr "Impossible de mettre à niveau vers %s : branchez le secteur"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1321
+#: src/gs-shell.c:1322
 #, c-format
 msgid "Unable to upgrade to %s"
 msgstr "Impossible de mettre à niveau vers %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1363
+#: src/gs-shell.c:1364
 #, c-format
 msgid "Unable to remove %s: authentication was required"
 msgstr "Impossible de désinstaller %s : authentification requise"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1369
+#: src/gs-shell.c:1370
 #, c-format
 msgid "Unable to remove %s: authentication was invalid"
 msgstr "Impossible de désinstaller %s : authentification non valide"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1375
+#: src/gs-shell.c:1376
 #, c-format
 msgid "Unable to remove %s: you do not have permission to remove software"
-msgstr "Impossible de désinstaller %s : vous n’avez pas la permission de désinstaller le logiciel"
+msgstr ""
+"Impossible de désinstaller %s : vous n’avez pas la permission de "
+"désinstaller le logiciel"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1382
+#: src/gs-shell.c:1383
 #, c-format
 msgid "Unable to remove %s: AC power is required"
 msgstr "Impossible de désinstaller %s : branchez le secteur"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1391
+#: src/gs-shell.c:1392
 #, c-format
 msgid "Unable to remove %s"
 msgstr "Impossible de désinstaller %s"
@@ -2582,48 +2722,49 @@ msgstr "Impossible de désinstaller %s"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1437
+#: src/gs-shell.c:1438
 #, c-format
 msgid "Unable to launch %s: %s is not installed"
 msgstr "Impossible de lancer %s : %s n’est pas installé"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1444 src/gs-shell.c:1492 src/gs-shell.c:1540
+#: src/gs-shell.c:1445 src/gs-shell.c:1493 src/gs-shell.c:1541
 msgid "Not enough disk space — free up some space and try again"
 msgstr "Espace disque insuffisant — veuillez en libérer et réessayez"
 
 #. TRANSLATORS: we failed to get a proper error code
-#: src/gs-shell.c:1452 src/gs-shell.c:1500 src/gs-shell.c:1567
+#: src/gs-shell.c:1453 src/gs-shell.c:1501 src/gs-shell.c:1568
 msgid "Sorry, something went wrong"
 msgstr "Désolé, quelque chose n’a pas marché"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1487
+#: src/gs-shell.c:1488
 msgid "Failed to install file: authentication failed"
 msgstr "Impossible d’installer le fichier : l’authentification a échoué"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1534
+#: src/gs-shell.c:1535
 #, c-format
 msgid "Unable to contact %s"
 msgstr "Impossible de contacter %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1549
+#: src/gs-shell.c:1550
 #, c-format
 msgid "%s needs to be restarted to use new plugins."
 msgstr "%s doit être redémarré pour utiliser les nouveaux greffons."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1554
+#: src/gs-shell.c:1555
 msgid "This application needs to be restarted to use new plugins."
-msgstr "Cette application doit être redémarrée pour utiliser les nouveaux greffons."
+msgstr ""
+"Cette application doit être redémarrée pour utiliser les nouveaux greffons."
 
 #. TRANSLATORS: need to be connected to the AC power
-#: src/gs-shell.c:1561
+#: src/gs-shell.c:1562
 msgid "AC power is required"
 msgstr "Branchez le secteur"
 
@@ -2631,7 +2772,9 @@ msgstr "Branchez le secteur"
 #. has no software installed from it.
 #: src/gs-sources-dialog.c:98
 msgid "No applications or addons installed; other software might still be"
-msgstr "Aucune application ou extension installée ; d’autres logiciels pourraient l’être"
+msgstr ""
+"Aucune application ou extension installée ; d’autres logiciels pourraient "
+"l’être"
 
 #. TRANSLATORS: This string is used to construct the 'X applications
 #. installed' sentence, describing a software source.
@@ -2685,7 +2828,9 @@ msgstr[1] "%s et %s installées"
 #. TRANSLATORS: nonfree software
 #: src/gs-sources-dialog.c:257
 msgid "Typically has restrictions on use and access to source code."
-msgstr "A généralement des restrictions concernant l’utilisation et l’accès au code source."
+msgstr ""
+"A généralement des restrictions concernant l’utilisation et l’accès au code "
+"source."
 
 #. TRANSLATORS: list header
 #: src/gs-sources-dialog.c:278
@@ -2710,7 +2855,9 @@ msgstr "le système d’exploitation"
 msgid ""
 "Software sources can be downloaded from the internet. They give you access "
 "to additional software that is not provided by %s."
-msgstr "Les sources de logiciels peuvent être téléchargées depuis Internet. Elles vous donnent accès à des logiciels qui ne sont pas fournis par %s."
+msgstr ""
+"Les sources de logiciels peuvent être téléchargées depuis Internet. Elles "
+"vous donnent accès à des logiciels qui ne sont pas fournis par %s."
 
 #: src/gs-sources-dialog.ui:155
 msgid "Additional Sources"
@@ -2719,7 +2866,8 @@ msgstr "Sources supplémentaires"
 #: src/gs-sources-dialog.ui:175
 msgid ""
 "Removing a source will also remove any software you have installed from it."
-msgstr "Supprimer une source supprime aussi tout logiciel installé depuis celle-ci."
+msgstr ""
+"Supprimer une source supprime aussi tout logiciel installé depuis celle-ci."
 
 #: src/gs-sources-dialog.ui:260
 msgid "No software installed from this source"
@@ -2826,7 +2974,9 @@ msgstr "Des mises à jour logicielles sont disponibles"
 
 #: src/gs-update-monitor.c:97
 msgid "Important OS and application updates are ready to be installed"
-msgstr "D’importantes mises à jour du système d’exploitation et des applications sont prêtes à être installées"
+msgstr ""
+"D’importantes mises à jour du système d’exploitation et des applications "
+"sont prêtes à être installées"
 
 #. TRANSLATORS: button text
 #: src/gs-update-monitor.c:100 src/gs-updates-page.c:775
@@ -2845,7 +2995,8 @@ msgstr "Les mises à jour du système d’exploitation sont indisponibles"
 #. TRANSLATORS: this is the message dialog for the distro EOL notice
 #: src/gs-update-monitor.c:257
 msgid "Upgrade to continue receiving security updates."
-msgstr "Mettez à niveau pour continuer à bénéficier des mises à jour de sécurité."
+msgstr ""
+"Mettez à niveau pour continuer à bénéficier des mises à jour de sécurité."
 
 #. TRANSLATORS: this is a distro upgrade, the replacement would be the
 #. * distro name, e.g. 'Fedora'
@@ -2867,7 +3018,8 @@ msgstr "Échec des mises à jour logicielles"
 #. TRANSLATORS: message when we offline updates have failed
 #: src/gs-update-monitor.c:612
 msgid "An important OS update failed to be installed."
-msgstr "Échec d’installation d’une importante mise à jour du système d’exploitation."
+msgstr ""
+"Échec d’installation d’une importante mise à jour du système d’exploitation."
 
 #: src/gs-update-monitor.c:613
 msgid "Show Details"
@@ -2884,8 +3036,10 @@ msgstr[1] "Mises à jour logicielles installées"
 #: src/gs-update-monitor.c:639
 msgid "An important OS update has been installed."
 msgid_plural "Important OS updates have been installed."
-msgstr[0] "Une importante mise à jour du système d’exploitation a été installée."
-msgstr[1] "D’importantes mises à jour du système d’exploitation ont été installées."
+msgstr[0] ""
+"Une importante mise à jour du système d’exploitation a été installée."
+msgstr[1] ""
+"D’importantes mises à jour du système d’exploitation ont été installées."
 
 #. TRANSLATORS: Button to look at the updates that were installed.
 #. * Note that it has nothing to do with the application reviews, the
@@ -2917,29 +3071,37 @@ msgstr "La mise à jour a été annulée."
 #. * something with no network available
 #: src/gs-update-monitor.c:714
 msgid ""
-"Internet access was required but wasn’t available. Please make sure that you"
-" have internet access and try again."
-msgstr "L’accès à Internet est nécessaire mais n’est pas disponible. Assurez-vous d’avoir un accès à Internet puis réessayez."
+"Internet access was required but wasn’t available. Please make sure that you "
+"have internet access and try again."
+msgstr ""
+"L’accès à Internet est nécessaire mais n’est pas disponible. Assurez-vous "
+"d’avoir un accès à Internet puis réessayez."
 
 #. TRANSLATORS: if the package is not signed correctly
 #: src/gs-update-monitor.c:720
 msgid ""
 "There were security issues with the update. Please consult your software "
 "provider for more details."
-msgstr "Il y a eu un problème de sécurité avec la mise à jour. Veuillez consulter votre fournisseur de logiciels pour plus d’informations."
+msgstr ""
+"Il y a eu un problème de sécurité avec la mise à jour. Veuillez consulter "
+"votre fournisseur de logiciels pour plus d’informations."
 
 #. TRANSLATORS: we ran out of disk space
 #: src/gs-update-monitor.c:726
 msgid ""
 "There wasn’t enough disk space. Please free up some space and try again."
-msgstr "Il n’y avait pas assez d’espace disque. Veuillez en libérer et réessayez."
+msgstr ""
+"Il n’y avait pas assez d’espace disque. Veuillez en libérer et réessayez."
 
 #. TRANSLATORS: We didn't handle the error type
 #: src/gs-update-monitor.c:731
 msgid ""
 "We’re sorry: the update failed to install. Please wait for another update "
 "and try again. If the problem persists, contact your software provider."
-msgstr "Nous sommes désolés : l’installation de la mise à jour à échoué. Veuillez attendre la prochaine mise à jour et réessayer. Si le problème persiste, contactez le fournisseur du logiciel."
+msgstr ""
+"Nous sommes désolés : l’installation de la mise à jour à échoué. Veuillez "
+"attendre la prochaine mise à jour et réessayer. Si le problème persiste, "
+"contactez le fournisseur du logiciel."
 
 #. TRANSLATORS: Time in 24h format
 #: src/gs-updates-page.c:297
@@ -3119,7 +3281,9 @@ msgstr "Il peut y avoir facturation"
 msgid ""
 "Checking for updates while using mobile broadband could cause you to incur "
 "charges."
-msgstr "Rechercher des mises à jour avec votre connexion mobile peut faire l’objet d’une facturation."
+msgstr ""
+"Rechercher des mises à jour avec votre connexion mobile peut faire l’objet "
+"d’une facturation."
 
 #. TRANSLATORS: this is a link to the
 #. * control-center network panel
@@ -3158,7 +3322,9 @@ msgstr "Le logiciel est à jour"
 msgid ""
 "Checking for updates when using mobile broadband could cause you to incur "
 "charges"
-msgstr "Rechercher des mises à jour avec votre téléphone portable peut vous être facturé."
+msgstr ""
+"Rechercher des mises à jour avec votre téléphone portable peut vous être "
+"facturé."
 
 #: src/gs-updates-page.ui:257
 msgid "_Check Anyway"
@@ -3203,7 +3369,8 @@ msgstr "%s %s est prête à être installée"
 
 #: src/gs-upgrade-banner.ui:32
 msgid "A major upgrade, with new features and added polish."
-msgstr "Une mise à niveau majeure, avec de nouvelles fonctionnalités et plus belle."
+msgstr ""
+"Une mise à niveau majeure, avec de nouvelles fonctionnalités et plus belle."
 
 #: src/gs-upgrade-banner.ui:52
 msgid "_Learn More"
@@ -3212,7 +3379,9 @@ msgstr "_En savoir plus"
 #: src/gs-upgrade-banner.ui:98
 msgid ""
 "It is recommended that you back up your data and files before upgrading."
-msgstr "Il est recommandé de sauvegarder vos données et fichiers avant la mise à niveau."
+msgstr ""
+"Il est recommandé de sauvegarder vos données et fichiers avant la mise à "
+"niveau."
 
 #: src/gs-upgrade-banner.ui:116
 msgid "_Download"
@@ -3223,22 +3392,28 @@ msgid "App Center"
 msgstr "App Center"
 
 #: src/org.gnome.Software.desktop.in:4
-msgid "Add, remove or update software on this computer"
-msgstr "Ajouter, supprimer ou mettre à jour des applications sur cet ordinateur"
+msgid "More Apps"
+msgstr "Plus d'Apps"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
-#: src/org.gnome.Software.desktop.in:6
+#: src/org.gnome.Software.desktop.in:5
+msgid "Add, remove or update software on this computer"
+msgstr ""
+"Ajouter, supprimer ou mettre à jour des applications sur cet ordinateur"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: src/org.gnome.Software.desktop.in:7
 #: src/org.gnome.Software.Editor.desktop.in:6
 msgid "org.gnome.Software"
 msgstr "org.gnome.Software"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
-#: src/org.gnome.Software.desktop.in:12
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: src/org.gnome.Software.desktop.in:13
 msgid ""
-"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;"
-msgstr "mises à jour;mise à niveau;sources;dépôts;préférences;installer;désinstaller;programme;application;logiciel;magasin;"
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;"
+msgstr ""
+"mises à jour;mise à niveau;sources;dépôts;préférences;installer;désinstaller;"
+"programme;application;logiciel;magasin;"
 
 #: src/org.gnome.Software.Editor.desktop.in:3
 msgid "Banner Designer"
@@ -3248,8 +3423,7 @@ msgstr "Concepteur de la bannière"
 msgid "Design the featured banners for GNOME Software"
 msgstr "Concevoir les meilleures bannières pour Logiciels de GNOME"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: src/org.gnome.Software.Editor.desktop.in:13
 msgid "AppStream;Software;App;"
 msgstr "AppStream;Logiciel;Application;"
@@ -3519,100 +3693,111 @@ msgctxt "Menu of Communication & News"
 msgid "Web Browsers"
 msgstr "Navigateurs Web"
 
-#: plugins/core/gs-desktop-common.c:247
-msgctxt "Menu of Reference"
-msgid "All"
-msgstr "Tout"
-
-#: plugins/core/gs-desktop-common.c:250
-msgctxt "Menu of Reference"
-msgid "Featured"
-msgstr "Mises en avant"
-
-#: plugins/core/gs-desktop-common.c:253
-msgctxt "Menu of Reference"
-msgid "Art"
-msgstr "Art"
-
-#: plugins/core/gs-desktop-common.c:256
-msgctxt "Menu of Reference"
-msgid "Biography"
-msgstr "Biographie"
-
-#: plugins/core/gs-desktop-common.c:259
-msgctxt "Menu of Reference"
-msgid "Comics"
-msgstr "Bandes dessinées"
-
-#: plugins/core/gs-desktop-common.c:262
-msgctxt "Menu of Reference"
-msgid "Fiction"
-msgstr "Fiction"
-
-#: plugins/core/gs-desktop-common.c:265
-msgctxt "Menu of Reference"
-msgid "Health"
-msgstr "Santé"
-
-#: plugins/core/gs-desktop-common.c:268
-msgctxt "Menu of Reference"
-msgid "History"
-msgstr "Histoire"
-
-#: plugins/core/gs-desktop-common.c:271
-msgctxt "Menu of Reference"
-msgid "Lifestyle"
-msgstr "Style de vie"
-
-#: plugins/core/gs-desktop-common.c:274
+#: plugins/core/gs-desktop-common.c:242
 msgctxt "Menu of Communication & News"
 msgid "News"
 msgstr "Nouvelles"
 
+#: plugins/core/gs-desktop-common.c:251
+msgctxt "Menu of Reference"
+msgid "All"
+msgstr "Tout"
+
+#: plugins/core/gs-desktop-common.c:254
+msgctxt "Menu of Reference"
+msgid "Featured"
+msgstr "Mises en avant"
+
+#: plugins/core/gs-desktop-common.c:257
+msgctxt "Menu of Reference"
+msgid "Art"
+msgstr "Art"
+
+#: plugins/core/gs-desktop-common.c:260
+msgctxt "Menu of Reference"
+msgid "Biography"
+msgstr "Biographie"
+
+#: plugins/core/gs-desktop-common.c:263
+msgctxt "Menu of Reference"
+msgid "Comics"
+msgstr "Bandes dessinées"
+
+#: plugins/core/gs-desktop-common.c:266
+msgctxt "Menu of Reference"
+msgid "Feed"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:269
+msgctxt "Menu of Reference"
+msgid "Fiction"
+msgstr "Fiction"
+
+#: plugins/core/gs-desktop-common.c:272
+msgctxt "Menu of Reference"
+msgid "Health"
+msgstr "Santé"
+
+#: plugins/core/gs-desktop-common.c:275
+msgctxt "Menu of Reference"
+msgid "History"
+msgstr "Histoire"
+
 #: plugins/core/gs-desktop-common.c:278
+msgctxt "Menu of Reference"
+msgid "Lifestyle"
+msgstr "Style de vie"
+
+#: plugins/core/gs-desktop-common.c:281
+#, fuzzy
+msgctxt "Menu of Reference"
+msgid "News"
+msgstr "Nouvelles"
+
+#: plugins/core/gs-desktop-common.c:284
 msgctxt "Menu of Reference"
 msgid "Politics"
 msgstr "Politique"
 
-#: plugins/core/gs-desktop-common.c:281
+#: plugins/core/gs-desktop-common.c:287
 msgctxt "Menu of Reference"
 msgid "Sports"
 msgstr "Sports"
 
 #. TRANSLATORS: this is the menu spec main category for Learning
-#: plugins/core/gs-desktop-common.c:291
+#: plugins/core/gs-desktop-common.c:297
 msgid "Learning"
 msgstr "Apprentissage"
 
 #. TRANSLATORS: this is the menu spec main category for Game
-#: plugins/core/gs-desktop-common.c:294
+#: plugins/core/gs-desktop-common.c:300
 msgid "Games"
 msgstr "Jeux"
 
 #. TRANSLATORS: this is the menu spec main category for Multimedia
-#: plugins/core/gs-desktop-common.c:297
+#: plugins/core/gs-desktop-common.c:303
 msgid "Multimedia"
 msgstr "Multimédia"
 
 #. TRANSLATORS: this is the menu spec main category for Work
-#: plugins/core/gs-desktop-common.c:300
+#: plugins/core/gs-desktop-common.c:306
 msgid "Work"
 msgstr "Travail"
 
 #. TRANSLATORS: this is the menu spec main category for Reference
-#: plugins/core/gs-desktop-common.c:303
+#: plugins/core/gs-desktop-common.c:309
 msgid "Reference & News"
 msgstr "Références et nouvelles"
 
 #. TRANSLATORS: this is the menu spec main category for Utilities
-#: plugins/core/gs-desktop-common.c:306
+#: plugins/core/gs-desktop-common.c:312
 msgid "Utilities"
 msgstr "Utilitaires"
 
 #. TRANSLATORS: this is the menu spec main category for Dev Tools; it
 #. * should be a relatively short label; as an example, in Portuguese and
 #. * Spanish the direct translation of "Programming" (noun) is used
-#: plugins/core/gs-desktop-common.c:311
+#: plugins/core/gs-desktop-common.c:317
 msgid "Dev Tools"
 msgstr "Outils de développement"
 
@@ -3631,23 +3816,24 @@ msgstr "Mises à jour du système d’exploitation"
 #. * "OS Updates" string
 #: plugins/core/gs-plugin-generic-updates.c:70
 msgid "Includes performance, stability and security improvements."
-msgstr "Elle inclut des améliorations de performances, de stabilité et de sécurité."
+msgstr ""
+"Elle inclut des améliorations de performances, de stabilité et de sécurité."
 
 #. TRANSLATORS: status text when downloading
 #: plugins/core/gs-plugin-rewrite-resource.c:55
 msgid "Downloading featured images…"
 msgstr "Téléchargement des images mises en avant…"
 
-#: plugins/eos/gs-plugin-eos.c:1249
+#: plugins/eos/gs-plugin-eos.c:1233
 #, c-format
 msgid "Could not launch this application."
 msgstr "Nous n'avons pas pu lancer cette application."
 
-#: plugins/eos/gs-plugin-eos.c:1305
+#: plugins/eos/gs-plugin-eos.c:1289
 msgid "Endless Platform"
 msgstr "Plate-forme Endless"
 
-#: plugins/eos/gs-plugin-eos.c:1308
+#: plugins/eos/gs-plugin-eos.c:1292
 msgid "Framework for applications"
 msgstr "Cadre pour les applications"
 
@@ -3662,7 +3848,9 @@ msgstr "Exécuter des applications Web connues dans un navigateur"
 #. TRANSLATORS: tool that is used when copying profiles system-wide
 #: plugins/external-appstream/gs-install-appstream.c:105
 msgid "GNOME Software AppStream system-wide installer"
-msgstr "Outil d’installation AppStream sur l’ensemble du système de Logiciels de GNOME"
+msgstr ""
+"Outil d’installation AppStream sur l’ensemble du système de Logiciels de "
+"GNOME"
 
 #: plugins/external-appstream/gs-install-appstream.c:107
 msgid "Failed to parse command line arguments"
@@ -3696,7 +3884,9 @@ msgstr "Téléchargement des informations de mise à niveau…"
 #. TRANSLATORS: this is a title for Fedora distro upgrades
 #: plugins/fedora-pkgdb-collections/gs-plugin-fedora-pkgdb-collections.c:303
 msgid "Upgrade your Fedora system to the latest features and improvements."
-msgstr "Mise à niveau de votre système Fedora vers les dernières fonctionnalités et améliorations."
+msgstr ""
+"Mise à niveau de votre système Fedora vers les dernières fonctionnalités et "
+"améliorations."
 
 #: plugins/flatpak/org.gnome.Software.Plugin.Flatpak.metainfo.xml.in:6
 msgid "Flatpak Support"
@@ -3707,13 +3897,13 @@ msgid "Flatpak is a framework for desktop applications on Linux"
 msgstr "Flatpak est une structure pour les applications de bureau sous Linux"
 
 #. TRANSLATORS: status text when downloading new metadata
-#: plugins/flatpak/gs-flatpak.c:821
+#: plugins/flatpak/gs-flatpak.c:815
 #, c-format
 msgid "Getting flatpak metadata for %s…"
 msgstr "Téléchargement des métadonnées de Flatpak pour %s…"
 
 #. TRANSLATORS: status text when downloading the RuntimeRepo
-#: plugins/flatpak/gs-flatpak.c:2796
+#: plugins/flatpak/gs-flatpak.c:2803
 msgid "Getting runtime source…"
 msgstr "Téléchargement des sources des environnements d’exécution…"
 
@@ -3746,7 +3936,9 @@ msgstr "Prise en charge de Limba"
 
 #: plugins/limba/org.gnome.Software.Plugin.Limba.metainfo.xml.in:7
 msgid "Limba provides developers a way to easily create software bundles"
-msgstr "Limba donne aux développeurs un moyen de créer facilement des paquets logiciels"
+msgstr ""
+"Limba donne aux développeurs un moyen de créer facilement des paquets "
+"logiciels"
 
 #. TRANSLATORS: status text when downloading
 #: plugins/odrs/gs-plugin-odrs.c:205
@@ -3759,7 +3951,9 @@ msgstr "Prise en charge d’Open Desktop Ratings"
 
 #: plugins/odrs/org.gnome.Software.Plugin.Odrs.metainfo.xml.in:7
 msgid "ODRS is a service providing user reviews of applications"
-msgstr "ODRS est un service qui met à disposition les appréciations d’utilisateurs sur des applications"
+msgstr ""
+"ODRS est un service qui met à disposition les appréciations d’utilisateurs "
+"sur des applications"
 
 #. TRANSLATORS: status text when downloading
 #: plugins/shell-extensions/gs-plugin-shell-extensions.c:669

--- a/po/gnome-software.pot
+++ b/po/gnome-software.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-software\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-12 22:31-0700\n"
+"POT-Creation-Date: 2017-11-02 16:28+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -345,7 +345,7 @@ msgstr ""
 
 #. TRANSLATORS: this is a button next to the search results that
 #. * shows the status of an application being installed
-#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:443
+#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:439
 msgid "Installing"
 msgstr ""
 
@@ -360,7 +360,7 @@ msgid "Folder Name"
 msgstr ""
 
 #: src/gs-app-folder-dialog.c:321 src/gs-app-folder-dialog.ui:16
-#: src/gs-details-page.c:383 src/gs-details-page.ui:342 src/gs-editor.c:623
+#: src/gs-details-page.c:379 src/gs-details-page.ui:342 src/gs-editor.c:623
 #: src/gs-editor.c:655 src/gs-installed-page.c:609 src/gs-removal-dialog.ui:33
 #: src/gs-review-dialog.ui:23 src/gs-upgrade-banner.ui:131
 msgid "_Cancel"
@@ -375,90 +375,90 @@ msgid "Add to Application Folder"
 msgstr ""
 
 #. TRANSLATORS: this is a command line option
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "Start up mode: either ‘updates’, ‘updated’, ‘installed’ or ‘overview’"
 msgstr ""
 
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "MODE"
 msgstr ""
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "Search for applications"
 msgstr ""
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "SEARCH"
 msgstr ""
 
-#: src/gs-application.c:105
+#: src/gs-application.c:133
 msgid "Show application details (using application ID)"
 msgstr ""
 
-#: src/gs-application.c:105 src/gs-application.c:109
+#: src/gs-application.c:133 src/gs-application.c:137
 msgid "ID"
 msgstr ""
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "Show application details (using package name)"
 msgstr ""
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "PKGNAME"
 msgstr ""
 
-#: src/gs-application.c:109
+#: src/gs-application.c:137
 msgid "Install the application (using application ID)"
 msgstr ""
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "Open a local package file"
 msgstr ""
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "FILENAME"
 msgstr ""
 
-#: src/gs-application.c:113
+#: src/gs-application.c:141
 msgid ""
 "The kind of interaction expected for this action: either ‘none’, ‘notify’, "
 "or ‘full’"
 msgstr ""
 
-#: src/gs-application.c:116
+#: src/gs-application.c:144
 msgid "Show verbose debugging information"
 msgstr ""
 
-#: src/gs-application.c:118
+#: src/gs-application.c:146
 msgid "Show profiling information for the service"
 msgstr ""
 
-#: src/gs-application.c:120
+#: src/gs-application.c:148
 msgid "Quit the running instance"
 msgstr ""
 
-#: src/gs-application.c:122
+#: src/gs-application.c:150
 msgid "Prefer local file sources to AppStream"
 msgstr ""
 
-#: src/gs-application.c:124
+#: src/gs-application.c:152
 msgid "Show version number"
 msgstr ""
 
-#: src/gs-application.c:325
+#: src/gs-application.c:358
 msgid "translator-credits"
 msgstr ""
 
 #. TRANSLATORS: this is the title of the about window, e.g.
 #. * 'About Software' or 'About Application Installer' where the %s is
 #. * the application name chosen by the distro
-#: src/gs-application.c:332
+#: src/gs-application.c:365
 #, c-format
 msgid "About %s"
 msgstr ""
 
 #. TRANSLATORS: well, we seem to think so, anyway
-#: src/gs-application.c:336
+#: src/gs-application.c:369
 msgid "A nice way to manage the software on your system."
 msgstr ""
 
@@ -573,7 +573,7 @@ msgid "All"
 msgstr ""
 
 #. TRANSLATORS: this is a subcategory of featured apps
-#: lib/gs-category.c:202 src/gs-shell.c:2180
+#: lib/gs-category.c:202 src/gs-shell.c:2181
 msgid "Featured"
 msgstr ""
 
@@ -1098,14 +1098,14 @@ msgstr ""
 #. * can be installed
 #. TRANSLATORS: button text in the header when firmware
 #. * can be live-installed
-#: src/gs-details-page.c:281 src/gs-details-page.c:312
-#: src/gs-details-page.ui:206 src/gs-upgrade-banner.ui:146
+#: src/gs-details-page.c:280 src/gs-details-page.c:310
+#: src/gs-details-page.ui:237 src/gs-upgrade-banner.ui:146
 msgid "_Install"
 msgstr ""
 
 #. TRANSLATORS: button text in the header when an application
 #. * can be live-updated
-#: src/gs-details-page.c:316
+#: src/gs-details-page.c:314
 msgid "_Update"
 msgstr ""
 
@@ -1113,67 +1113,67 @@ msgstr ""
 #. * be installed.
 #. * The ellipsis indicates that further steps are required,
 #. * e.g. enabling software sources or the like
-#: src/gs-details-page.c:330
+#: src/gs-details-page.c:326
 msgid "_Install…"
 msgstr ""
 
 #. TRANSLATORS: button text in the header when an application can be erased
-#: src/gs-details-page.c:377 src/gs-details-page.ui:547
+#: src/gs-details-page.c:373 src/gs-details-page.ui:547
 msgid "_Uninstall"
 msgstr ""
 
-#: src/gs-details-page.c:438 src/gs-sources-dialog.c:513
+#: src/gs-details-page.c:434 src/gs-sources-dialog.c:513
 msgid "Removing…"
 msgstr ""
 
 #. TRANSLATORS: this is the warning box
-#: src/gs-details-page.c:748
+#: src/gs-details-page.c:744
 msgid ""
 "This application can only be used when there is an active internet "
 "connection."
 msgstr ""
 
 #. TRANSLATORS: this is where the version is not known
-#: src/gs-details-page.c:892
+#: src/gs-details-page.c:888
 msgctxt "version"
 msgid "Unknown"
 msgstr ""
 
 #. TRANSLATORS: this is where we don't know the origin of the
 #. * application
-#: src/gs-details-page.c:971
+#: src/gs-details-page.c:967
 msgctxt "origin"
 msgid "Unknown"
 msgstr ""
 
 #. TRANSLATORS: we need a remote server to process
-#: src/gs-details-page.c:1378
+#: src/gs-details-page.c:1374
 msgid "You need internet access to write a review"
 msgstr ""
 
-#: src/gs-details-page.c:1507
+#: src/gs-details-page.c:1503
 #, c-format
 msgid "Unable to find “%s”"
 msgstr ""
 
 #. TRANSLATORS: see the wikipedia page
-#: src/gs-details-page.c:2087
+#: src/gs-details-page.c:2083
 msgid "Public domain"
 msgstr ""
 
 #. TRANSLATORS: see GNU page
-#: src/gs-details-page.c:2103 src/gs-details-page.ui:1397
+#: src/gs-details-page.c:2099 src/gs-details-page.ui:1397
 msgid "Free Software"
 msgstr ""
 
 #. TRANSLATORS: for the free software popover
-#: src/gs-details-page.c:2160
+#: src/gs-details-page.c:2156
 msgid "Users are bound by the following license:"
 msgid_plural "Users are bound by the following licenses:"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/gs-details-page.c:2176 src/gs-details-page.ui:1506
+#: src/gs-details-page.c:2172 src/gs-details-page.ui:1506
 msgid "More information"
 msgstr ""
 
@@ -1182,12 +1182,12 @@ msgid "Details page"
 msgstr ""
 
 #. Translators: A label for a button to add a shortcut to the selected application.
-#: src/gs-details-page.ui:228
+#: src/gs-details-page.ui:209
 msgid "_Add to Desktop"
 msgstr ""
 
 #. Translators: A label for a button to remove a shortcut to the selected application.
-#: src/gs-details-page.ui:245
+#: src/gs-details-page.ui:226
 msgid "_Remove from Desktop"
 msgstr ""
 
@@ -1604,7 +1604,7 @@ msgstr ""
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
-#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1426
+#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1430
 #, c-format
 msgid "No addon codecs are available for the %s format."
 msgstr ""
@@ -1944,7 +1944,7 @@ msgstr ""
 msgid "%s will be removed, and you will have to install it to use it again."
 msgstr ""
 
-#: lib/gs-plugin-loader.c:1429
+#: lib/gs-plugin-loader.c:1433
 #, c-format
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
@@ -2227,80 +2227,80 @@ msgstr ""
 #. TRANSLATORS: this is part of the in-app notification,
 #. * where the %s is a multi-word localised app name
 #. * e.g. 'Getting things GNOME!"
-#: src/gs-shell.c:846 src/gs-shell.c:851 src/gs-shell.c:866 src/gs-shell.c:870
+#: src/gs-shell.c:847 src/gs-shell.c:852 src/gs-shell.c:867 src/gs-shell.c:871
 #, c-format
 msgid "“%s”"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:898
+#: src/gs-shell.c:899
 #, c-format
 msgid "Unable to download firmware updates from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:904
+#: src/gs-shell.c:905
 #, c-format
 msgid "Unable to download updates from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:911
+#: src/gs-shell.c:912
 msgid "Unable to download updates"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:916
+#: src/gs-shell.c:917
 msgid ""
 "Unable to download updates: internet access was required but wasn’t available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:925
+#: src/gs-shell.c:926
 #, c-format
 msgid "Unable to download updates from %s: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:930
+#: src/gs-shell.c:931
 msgid "Unable to download updates: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:938
+#: src/gs-shell.c:939
 msgid "Unable to download updates: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:943
+#: src/gs-shell.c:944
 msgid "Unable to download updates: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:948
+#: src/gs-shell.c:949
 msgid ""
 "Unable to download updates: you do not have permission to install software"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:955
+#: src/gs-shell.c:956
 msgid "Unable to get list of updates"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the application name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1001
+#: src/gs-shell.c:1002
 #, c-format
 msgid "Unable to install %s as download failed from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1007
+#: src/gs-shell.c:1008
 #, c-format
 msgid "Unable to install %s as download failed"
 msgstr ""
@@ -2309,51 +2309,51 @@ msgstr ""
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1019
+#: src/gs-shell.c:1020
 #, c-format
 msgid "Unable to install %s as runtime %s not available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1025
+#: src/gs-shell.c:1026
 #, c-format
 msgid "Unable to install %s as not supported"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1032
+#: src/gs-shell.c:1033
 msgid "Unable to install: internet access was required but wasn’t available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1038
+#: src/gs-shell.c:1039
 msgid "Unable to install: the application has an invalid format"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1043
+#: src/gs-shell.c:1044
 #, c-format
 msgid "Unable to install %s: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1051
+#: src/gs-shell.c:1052
 #, c-format
 msgid "Unable to install %s: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1058
+#: src/gs-shell.c:1059
 #, c-format
 msgid "Unable to install %s: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1065
+#: src/gs-shell.c:1066
 #, c-format
 msgid "Unable to install %s: you do not have permission to install software"
 msgstr ""
@@ -2361,34 +2361,34 @@ msgstr ""
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the name of the authentication service,
 #. * e.g. "Ubuntu One"
-#: src/gs-shell.c:1078
+#: src/gs-shell.c:1079
 #, c-format
 msgid "Your %s account has been suspended."
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1082
+#: src/gs-shell.c:1083
 msgid "It is not possible to install software until this has been resolved."
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the clickable link (e.g.
 #. * "http://example.com/what-did-i-do-wrong/")
-#: src/gs-shell.c:1093
+#: src/gs-shell.c:1094
 #, c-format
 msgid "For more information, visit %s."
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1102
+#: src/gs-shell.c:1103
 #, c-format
 msgid "Unable to install %s: AC power is required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1111
+#: src/gs-shell.c:1112
 #, c-format
 msgid "Unable to install %s"
 msgstr ""
@@ -2397,61 +2397,61 @@ msgstr ""
 #. * where the first %s is the app name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1157
+#: src/gs-shell.c:1158
 #, c-format
 msgid "Unable to update %s from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1163
+#: src/gs-shell.c:1164
 #, c-format
 msgid "Unable to update %s as download failed"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1169
+#: src/gs-shell.c:1170
 msgid "Unable to update: internet access was required but wasn’t available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1177
+#: src/gs-shell.c:1178
 #, c-format
 msgid "Unable to update %s: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1186
+#: src/gs-shell.c:1187
 #, c-format
 msgid "Unable to update %s: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1193
+#: src/gs-shell.c:1194
 #, c-format
 msgid "Unable to update %s: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1200
+#: src/gs-shell.c:1201
 #, c-format
 msgid "Unable to update %s: you do not have permission to update software"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1208
+#: src/gs-shell.c:1209
 #, c-format
 msgid "Unable to update %s: AC power is required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1217
+#: src/gs-shell.c:1218
 #, c-format
 msgid "Unable to update %s"
 msgstr ""
@@ -2459,96 +2459,96 @@ msgstr ""
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the distro name (e.g. "Fedora 25") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1262
+#: src/gs-shell.c:1263
 #, c-format
 msgid "Unable to upgrade to %s from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the app name (e.g. "GIMP")
-#: src/gs-shell.c:1267
+#: src/gs-shell.c:1268
 #, c-format
 msgid "Unable to upgrade to %s as download failed"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1274
+#: src/gs-shell.c:1275
 msgid "Unable to upgrade: internet access was required but wasn’t available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1282
+#: src/gs-shell.c:1283
 #, c-format
 msgid "Unable to upgrade to %s: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1291
+#: src/gs-shell.c:1292
 #, c-format
 msgid "Unable to upgrade to %s: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1298
+#: src/gs-shell.c:1299
 #, c-format
 msgid "Unable to upgrade to %s: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1305
+#: src/gs-shell.c:1306
 #, c-format
 msgid "Unable to upgrade to %s: you do not have permission to upgrade"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1312
+#: src/gs-shell.c:1313
 #, c-format
 msgid "Unable to upgrade to %s: AC power is required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1321
+#: src/gs-shell.c:1322
 #, c-format
 msgid "Unable to upgrade to %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1363
+#: src/gs-shell.c:1364
 #, c-format
 msgid "Unable to remove %s: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1369
+#: src/gs-shell.c:1370
 #, c-format
 msgid "Unable to remove %s: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1375
+#: src/gs-shell.c:1376
 #, c-format
 msgid "Unable to remove %s: you do not have permission to remove software"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1382
+#: src/gs-shell.c:1383
 #, c-format
 msgid "Unable to remove %s: AC power is required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1391
+#: src/gs-shell.c:1392
 #, c-format
 msgid "Unable to remove %s"
 msgstr ""
@@ -2557,48 +2557,48 @@ msgstr ""
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1437
+#: src/gs-shell.c:1438
 #, c-format
 msgid "Unable to launch %s: %s is not installed"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1444 src/gs-shell.c:1492 src/gs-shell.c:1540
+#: src/gs-shell.c:1445 src/gs-shell.c:1493 src/gs-shell.c:1541
 msgid "Not enough disk space — free up some space and try again"
 msgstr ""
 
 #. TRANSLATORS: we failed to get a proper error code
-#: src/gs-shell.c:1452 src/gs-shell.c:1500 src/gs-shell.c:1567
+#: src/gs-shell.c:1453 src/gs-shell.c:1501 src/gs-shell.c:1568
 msgid "Sorry, something went wrong"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1487
+#: src/gs-shell.c:1488
 msgid "Failed to install file: authentication failed"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1534
+#: src/gs-shell.c:1535
 #, c-format
 msgid "Unable to contact %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1549
+#: src/gs-shell.c:1550
 #, c-format
 msgid "%s needs to be restarted to use new plugins."
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1554
+#: src/gs-shell.c:1555
 msgid "This application needs to be restarted to use new plugins."
 msgstr ""
 
 #. TRANSLATORS: need to be connected to the AC power
-#: src/gs-shell.c:1561
+#: src/gs-shell.c:1562
 msgid "AC power is required"
 msgstr ""
 
@@ -3198,17 +3198,21 @@ msgid "App Center"
 msgstr ""
 
 #: src/org.gnome.Software.desktop.in:4
+msgid "More Apps"
+msgstr ""
+
+#: src/org.gnome.Software.desktop.in:5
 msgid "Add, remove or update software on this computer"
 msgstr ""
 
 #. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: src/org.gnome.Software.desktop.in:6
+#: src/org.gnome.Software.desktop.in:7
 #: src/org.gnome.Software.Editor.desktop.in:6
 msgid "org.gnome.Software"
 msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-#: src/org.gnome.Software.desktop.in:12
+#: src/org.gnome.Software.desktop.in:13
 msgid ""
 "Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
 "Software;App;Store;"
@@ -3492,100 +3496,110 @@ msgctxt "Menu of Communication & News"
 msgid "Web Browsers"
 msgstr ""
 
-#: plugins/core/gs-desktop-common.c:247
-msgctxt "Menu of Reference"
-msgid "All"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:250
-msgctxt "Menu of Reference"
-msgid "Featured"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:253
-msgctxt "Menu of Reference"
-msgid "Art"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:256
-msgctxt "Menu of Reference"
-msgid "Biography"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:259
-msgctxt "Menu of Reference"
-msgid "Comics"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:262
-msgctxt "Menu of Reference"
-msgid "Fiction"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:265
-msgctxt "Menu of Reference"
-msgid "Health"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:268
-msgctxt "Menu of Reference"
-msgid "History"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:271
-msgctxt "Menu of Reference"
-msgid "Lifestyle"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:274
+#: plugins/core/gs-desktop-common.c:242
 msgctxt "Menu of Communication & News"
 msgid "News"
 msgstr ""
 
+#: plugins/core/gs-desktop-common.c:251
+msgctxt "Menu of Reference"
+msgid "All"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:254
+msgctxt "Menu of Reference"
+msgid "Featured"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:257
+msgctxt "Menu of Reference"
+msgid "Art"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:260
+msgctxt "Menu of Reference"
+msgid "Biography"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:263
+msgctxt "Menu of Reference"
+msgid "Comics"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:266
+msgctxt "Menu of Reference"
+msgid "Feed"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:269
+msgctxt "Menu of Reference"
+msgid "Fiction"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:272
+msgctxt "Menu of Reference"
+msgid "Health"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:275
+msgctxt "Menu of Reference"
+msgid "History"
+msgstr ""
+
 #: plugins/core/gs-desktop-common.c:278
+msgctxt "Menu of Reference"
+msgid "Lifestyle"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:281
+msgctxt "Menu of Reference"
+msgid "News"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:284
 msgctxt "Menu of Reference"
 msgid "Politics"
 msgstr ""
 
-#: plugins/core/gs-desktop-common.c:281
+#: plugins/core/gs-desktop-common.c:287
 msgctxt "Menu of Reference"
 msgid "Sports"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Learning
-#: plugins/core/gs-desktop-common.c:291
+#: plugins/core/gs-desktop-common.c:297
 msgid "Learning"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Game
-#: plugins/core/gs-desktop-common.c:294
+#: plugins/core/gs-desktop-common.c:300
 msgid "Games"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Multimedia
-#: plugins/core/gs-desktop-common.c:297
+#: plugins/core/gs-desktop-common.c:303
 msgid "Multimedia"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Work
-#: plugins/core/gs-desktop-common.c:300
+#: plugins/core/gs-desktop-common.c:306
 msgid "Work"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Reference
-#: plugins/core/gs-desktop-common.c:303
+#: plugins/core/gs-desktop-common.c:309
 msgid "Reference & News"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Utilities
-#: plugins/core/gs-desktop-common.c:306
+#: plugins/core/gs-desktop-common.c:312
 msgid "Utilities"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Dev Tools; it
 #. * should be a relatively short label; as an example, in Portuguese and
 #. * Spanish the direct translation of "Programming" (noun) is used
-#: plugins/core/gs-desktop-common.c:311
+#: plugins/core/gs-desktop-common.c:317
 msgid "Dev Tools"
 msgstr ""
 
@@ -3611,16 +3625,16 @@ msgstr ""
 msgid "Downloading featured images…"
 msgstr ""
 
-#: plugins/eos/gs-plugin-eos.c:1249
+#: plugins/eos/gs-plugin-eos.c:1233
 #, c-format
 msgid "Could not launch this application."
 msgstr ""
 
-#: plugins/eos/gs-plugin-eos.c:1305
+#: plugins/eos/gs-plugin-eos.c:1289
 msgid "Endless Platform"
 msgstr ""
 
-#: plugins/eos/gs-plugin-eos.c:1308
+#: plugins/eos/gs-plugin-eos.c:1292
 msgid "Framework for applications"
 msgstr ""
 
@@ -3680,13 +3694,13 @@ msgid "Flatpak is a framework for desktop applications on Linux"
 msgstr ""
 
 #. TRANSLATORS: status text when downloading new metadata
-#: plugins/flatpak/gs-flatpak.c:821
+#: plugins/flatpak/gs-flatpak.c:815
 #, c-format
 msgid "Getting flatpak metadata for %s…"
 msgstr ""
 
 #. TRANSLATORS: status text when downloading the RuntimeRepo
-#: plugins/flatpak/gs-flatpak.c:2796
+#: plugins/flatpak/gs-flatpak.c:2803
 msgid "Getting runtime source…"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the gnome-software package.
-# 
+#
 # Translators:
 # e2f_in c7 <e2f_in_c7@outlook.com>, 2016-2017
 # Roddy Shuler <roddy@endlessm.com>, 2016-2017
@@ -9,14 +9,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-software\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-12 22:31-0700\n"
+"POT-Creation-Date: 2017-11-02 16:28+0100\n"
 "PO-Revision-Date: 2017-10-17 09:46+0000\n"
 "Last-Translator: e2f_in c7 <e2f_in_c7@outlook.com>\n"
-"Language-Team: Hindi (http://www.transifex.com/endless-mobile-inc/gnome-software/language/hi/)\n"
+"Language-Team: Hindi (http://www.transifex.com/endless-mobile-inc/gnome-"
+"software/language/hi/)\n"
+"Language: hi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:7
@@ -31,7 +32,9 @@ msgstr "GNOME के लिए एप्लिकेशन प्रबंधक
 msgid ""
 "Software allows you to find and install new applications and system "
 "extensions and remove existing installed applications."
-msgstr "सॉफ़्टवेयर आपको नए एप्लिकेशन और सिस्टम विस्तारण ढूँढने और स्थापित करने देता है और मौजूदा स्थापित एप्लिकेशन को निकालने देता है."
+msgstr ""
+"सॉफ़्टवेयर आपको नए एप्लिकेशन और सिस्टम विस्तारण ढूँढने और स्थापित करने देता है और मौजूदा "
+"स्थापित एप्लिकेशन को निकालने देता है."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:14
 msgid ""
@@ -39,7 +42,11 @@ msgid ""
 "descriptions and multiple screenshots per application. Applications can be "
 "found either through browsing the list of categories or by searching. It "
 "also allows you to update your system using an offline update."
-msgstr "GNOME सॉफ़्टवेयर उपयोगी विवरणों और प्रति एप्लिकेशन एकाधिक स्क्रीनशॉट के साथ पसंदीदा और लोकप्रिय एप्लिकेशन को दिखाता है. एप्लिकेशन को श्रेणियों की सूची को ब्राउज़ करके या उन्हें खोजकर ब्राउज़ किया जा सकता है. यह आपको ऑफ़लाइन अपडेट का उपयोग करके आपके सिस्टम को भी अद्यतित करने देता है."
+msgstr ""
+"GNOME सॉफ़्टवेयर उपयोगी विवरणों और प्रति एप्लिकेशन एकाधिक स्क्रीनशॉट के साथ पसंदीदा और "
+"लोकप्रिय एप्लिकेशन को दिखाता है. एप्लिकेशन को श्रेणियों की सूची को ब्राउज़ करके या उन्हें "
+"खोजकर ब्राउज़ किया जा सकता है. यह आपको ऑफ़लाइन अपडेट का उपयोग करके आपके सिस्टम को भी "
+"अद्यतित करने देता है."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:25
 msgid "Overview panel"
@@ -83,7 +90,9 @@ msgstr "GNOME Software में अपडेट प्रबंधित कर
 msgid ""
 "If disabled, GNOME Software will hide the updates panel and not perform any "
 "automatic updates actions."
-msgstr "अक्षम होने पर, GNOME Software अपडेट पैनल को छिपा देगा और कोई भी स्वचालित अपडेट क्रिया नहीं करेगा."
+msgstr ""
+"अक्षम होने पर, GNOME Software अपडेट पैनल को छिपा देगा और कोई भी स्वचालित अपडेट "
+"क्रिया नहीं करेगा."
 
 #: data/org.gnome.software.gschema.xml:15
 msgid "Whether to automatically download updates"
@@ -91,9 +100,11 @@ msgstr "चाहे स्वचालित रूप से अपडेट �
 
 #: data/org.gnome.software.gschema.xml:16
 msgid ""
-"If enabled, GNOME Software automatically downloads updates in the background"
-" and prompts the user to install them when ready."
-msgstr "सक्षम होने पर, GNOME सॉफ़्टवेयर स्वचालित रूप से पृष्ठभूमि में अपडेट को डाउनलोड करता है और उनके तैयार होने पर स्थापित करने करने के लिए उपयोगकर्ता को संकेत देता है."
+"If enabled, GNOME Software automatically downloads updates in the background "
+"and prompts the user to install them when ready."
+msgstr ""
+"सक्षम होने पर, GNOME सॉफ़्टवेयर स्वचालित रूप से पृष्ठभूमि में अपडेट को डाउनलोड करता है और "
+"उनके तैयार होने पर स्थापित करने करने के लिए उपयोगकर्ता को संकेत देता है."
 
 #: data/org.gnome.software.gschema.xml:20
 msgid "Whether to automatically refresh when on a metered connection"
@@ -104,7 +115,10 @@ msgid ""
 "If enabled, GNOME Software automatically refreshes in the background even "
 "when using a metered connection (eventually downloading some metadata, "
 "checking for updates, etc., which may incur in costs for the user)."
-msgstr "सक्षम होने पर, मीटर्ड कनेक्शन का उपयोग करने पर भी GNOME Software स्वचालित रूप से पृष्ठभूमि में रिफ़्रेश होगा (फलतः कुछ मेटाडाटा डाउनलोड करना, अपडेट के लिए जाँचना इत्यादि, जिससे हो सकता है कि उपयोगकर्ता पर शुल्क लगेे)."
+msgstr ""
+"सक्षम होने पर, मीटर्ड कनेक्शन का उपयोग करने पर भी GNOME Software स्वचालित रूप से "
+"पृष्ठभूमि में रिफ़्रेश होगा (फलतः कुछ मेटाडाटा डाउनलोड करना, अपडेट के लिए जाँचना इत्यादि, "
+"जिससे हो सकता है कि उपयोगकर्ता पर शुल्क लगेे)."
 
 #: data/org.gnome.software.gschema.xml:25
 msgid "Whether it’s the very first run of GNOME Software"
@@ -124,9 +138,11 @@ msgstr "सशुल्क एप्लिकेशन स्थापित ह
 
 #: data/org.gnome.software.gschema.xml:38
 msgid ""
-"When non-free applications are installed a warning dialog can be shown. This"
-" controls if that dialog is suppressed."
-msgstr "सशुल्क एप्लिकेशन के स्थापित होने पर चेतावनी संवाद दिखाई दे सकता है. उस संवाद के दबे होने पर वह इसे नियंत्रित करता है."
+"When non-free applications are installed a warning dialog can be shown. This "
+"controls if that dialog is suppressed."
+msgstr ""
+"सशुल्क एप्लिकेशन के स्थापित होने पर चेतावनी संवाद दिखाई दे सकता है. उस संवाद के दबे होने पर "
+"वह इसे नियंत्रित करता है."
 
 #: data/org.gnome.software.gschema.xml:42
 msgid "A list of popular applications"
@@ -134,7 +150,8 @@ msgstr "लोकप्रिय एप्लिकेशन की सूची
 
 #: data/org.gnome.software.gschema.xml:43
 msgid "A list of applications to use, overriding the system defined ones."
-msgstr "परिभाषित किए गए सिस्टम को ओवरराइड करने पर उपयोग किए जाने वाले एप्लिकेशन की सूची."
+msgstr ""
+"परिभाषित किए गए सिस्टम को ओवरराइड करने पर उपयोग किए जाने वाले एप्लिकेशन की सूची."
 
 #: data/org.gnome.software.gschema.xml:47
 msgid "The list of extra sources that have been previously enabled"
@@ -169,9 +186,12 @@ msgstr "अपस्ट्रीम स्क्रीनशॉट अभी भ
 #: data/org.gnome.software.gschema.xml:69
 msgid ""
 "Choosing a larger value will mean less round-trips to the remote server but "
-"updates to the screenshots may take longer to show to the user. A value of 0"
-" means to never check the server if the image already exists in the cache."
-msgstr "बड़ा मान चुनने का अर्थ होगा कि रिमोट सर्वर के लिए कम राउंड-ट्रिप्स लेकिन उपयोगकर्ताओं को स्क्रीनशॉट्स के अपडेट दिखाने में अधिक समय लग सकता है. 0 मान का अर्थ है कि अगर छवि पहले से ही कैशे में मौजूद है तो सर्वर की कभी जाँच नहीं की जाएगी."
+"updates to the screenshots may take longer to show to the user. A value of 0 "
+"means to never check the server if the image already exists in the cache."
+msgstr ""
+"बड़ा मान चुनने का अर्थ होगा कि रिमोट सर्वर के लिए कम राउंड-ट्रिप्स लेकिन उपयोगकर्ताओं को "
+"स्क्रीनशॉट्स के अपडेट दिखाने में अधिक समय लग सकता है. 0 मान का अर्थ है कि अगर छवि पहले से "
+"ही कैशे में मौजूद है तो सर्वर की कभी जाँच नहीं की जाएगी."
 
 #: data/org.gnome.software.gschema.xml:78
 msgid "The server to use for application reviews"
@@ -195,14 +215,15 @@ msgstr "उन आधिकारिक स्रोतों की सूच�
 
 #: data/org.gnome.software.gschema.xml:95
 msgid ""
-"The licence URL to use when an application should be considered free "
-"software"
-msgstr "किसी एप्लिकेशन को निःशुल्क सॉफ़्टवेयर के रूप में माने जाने पर उपयोग किए जाने के लिए लाइसेंस URL"
+"The licence URL to use when an application should be considered free software"
+msgstr ""
+"किसी एप्लिकेशन को निःशुल्क सॉफ़्टवेयर के रूप में माने जाने पर उपयोग किए जाने के लिए लाइसेंस "
+"URL"
 
 #: data/org.gnome.software.gschema.xml:99
-msgid ""
-"Install bundled applications for all users on the system where possible"
-msgstr "जहाँ भी संभव हो, वहाँ सिस्टम पर सभी उपयोगकर्ताओं के लिए बंडल किए गए ऐप्लिकेशन स्थापित करें"
+msgid "Install bundled applications for all users on the system where possible"
+msgstr ""
+"जहाँ भी संभव हो, वहाँ सिस्टम पर सभी उपयोगकर्ताओं के लिए बंडल किए गए ऐप्लिकेशन स्थापित करें"
 
 #: data/org.gnome.software.gschema.xml:103
 msgid "Show the folder management UI"
@@ -244,7 +265,9 @@ msgstr "शुल्क सहित स्रोतों की सूची �
 msgid ""
 "A list of URLs pointing to appstream files that will be downloaded into an "
 "app-info folder"
-msgstr "ऐपस्ट्रीम फ़ाइलों का संकेत कर रहेे URL की सूची जिसे एक ऐप-इन्फ़ो फ़ोल्डर में डाउनलोड किया जाएगा"
+msgstr ""
+"ऐपस्ट्रीम फ़ाइलों का संकेत कर रहेे URL की सूची जिसे एक ऐप-इन्फ़ो फ़ोल्डर में डाउनलोड किया "
+"जाएगा"
 
 #: data/org.gnome.software.gschema.xml:143
 msgid "Install the AppStream files to a system-wide location for all users"
@@ -268,8 +291,7 @@ msgstr "सॉफ़्टवेयर स्थापना"
 msgid "Install selected software on the system"
 msgstr "सिस्टम पर चयनित सॉफ़्टवेयर स्थापित करें"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 #: src/gnome-software-local-file.desktop.in:10
 msgid "system-software-install"
 msgstr "सिस्टम सॉफ़्टवेयर स्थापना"
@@ -296,14 +318,12 @@ msgstr "पीछे जाएँ"
 msgid "_All"
 msgstr "_सभी"
 
-#. Translators: A label for a button to show only software which is already
-#. installed.
+#. Translators: A label for a button to show only software which is already installed.
 #: src/gnome-software.ui:104
 msgid "_Installed"
 msgstr "_स्थापित किया गया"
 
-#. Translators: A label for a button to show only updates which are available
-#. to install.
+#. Translators: A label for a button to show only updates which are available to install.
 #: src/gnome-software.ui:155
 msgid "_Updates"
 msgstr "_अपडेट"
@@ -351,7 +371,7 @@ msgstr "स्थापित किया गया"
 
 #. TRANSLATORS: this is a button next to the search results that
 #. * shows the status of an application being installed
-#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:443
+#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:439
 msgid "Installing"
 msgstr "स्थापित करना"
 
@@ -366,7 +386,7 @@ msgid "Folder Name"
 msgstr "फ़ोल्डर का नाम"
 
 #: src/gs-app-folder-dialog.c:321 src/gs-app-folder-dialog.ui:16
-#: src/gs-details-page.c:383 src/gs-details-page.ui:342 src/gs-editor.c:623
+#: src/gs-details-page.c:379 src/gs-details-page.ui:342 src/gs-editor.c:623
 #: src/gs-editor.c:655 src/gs-installed-page.c:609 src/gs-removal-dialog.ui:33
 #: src/gs-review-dialog.ui:23 src/gs-upgrade-banner.ui:131
 msgid "_Cancel"
@@ -381,90 +401,91 @@ msgid "Add to Application Folder"
 msgstr "एप्लिकेशन फ़ोल्डर में जोड़ें"
 
 #. TRANSLATORS: this is a command line option
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "Start up mode: either ‘updates’, ‘updated’, ‘installed’ or ‘overview’"
 msgstr "प्रारंभ मोड: या तो ‘अपडेट’, ‘अपडेट किया गया’, ‘स्थापित किया गया’ या ‘ओवरव्यू’"
 
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "MODE"
 msgstr "मोड"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "Search for applications"
 msgstr "एप्लिकेशन खोजें"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "SEARCH"
 msgstr "खोजें"
 
-#: src/gs-application.c:105
+#: src/gs-application.c:133
 msgid "Show application details (using application ID)"
 msgstr "एप्लिकेशन का विवरण दिखाएँ (एप्लिकेशन ID उपयोग करके)"
 
-#: src/gs-application.c:105 src/gs-application.c:109
+#: src/gs-application.c:133 src/gs-application.c:137
 msgid "ID"
 msgstr "ID"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "Show application details (using package name)"
 msgstr "एप्लिकेशन का विवरण दिखाएँ (पैकेज का नाम उपयोग करके)"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "PKGNAME"
 msgstr "पैकेज का नाम"
 
-#: src/gs-application.c:109
+#: src/gs-application.c:137
 msgid "Install the application (using application ID)"
 msgstr "ऐप्लिकेशन स्थापित करें (ऐप्लिकेशन ID का उपयोग करके)"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "Open a local package file"
 msgstr "स्थानीय पैकेज फ़ाइल खोलें"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "FILENAME"
 msgstr "फ़ाइल का नाम"
 
-#: src/gs-application.c:113
+#: src/gs-application.c:141
 msgid ""
 "The kind of interaction expected for this action: either ‘none’, ‘notify’, "
 "or ‘full’"
-msgstr "इस क्रिया के लिए अपेक्षित अंतर्क्रिया का प्रकार: या तो ‘कोई नहीं’, ‘सूचित करें’ या  ‘पूर्ण’"
+msgstr ""
+"इस क्रिया के लिए अपेक्षित अंतर्क्रिया का प्रकार: या तो ‘कोई नहीं’, ‘सूचित करें’ या  ‘पूर्ण’"
 
-#: src/gs-application.c:116
+#: src/gs-application.c:144
 msgid "Show verbose debugging information"
 msgstr "डीबगिंग के लिए विस्तृत मुद्रित जानकारी दिखाएँ"
 
-#: src/gs-application.c:118
+#: src/gs-application.c:146
 msgid "Show profiling information for the service"
 msgstr "सेवा के लिए प्रोफ़ाइलिंग जानकारी दिखाएँ"
 
-#: src/gs-application.c:120
+#: src/gs-application.c:148
 msgid "Quit the running instance"
 msgstr "चल रहे इंस्टैंस से बाहर आएं"
 
-#: src/gs-application.c:122
+#: src/gs-application.c:150
 msgid "Prefer local file sources to AppStream"
 msgstr "AppStream के लिए स्थानीय फ़ाइल स्रोतों को प्राथमिकता दें"
 
-#: src/gs-application.c:124
+#: src/gs-application.c:152
 msgid "Show version number"
 msgstr "संस्करण संख्या दिखाएँ"
 
-#: src/gs-application.c:325
+#: src/gs-application.c:358
 msgid "translator-credits"
 msgstr "अनुवादक-श्रेय"
 
 #. TRANSLATORS: this is the title of the about window, e.g.
 #. * 'About Software' or 'About Application Installer' where the %s is
 #. * the application name chosen by the distro
-#: src/gs-application.c:332
+#: src/gs-application.c:365
 #, c-format
 msgid "About %s"
 msgstr "%s के बारे में"
 
 #. TRANSLATORS: well, we seem to think so, anyway
-#: src/gs-application.c:336
+#: src/gs-application.c:369
 msgid "A nice way to manage the software on your system."
 msgstr "आपके सिस्टम पर सॉफ़्टवेयर को प्रबंधित करने का बेहतर तरीका."
 
@@ -579,7 +600,7 @@ msgid "All"
 msgstr "सभी"
 
 #. TRANSLATORS: this is a subcategory of featured apps
-#: lib/gs-category.c:202 src/gs-shell.c:2180
+#: lib/gs-category.c:202 src/gs-shell.c:2181
 msgid "Featured"
 msgstr "पसंदीदा"
 
@@ -589,9 +610,11 @@ msgstr "विस्तारित सेटिंग"
 
 #: src/gs-category-page.ui:110
 msgid ""
-"Extensions are used at your own risk. If you have any system problems, it is"
-" recommended to disable them."
-msgstr "विस्तारण आपके स्वयं के जोखिम पर उपयोग किए जाते हैं. यदि आपको कोई सिस्टम समस्याएँ हैं, तो उन्हें अक्षम करने का सुझाव दिया जाता है."
+"Extensions are used at your own risk. If you have any system problems, it is "
+"recommended to disable them."
+msgstr ""
+"विस्तारण आपके स्वयं के जोखिम पर उपयोग किए जाते हैं. यदि आपको कोई सिस्टम समस्याएँ हैं, तो "
+"उन्हें अक्षम करने का सुझाव दिया जाता है."
 
 #. TRANSLATORS: the user isn't reading the question
 #: lib/gs-cmd.c:205
@@ -647,13 +670,15 @@ msgstr "तृतीय-पक्ष सॉफ़्टवेयर स्रो
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
 #. * 2. Software source name, e.g. fedora-optional
+#.
 #: src/gs-common.c:232
 #, c-format
 msgid ""
 "%s is not <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
-"source_software\">free and open source software</a>, and is provided by "
-"“%s”."
-msgstr "%s, <a href=\"https://en.wikipedia.org/wiki/Free_and_open-source_software\">मुफ़्त और खुले स्रोत सॉफ़्टवेयर नहीं है</a>, और “%s” द्वारा प्रदान किए जाते हैं."
+"source_software\">free and open source software</a>, and is provided by “%s”."
+msgstr ""
+"%s, <a href=\"https://en.wikipedia.org/wiki/Free_and_open-source_software"
+"\">मुफ़्त और खुले स्रोत सॉफ़्टवेयर नहीं है</a>, और “%s” द्वारा प्रदान किए जाते हैं."
 
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
@@ -943,7 +968,8 @@ msgstr "विशेष ब्रांड या ट्रेडमार्क
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:219
 msgid "Players are encouraged to purchase specific real-world items"
-msgstr "विशिष्ट वास्तविक विश्व के आइटम खरीदने के लिए खिलाड़ियों को प्रोत्साहित किया जाता है"
+msgstr ""
+"विशिष्ट वास्तविक विश्व के आइटम खरीदने के लिए खिलाड़ियों को प्रोत्साहित किया जाता है"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:222
@@ -1035,14 +1061,12 @@ msgstr "अन्य उपयोगकर्ताओं के साथ भ�
 msgid "Sharing physical location to other users"
 msgstr "अन्य उपयोगकर्ताओं के साथ भौतिक स्थान साझा करना"
 
-#. TRANSLATORS: this is a what we use in notifications if the app's name is
-#. unknown
+#. TRANSLATORS: this is a what we use in notifications if the app's name is unknown
 #: src/gs-dbus-helper.c:294
 msgid "An application"
 msgstr "कोई एप्लिकेशन"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. MIME types.
+#. TRANSLATORS: this is a notification displayed when an app needs additional MIME types.
 #: src/gs-dbus-helper.c:300
 #, c-format
 msgid "%s is requesting additional file format support."
@@ -1053,8 +1077,7 @@ msgstr "%s अतिरिक्त फ़ाइल फ़ॉर्मेट स
 msgid "Additional MIME Types Required"
 msgstr "अतिरिक्त MIME प्रकार आवश्यक"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. fonts.
+#. TRANSLATORS: this is a notification displayed when an app needs additional fonts.
 #: src/gs-dbus-helper.c:306
 #, c-format
 msgid "%s is requesting additional fonts."
@@ -1065,8 +1088,7 @@ msgstr "%s अतिरिक्त फ़ॉन्ट का अनुरोध
 msgid "Additional Fonts Required"
 msgstr "अतिरिक्त फ़ॉन्ट आवश्यक"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. codecs.
+#. TRANSLATORS: this is a notification displayed when an app needs additional codecs.
 #: src/gs-dbus-helper.c:312
 #, c-format
 msgid "%s is requesting additional multimedia codecs."
@@ -1077,8 +1099,7 @@ msgstr "%s अतिरिक्त मल्टीमीडिया कोड�
 msgid "Additional Multimedia Codecs Required"
 msgstr "अतिरिक्त मल्टीमीडिया कोडेक्स्स आवश्यक"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. printer drivers.
+#. TRANSLATORS: this is a notification displayed when an app needs additional printer drivers.
 #: src/gs-dbus-helper.c:318
 #, c-format
 msgid "%s is requesting additional printer drivers."
@@ -1089,8 +1110,7 @@ msgstr "%s अतिरिक्त प्रिंटर ड्राइवर 
 msgid "Additional Printer Drivers Required"
 msgstr "अतिरिक्त प्रिंटर ड्राइवर आवश्यक"
 
-#. TRANSLATORS: this is a notification displayed when an app wants to install
-#. additional packages.
+#. TRANSLATORS: this is a notification displayed when an app wants to install additional packages.
 #: src/gs-dbus-helper.c:324
 #, c-format
 msgid "%s is requesting additional packages."
@@ -1110,14 +1130,14 @@ msgstr "सॉफ़्टवेयर में खोजें"
 #. * can be installed
 #. TRANSLATORS: button text in the header when firmware
 #. * can be live-installed
-#: src/gs-details-page.c:281 src/gs-details-page.c:312
-#: src/gs-details-page.ui:206 src/gs-upgrade-banner.ui:146
+#: src/gs-details-page.c:280 src/gs-details-page.c:310
+#: src/gs-details-page.ui:237 src/gs-upgrade-banner.ui:146
 msgid "_Install"
 msgstr "_स्थापित करें"
 
 #. TRANSLATORS: button text in the header when an application
 #. * can be live-updated
-#: src/gs-details-page.c:316
+#: src/gs-details-page.c:314
 msgid "_Update"
 msgstr "_अपडेट करें"
 
@@ -1125,67 +1145,67 @@ msgstr "_अपडेट करें"
 #. * be installed.
 #. * The ellipsis indicates that further steps are required,
 #. * e.g. enabling software sources or the like
-#: src/gs-details-page.c:330
+#: src/gs-details-page.c:326
 msgid "_Install…"
 msgstr "_स्थापित करना…"
 
 #. TRANSLATORS: button text in the header when an application can be erased
-#: src/gs-details-page.c:377 src/gs-details-page.ui:547
+#: src/gs-details-page.c:373 src/gs-details-page.ui:547
 msgid "_Uninstall"
 msgstr "_स्थापना रद्द करें"
 
-#: src/gs-details-page.c:438 src/gs-sources-dialog.c:513
+#: src/gs-details-page.c:434 src/gs-sources-dialog.c:513
 msgid "Removing…"
 msgstr "निकाल रहा है…"
 
 #. TRANSLATORS: this is the warning box
-#: src/gs-details-page.c:748
+#: src/gs-details-page.c:744
 msgid ""
 "This application can only be used when there is an active internet "
 "connection."
 msgstr "इस एप्लिकेशन का उपयोग केवल सक्रिय इंटरनेट कनेक्शन होने पर ही किया जा सकता है."
 
 #. TRANSLATORS: this is where the version is not known
-#: src/gs-details-page.c:892
+#: src/gs-details-page.c:888
 msgctxt "version"
 msgid "Unknown"
 msgstr "अज्ञात"
 
 #. TRANSLATORS: this is where we don't know the origin of the
 #. * application
-#: src/gs-details-page.c:971
+#: src/gs-details-page.c:967
 msgctxt "origin"
 msgid "Unknown"
 msgstr "अज्ञात"
 
 #. TRANSLATORS: we need a remote server to process
-#: src/gs-details-page.c:1378
+#: src/gs-details-page.c:1374
 msgid "You need internet access to write a review"
 msgstr "समीक्षा लिखने के लिए आपको इंटरनेट पहुँच की आवश्यकता है"
 
-#: src/gs-details-page.c:1507
+#: src/gs-details-page.c:1503
 #, c-format
 msgid "Unable to find “%s”"
 msgstr "“%s” को ढूँढ़ने में असमर्थ"
 
 #. TRANSLATORS: see the wikipedia page
-#: src/gs-details-page.c:2087
+#: src/gs-details-page.c:2083
 msgid "Public domain"
 msgstr "सार्वजनिक डोमेन"
 
 #. TRANSLATORS: see GNU page
-#: src/gs-details-page.c:2103 src/gs-details-page.ui:1397
+#: src/gs-details-page.c:2099 src/gs-details-page.ui:1397
 msgid "Free Software"
 msgstr "निशुल्क सॉफ़्टवेयर"
 
 #. TRANSLATORS: for the free software popover
-#: src/gs-details-page.c:2160
+#: src/gs-details-page.c:2156
 msgid "Users are bound by the following license:"
 msgid_plural "Users are bound by the following licenses:"
 msgstr[0] "उपयोगकर्ता निम्न लाइसेंस द्वारा बँधे हुए हैं:"
 msgstr[1] "उपयोगकर्ता निम्न लाइसेंसों द्वारा बँधे हुए हैं:"
 
-#: src/gs-details-page.c:2176 src/gs-details-page.ui:1506
+#: src/gs-details-page.c:2172 src/gs-details-page.ui:1506
 msgid "More information"
 msgstr "अधिक जानकारी"
 
@@ -1193,15 +1213,13 @@ msgstr "अधिक जानकारी"
 msgid "Details page"
 msgstr "विवरण पृष्ठ"
 
-#. Translators: A label for a button to add a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:228
+#. Translators: A label for a button to add a shortcut to the selected application.
+#: src/gs-details-page.ui:209
 msgid "_Add to Desktop"
 msgstr "_डेस्कटॉप पर जोड़ें"
 
-#. Translators: A label for a button to remove a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:245
+#. Translators: A label for a button to remove a shortcut to the selected application.
+#: src/gs-details-page.ui:226
 msgid "_Remove from Desktop"
 msgstr "_डेस्कटॉप से निकालें"
 
@@ -1222,7 +1240,9 @@ msgstr "सॉफ़्टवेयर स्रोत शामिल"
 msgid ""
 "This application includes a software source which provides updates, as well "
 "as access to other software."
-msgstr "इस एप्लिकेशन में वह सॉफ़्टवेयर स्रोत शामिल है जो अपडेट के साथ ही अन्य सॉफ़्टवेयर पर पहुँच प्रदान करता है."
+msgstr ""
+"इस एप्लिकेशन में वह सॉफ़्टवेयर स्रोत शामिल है जो अपडेट के साथ ही अन्य सॉफ़्टवेयर पर पहुँच "
+"प्रदान करता है."
 
 #: src/gs-details-page.ui:500
 msgid "No Software Source Included"
@@ -1232,16 +1252,19 @@ msgstr "कोई सॉफ़्टवेयर स्रोत शामिल
 msgid ""
 "This application does not include a software source. It will not be updated "
 "with new versions."
-msgstr "इस एप्लिकेशन में सॉफ़्टवेयर स्रोत शामिल नहीं है. इसे नए संस्करणों के साथ अपडेट नहीं किया जाएगा."
+msgstr ""
+"इस एप्लिकेशन में सॉफ़्टवेयर स्रोत शामिल नहीं है. इसे नए संस्करणों के साथ अपडेट नहीं किया "
+"जाएगा."
 
 #: src/gs-details-page.ui:515
 msgid ""
 "This software is already provided by your distribution and should not be "
 "replaced."
-msgstr "यह सॉफ़्टवेयर आपके वितरण द्वारा पहले से प्रदान किया गया है और इसे प्रतिस्थापित नहीं किया जाना चाहिए."
+msgstr ""
+"यह सॉफ़्टवेयर आपके वितरण द्वारा पहले से प्रदान किया गया है और इसे प्रतिस्थापित नहीं किया "
+"जाना चाहिए."
 
-#. Translators: a repository file used for installing software has been
-#. discovered.
+#. Translators: a repository file used for installing software has been discovered.
 #: src/gs-details-page.ui:528
 msgid "Software Source Identified"
 msgstr "सॉफ़्टवेयर स्रोत की पहचान की गई"
@@ -1342,14 +1365,12 @@ msgstr "एड-ऑन"
 msgid "Selected add-ons will be installed with the application."
 msgstr "चुने गए एड-ऑन एप्लिकेशन के साथ स्थापित किए जाएँगे."
 
-#. Translators: Header of the section with other users' opinions about the
-#. app.
+#. Translators: Header of the section with other users' opinions about the app.
 #: src/gs-details-page.ui:1233
 msgid "Reviews"
 msgstr "समीक्षाएँ"
 
-#. Translators: Button opening a dialog where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Button opening a dialog where the users can write and publish their opinions about the apps.
 #: src/gs-details-page.ui:1249
 msgid "_Write a Review"
 msgstr "_समीक्षा लिखें"
@@ -1361,9 +1382,11 @@ msgstr "_अधिक दिखाएँ"
 
 #: src/gs-details-page.ui:1414
 msgid ""
-"This means that the software can be freely run, copied, distributed, studied"
-" and modified."
-msgstr "इसका अर्थ है कि सॉफ़्टवेयर को बिना रोक-टोक चलाया जा सकता है, इसकी प्रतिलिपि बनाई जा सकती है, वितरित किया जा सकता है, पढ़ा और संशोधित किया जा सकता है."
+"This means that the software can be freely run, copied, distributed, studied "
+"and modified."
+msgstr ""
+"इसका अर्थ है कि सॉफ़्टवेयर को बिना रोक-टोक चलाया जा सकता है, इसकी प्रतिलिपि बनाई जा "
+"सकती है, वितरित किया जा सकता है, पढ़ा और संशोधित किया जा सकता है."
 
 #: src/gs-details-page.ui:1473
 msgid "Proprietary Software"
@@ -1374,7 +1397,9 @@ msgid ""
 "This means that the software is owned by an individual or a company. There "
 "are often restrictions on its use and its source code cannot usually be "
 "accessed."
-msgstr "इसका अर्थ है कि सॉफ़्टवेयर का स्वामित्व किसी व्यक्ति या कंपनी के पास है. इसके उपयोग के संबंध में प्रायः प्रतिबंध होता है और आमतौर पर इसके स्रोत कोड तक पहुँचा नहीं जा सकता."
+msgstr ""
+"इसका अर्थ है कि सॉफ़्टवेयर का स्वामित्व किसी व्यक्ति या कंपनी के पास है. इसके उपयोग के संबंध "
+"में प्रायः प्रतिबंध होता है और आमतौर पर इसके स्रोत कोड तक पहुँचा नहीं जा सकता."
 
 #: src/gs-details-page.ui:1535
 msgid "Unknown Software License"
@@ -1458,8 +1483,7 @@ msgstr "ऐप्लिकेशन सूची में सहेजे न�
 msgid "Use verbose logging"
 msgstr "शब्द बहुल लॉगिंग का उपयोग करें"
 
-#. TRANSLATORS: program name, an application to add and remove software
-#. repositories
+#. TRANSLATORS: program name, an application to add and remove software repositories
 #: src/gs-editor.c:1119
 msgid "GNOME Software Banner Designer"
 msgstr "GNOME सॉफ्टवेयर बैनर डिज़ाइनर"
@@ -1488,8 +1512,7 @@ msgstr "सारांश"
 msgid "Editor’s Pick"
 msgstr "संपादक का चुनिंदा"
 
-#. This check button controls whether the application’s banner appears in the
-#. “Featured” category
+#. This check button controls whether the application’s banner appears in the “Featured” category
 #: src/gs-editor.ui:397
 msgid "Category Featured"
 msgstr "फ़ीचर की गई श्रेणी"
@@ -1578,9 +1601,11 @@ msgstr "%s फ़ाइल को प्रदान करने वाले �
 #: src/gs-extras-page.c:337 src/gs-extras-page.c:348 src/gs-extras-page.c:359
 #, c-format
 msgid ""
-"Information about %s, as well as options for how to get missing applications"
-" might be found %s."
-msgstr "%s के बारे में जानकारी, के साथ ही अनुपलब्ध एप्लिकेशन को प्राप्त करने के तरीके %s को ढूँढ सकते हैं."
+"Information about %s, as well as options for how to get missing applications "
+"might be found %s."
+msgstr ""
+"%s के बारे में जानकारी, के साथ ही अनुपलब्ध एप्लिकेशन को प्राप्त करने के तरीके %s को ढूँढ सकते "
+"हैं."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1603,7 +1628,9 @@ msgstr "%s उपलब्ध नहीं है."
 msgid ""
 "Information about %s, as well as options for how to get an application that "
 "can support this format might be found %s."
-msgstr "%s के बारे में जानकारी, के साथ ही इस फ़ॉर्मेट का समर्थन कर सकने वाले एप्लिकेशन को प्राप्त करने के तरीके %s को ढूँढ सकते हैं."
+msgstr ""
+"%s के बारे में जानकारी, के साथ ही इस फ़ॉर्मेट का समर्थन कर सकने वाले एप्लिकेशन को प्राप्त "
+"करने के तरीके %s को ढूँढ सकते हैं."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1619,11 +1646,12 @@ msgstr "%s स्क्रिप्ट समर्थन के लिए क�
 msgid ""
 "Information about %s, as well as options for how to get additional fonts "
 "might be found %s."
-msgstr "%s के बारे में जानकारी, के साथ ही अतिरिक्त फ़ॉन्ट को प्राप्त करने के तरीके %s को ढूँढ सकते हैं."
+msgstr ""
+"%s के बारे में जानकारी, के साथ ही अतिरिक्त फ़ॉन्ट को प्राप्त करने के तरीके %s को ढूँढ सकते हैं."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
-#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1426
+#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1430
 #, c-format
 msgid "No addon codecs are available for the %s format."
 msgstr "%s फ़ॉर्मेट के लिए कोई एडऑन कोडेक उपलब्ध नहीं है."
@@ -1635,7 +1663,9 @@ msgstr "%s फ़ॉर्मेट के लिए कोई एडऑन क�
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format might be found %s."
-msgstr "%s के बारे में जानकारी, के साथ ही इस फ़ॉर्मेट को चलाने वाले कोडेक को प्राप्त करने के तरीके %s को ढूँढ सकते हैं."
+msgstr ""
+"%s के बारे में जानकारी, के साथ ही इस फ़ॉर्मेट को चलाने वाले कोडेक को प्राप्त करने के तरीके "
+"%s को ढूँढ सकते हैं."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1651,7 +1681,9 @@ msgstr "%s समर्थन के लिए कोई प्लाज़्�
 msgid ""
 "Information about %s, as well as options for how to get additional Plasma "
 "resources might be found %s."
-msgstr "%s के बारे में जानकारी, के साथ ही अतिरिक्त प्लाज़्मा स्रोत को प्राप्त करने के तरीके %s को ढूँढ सकते हैं."
+msgstr ""
+"%s के बारे में जानकारी, के साथ ही अतिरिक्त प्लाज़्मा स्रोत को प्राप्त करने के तरीके %s को "
+"ढूँढ सकते हैं."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1667,15 +1699,16 @@ msgstr "%s के लिए कोई प्रिंटर ड्राइव�
 msgid ""
 "Information about %s, as well as options for how to get a driver that "
 "supports this printer might be found %s."
-msgstr "%s के बारे में जानकारी, के साथ ही इस प्रिंटर का समर्थन करने वाले ड्राइवर को प्राप्त करने के तरीके %s के लिए विकल्पों को ढूँढ सकते हैं."
+msgstr ""
+"%s के बारे में जानकारी, के साथ ही इस प्रिंटर का समर्थन करने वाले ड्राइवर को प्राप्त करने के "
+"तरीके %s के लिए विकल्पों को ढूँढ सकते हैं."
 
 #. TRANSLATORS: hyperlink title
 #: src/gs-extras-page.c:459
 msgid "this website"
 msgstr "यह वेबसाइट"
 
-#. TRANSLATORS: no codecs were found. First %s will be replaced by actual
-#. codec name(s), second %s is a link titled "this website"
+#. TRANSLATORS: no codecs were found. First %s will be replaced by actual codec name(s), second %s is a link titled "this website"
 #: src/gs-extras-page.c:463
 #, c-format
 msgid ""
@@ -1684,8 +1717,12 @@ msgid ""
 msgid_plural ""
 "Unfortunately, the %s you were searching for could not be found. Please see "
 "%s for more information."
-msgstr[0] "दुर्भाग्यवश, जिस %s को आप खोज रहे थे, वह नहीं मिल सका. कृपया अधिक जानकारी के लिए %s देखें."
-msgstr[1] "दुर्भाग्यवश, जिस %s को आप खोज रहे थे, वह नहीं मिल सका. कृपया अधिक जानकारी के लिए %s देखें."
+msgstr[0] ""
+"दुर्भाग्यवश, जिस %s को आप खोज रहे थे, वह नहीं मिल सका. कृपया अधिक जानकारी के लिए %s "
+"देखें."
+msgstr[1] ""
+"दुर्भाग्यवश, जिस %s को आप खोज रहे थे, वह नहीं मिल सका. कृपया अधिक जानकारी के लिए %s "
+"देखें."
 
 #: src/gs-extras-page.c:535 src/gs-extras-page.c:591 src/gs-extras-page.c:630
 msgid "Failed to find any search results"
@@ -1710,10 +1747,12 @@ msgstr "सॉफ़्टवेयर में स्वागत है"
 
 #: src/gs-first-run-dialog.ui:66
 msgid ""
-"Software lets you install all the software you need, all from one place. See"
-" our recommendations, browse the categories, or search for the applications "
+"Software lets you install all the software you need, all from one place. See "
+"our recommendations, browse the categories, or search for the applications "
 "you want."
-msgstr "सॉफ़्टवेयर आपको एक ही स्थान से वे सभी सॉफ़्टवेयर स्थापित करने देता है जिसकी आपको आवश्यकता होती है. हमारी अनुशंसाएँ देखें, श्रेणियों को ब्राउज़ करें या जो आप चाहते हैं वह एप्लिकेशन खोजें."
+msgstr ""
+"सॉफ़्टवेयर आपको एक ही स्थान से वे सभी सॉफ़्टवेयर स्थापित करने देता है जिसकी आपको आवश्यकता "
+"होती है. हमारी अनुशंसाएँ देखें, श्रेणियों को ब्राउज़ करें या जो आप चाहते हैं वह एप्लिकेशन खोजें."
 
 #: src/gs-first-run-dialog.ui:85
 msgid "_Let’s Go Shopping"
@@ -1867,9 +1906,9 @@ msgstr "वेब ब्राउज़र और गेम सहित अत�
 
 #. TRANSLATORS: this is the proprietary info bar
 #: src/gs-overview-page.c:978
-msgid ""
-"Proprietary software has restrictions on use and access to source code."
-msgstr "स्वामित्व संबंंधी सॉफ़्टवेयर का उपयोग करने और स्रोत कोड की पहुँच प्राप्त करने पर प्रतिबंध है."
+msgid "Proprietary software has restrictions on use and access to source code."
+msgstr ""
+"स्वामित्व संबंंधी सॉफ़्टवेयर का उपयोग करने और स्रोत कोड की पहुँच प्राप्त करने पर प्रतिबंध है."
 
 #. TRANSLATORS: this is the clickable
 #. * link on the proprietary info bar
@@ -1898,14 +1937,12 @@ msgstr "फ़ीचर किए गए ऐप्लिकेशन"
 msgid "Categories"
 msgstr "श्रेणियाँ"
 
-#. Translators: This is a heading for software which has been featured
-#. ('picked') by the distribution.
+#. Translators: This is a heading for software which has been featured ('picked') by the distribution.
 #: src/gs-overview-page.ui:315
 msgid "Editor’s Picks"
 msgstr "संपादक की पसंद"
 
-#. Translators: This is a heading for software which has been recently
-#. released upstream.
+#. Translators: This is a heading for software which has been recently released upstream.
 #: src/gs-overview-page.ui:359
 msgid "Recent Releases"
 msgstr "हाल ही के रिलीज़"
@@ -1952,7 +1989,9 @@ msgstr "क्या आप वाकई %s सोर्स को निका�
 msgid ""
 "All applications from %s will be removed, and you will have to re-install "
 "the source to use them again."
-msgstr "%s से सभी ऐप्लिकेशन निकाल दिए जाएँगे और आपको फिर से उनका उपयोग करने के लिए सोर्स को पुनः स्थापित करना होगा."
+msgstr ""
+"%s से सभी ऐप्लिकेशन निकाल दिए जाएँगे और आपको फिर से उनका उपयोग करने के लिए सोर्स को "
+"पुनः स्थापित करना होगा."
 
 #. TRANSLATORS: this is a prompt message, and '%s' is an
 #. * application summary, e.g. 'GNOME Clocks'
@@ -1965,14 +2004,17 @@ msgstr "क्या आप %s को वाकई निकालना चा�
 #: src/gs-page.c:684
 #, c-format
 msgid "%s will be removed, and you will have to install it to use it again."
-msgstr "%s को निकाल दिया जाएगा और इसे पुनः उपयोग करने के लिए आपको इसे स्थापित करना होगा."
+msgstr ""
+"%s को निकाल दिया जाएगा और इसे पुनः उपयोग करने के लिए आपको इसे स्थापित करना होगा."
 
-#: lib/gs-plugin-loader.c:1429
+#: lib/gs-plugin-loader.c:1433
 #, c-format
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format can be found on the website."
-msgstr "%s के बारे में जानकारी, साथ ही इस फ़ॉर्मेट को चला सकने वाले कोडेक को प्राप्त करने के विकल्प जिन्हें इस वेबसाइट पर ढूँढा जा सकता हो."
+msgstr ""
+"%s के बारे में जानकारी, साथ ही इस फ़ॉर्मेट को चला सकने वाले कोडेक को प्राप्त करने के विकल्प "
+"जिन्हें इस वेबसाइट पर ढूँढा जा सकता हो."
 
 #: lib/gs-price.c:111
 #, c-format
@@ -2031,7 +2073,9 @@ msgstr "%s %f"
 msgid ""
 "Some of the currently installed software is not compatible with %s. If you "
 "continue, the following will be automatically removed during the upgrade:"
-msgstr "हाल ही में स्थापित किए गए सॉफ़्टवेयर में से कुछ %s के साथ संगत नहीं हैं. अगर आप जारी रखते हैं, तो नवीनीकरण के दौरान निम्न को स्वचालित रूप से निकाल दिया जाएगा:"
+msgstr ""
+"हाल ही में स्थापित किए गए सॉफ़्टवेयर में से कुछ %s के साथ संगत नहीं हैं. अगर आप जारी रखते हैं, "
+"तो नवीनीकरण के दौरान निम्न को स्वचालित रूप से निकाल दिया जाएगा:"
 
 #: src/gs-removal-dialog.ui:27
 msgid "Incompatible Software"
@@ -2101,8 +2145,7 @@ msgstr "विवरण बहुत छोटा है"
 msgid "The description is too long"
 msgstr "विवरण बहुत बड़ा है"
 
-#. Translators: Title of the dialog box where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Title of the dialog box where the users can write and publish their opinions about the apps.
 #: src/gs-review-dialog.ui:11
 msgid "Post Review"
 msgstr "समीक्षा पोस्ट करें"
@@ -2140,14 +2183,17 @@ msgstr "कुल रेटिंग"
 #. TRANSLATORS: we explain what the action is going to do
 #: src/gs-review-row.c:234
 msgid "You can report reviews for abusive, rude, or discriminatory behavior."
-msgstr "आप अपमानजनक, असभ्य या भेदभावपूर्ण व्यवहार के लिए समीक्षाओं की रिपोर्ट कर सकते हैं. "
+msgstr ""
+"आप अपमानजनक, असभ्य या भेदभावपूर्ण व्यवहार के लिए समीक्षाओं की रिपोर्ट कर सकते हैं. "
 
 #. TRANSLATORS: we ask the user if they really want to do this
 #: src/gs-review-row.c:239
 msgid ""
 "Once reported, a review will be hidden until it has been checked by an "
 "administrator."
-msgstr "रिपोर्ट किए जाने के बाद, व्यवस्थापक द्वारा जाँच किए जाने तक समीक्षा को छिपा दिया जाएगा."
+msgstr ""
+"रिपोर्ट किए जाने के बाद, व्यवस्थापक द्वारा जाँच किए जाने तक समीक्षा को छिपा दिया "
+"जाएगा."
 
 #. TRANSLATORS: window title when
 #. * reporting a user-submitted review
@@ -2162,8 +2208,7 @@ msgstr "समीक्षा की रिपोर्ट करना है?"
 msgid "Report"
 msgstr "रिपोर्ट"
 
-#. Translators: Users can express their opinions about other users' opinions
-#. about the apps.
+#. Translators: Users can express their opinions about other users' opinions about the apps.
 #: src/gs-review-row.ui:112
 msgid "Was this review useful to you?"
 msgstr "क्या यह समीक्षा आपके लिए उपयोगी थी?"
@@ -2252,81 +2297,80 @@ msgstr "कोई एप्लिकेशन नहीं मिला"
 #. TRANSLATORS: this is part of the in-app notification,
 #. * where the %s is a multi-word localised app name
 #. * e.g. 'Getting things GNOME!"
-#: src/gs-shell.c:846 src/gs-shell.c:851 src/gs-shell.c:866 src/gs-shell.c:870
+#: src/gs-shell.c:847 src/gs-shell.c:852 src/gs-shell.c:867 src/gs-shell.c:871
 #, c-format
 msgid "“%s”"
 msgstr "“%s”"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:898
+#: src/gs-shell.c:899
 #, c-format
 msgid "Unable to download firmware updates from %s"
 msgstr "%s से फ़र्मवेयर अपडेट डाउनलोड करने में असमर्थ"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:904
+#: src/gs-shell.c:905
 #, c-format
 msgid "Unable to download updates from %s"
 msgstr "%s से अपडेट डाउनलोड करने में असमर्थ"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:911
+#: src/gs-shell.c:912
 msgid "Unable to download updates"
 msgstr "अपडेट डाउनलोड करने में असमर्थ"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:916
+#: src/gs-shell.c:917
 msgid ""
-"Unable to download updates: internet access was required but wasn’t "
-"available"
+"Unable to download updates: internet access was required but wasn’t available"
 msgstr "अपडेट डाउनलोड करने में असमर्थ: इंटरनेट पहुँच की आवश्यकता थी लेकिन वह उपलब्ध नहीं थी"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:925
+#: src/gs-shell.c:926
 #, c-format
 msgid "Unable to download updates from %s: not enough disk space"
 msgstr "%s से अपडेट डाउनलोड करने में असमर्थ: पर्याप्त डिस्क स्थान नहीं"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:930
+#: src/gs-shell.c:931
 msgid "Unable to download updates: not enough disk space"
 msgstr "अपडेट डाउनलोड करने में असमर्थ: पर्याप्त डिस्क स्थान नहीं"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:938
+#: src/gs-shell.c:939
 msgid "Unable to download updates: authentication was required"
 msgstr "अपडेट डाउनलोड करने में असमर्थ: प्रमाणीकरण आवश्यक था"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:943
+#: src/gs-shell.c:944
 msgid "Unable to download updates: authentication was invalid"
 msgstr "अपडेट डाउनलोड करने में असमर्थ: प्रमाणीकरण अमान्य था"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:948
+#: src/gs-shell.c:949
 msgid ""
 "Unable to download updates: you do not have permission to install software"
 msgstr "अपडेट डाउनलोड करने में असमर्थ: आपके पास सॉफ़्टवेयर को स्थापित करने की अनुमति नहीं है"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:955
+#: src/gs-shell.c:956
 msgid "Unable to get list of updates"
 msgstr "अपडेट की सूची प्राप्त करने में असमर्थ"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the application name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1001
+#: src/gs-shell.c:1002
 #, c-format
 msgid "Unable to install %s as download failed from %s"
 msgstr "%s से डाउनलोड विफल होने के कारण %s स्थापित करने में असमर्थ"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1007
+#: src/gs-shell.c:1008
 #, c-format
 msgid "Unable to install %s as download failed"
 msgstr "डाउनलोड विफल होने के कारण %s स्थापित करने में असमर्थ"
@@ -2335,51 +2379,51 @@ msgstr "डाउनलोड विफल होने के कारण %s �
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1019
+#: src/gs-shell.c:1020
 #, c-format
 msgid "Unable to install %s as runtime %s not available"
 msgstr "%s रनटाइम उपलब्ध नहीं होने के कारण %s स्थापित करने में असमर्थ"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1025
+#: src/gs-shell.c:1026
 #, c-format
 msgid "Unable to install %s as not supported"
 msgstr "समर्थित नहीं होने के कारण %s स्थापित करने में असमर्थ"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1032
+#: src/gs-shell.c:1033
 msgid "Unable to install: internet access was required but wasn’t available"
 msgstr "स्थापित करने में असमर्थ: इंटरनेट पहुँच की आवश्यकता थी लेकिन वह उपलब्ध नहीं थी"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1038
+#: src/gs-shell.c:1039
 msgid "Unable to install: the application has an invalid format"
 msgstr "स्थापित करने में असमर्थ: ऐप्लिकेशन का स्वरूप अमान्य था"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1043
+#: src/gs-shell.c:1044
 #, c-format
 msgid "Unable to install %s: not enough disk space"
 msgstr "%s स्थापित करने में असमर्थ: पर्याप्त डिस्क स्थान नहीं"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1051
+#: src/gs-shell.c:1052
 #, c-format
 msgid "Unable to install %s: authentication was required"
 msgstr "%s स्थापित करने में असमर्थ: प्रमाणीकरण आवश्यक था"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1058
+#: src/gs-shell.c:1059
 #, c-format
 msgid "Unable to install %s: authentication was invalid"
 msgstr "%s स्थापित करने में असमर्थ: प्रमाणीकरण अमान्य था"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1065
+#: src/gs-shell.c:1066
 #, c-format
 msgid "Unable to install %s: you do not have permission to install software"
 msgstr "%s स्थापित करने में असमर्थ: आपके पास सॉफ़्टवेयर को स्थापित करने की अनुमति नहीं है"
@@ -2387,34 +2431,34 @@ msgstr "%s स्थापित करने में असमर्थ: आ�
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the name of the authentication service,
 #. * e.g. "Ubuntu One"
-#: src/gs-shell.c:1078
+#: src/gs-shell.c:1079
 #, c-format
 msgid "Your %s account has been suspended."
 msgstr "आपका %s खाता निलंबित कर दिया गया है."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1082
+#: src/gs-shell.c:1083
 msgid "It is not possible to install software until this has been resolved."
 msgstr "जब तक इसका समाधान नहीं हो जाता तब तक सॉफ़्टवेयर को स्थापित करना संभव नहीं है."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the clickable link (e.g.
 #. * "http://example.com/what-did-i-do-wrong/")
-#: src/gs-shell.c:1093
+#: src/gs-shell.c:1094
 #, c-format
 msgid "For more information, visit %s."
 msgstr "अधिक जानकारी के लिए, %s पर जाएँ."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1102
+#: src/gs-shell.c:1103
 #, c-format
 msgid "Unable to install %s: AC power is required"
 msgstr "%s स्थापित करने में असमर्थ: AC बिजली आवश्यक है"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1111
+#: src/gs-shell.c:1112
 #, c-format
 msgid "Unable to install %s"
 msgstr "%s को स्थापित करने में असमर्थ"
@@ -2423,61 +2467,61 @@ msgstr "%s को स्थापित करने में असमर्�
 #. * where the first %s is the app name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1157
+#: src/gs-shell.c:1158
 #, c-format
 msgid "Unable to update %s from %s"
 msgstr "%s से %s को अपडेट करने में असमर्थ"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1163
+#: src/gs-shell.c:1164
 #, c-format
 msgid "Unable to update %s as download failed"
 msgstr "डाउनलोड विफल होने के कारण %s को अपडेट करने में असमर्थ"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1169
+#: src/gs-shell.c:1170
 msgid "Unable to update: internet access was required but wasn’t available"
 msgstr "अपडेट करने में असमर्थ: इंटरनेट पहुँच की आवश्यकता थी लेकिन वह उपलब्ध नहीं थी"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1177
+#: src/gs-shell.c:1178
 #, c-format
 msgid "Unable to update %s: not enough disk space"
 msgstr "%s को अपडेट करने में असमर्थ: पर्याप्त डिस्क स्थान नहीं"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1186
+#: src/gs-shell.c:1187
 #, c-format
 msgid "Unable to update %s: authentication was required"
 msgstr "%s को अपडेट करने में असमर्थ: प्रमाणीकरण आवश्यक था"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1193
+#: src/gs-shell.c:1194
 #, c-format
 msgid "Unable to update %s: authentication was invalid"
 msgstr "%s को अपडेट करने में असमर्थ: प्रमाणीकरण अमान्य था"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1200
+#: src/gs-shell.c:1201
 #, c-format
 msgid "Unable to update %s: you do not have permission to update software"
 msgstr "%s को अपडेट करने में असमर्थ: आपके पास सॉफ़्टवेयर को अपडेट करने की अनुमति नहीं है"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1208
+#: src/gs-shell.c:1209
 #, c-format
 msgid "Unable to update %s: AC power is required"
 msgstr "%s अपडेट करने में असमर्थ: AC बिजली आवश्यक है"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1217
+#: src/gs-shell.c:1218
 #, c-format
 msgid "Unable to update %s"
 msgstr "%s को अपडेट करने में असमर्थ"
@@ -2485,96 +2529,96 @@ msgstr "%s को अपडेट करने में असमर्थ"
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the distro name (e.g. "Fedora 25") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1262
+#: src/gs-shell.c:1263
 #, c-format
 msgid "Unable to upgrade to %s from %s"
 msgstr "%s से %s पर नवीनीकृत करने में असमर्थ"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the app name (e.g. "GIMP")
-#: src/gs-shell.c:1267
+#: src/gs-shell.c:1268
 #, c-format
 msgid "Unable to upgrade to %s as download failed"
 msgstr "डाउनलोड विफल होने के कारण %s में नवीनीकृत करने में असमर्थ"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1274
+#: src/gs-shell.c:1275
 msgid "Unable to upgrade: internet access was required but wasn’t available"
 msgstr "नवीनीकृत करने में असमर्थ: इंटरनेट पहुँच की आवश्यकता थी लेकिन वह उपलब्ध नहीं था"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1282
+#: src/gs-shell.c:1283
 #, c-format
 msgid "Unable to upgrade to %s: not enough disk space"
 msgstr "%s में नवीनीकृत करने में असमर्थ: पर्याप्त डिस्क स्थान नहीं"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1291
+#: src/gs-shell.c:1292
 #, c-format
 msgid "Unable to upgrade to %s: authentication was required"
 msgstr "%s में नवीनीकृत करने में असमर्थ: प्रमाणीकरण आवश्यक था"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1298
+#: src/gs-shell.c:1299
 #, c-format
 msgid "Unable to upgrade to %s: authentication was invalid"
 msgstr "%s में नवीनीकृत करने में असमर्थ: प्रमाणीकरण अमान्य था"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1305
+#: src/gs-shell.c:1306
 #, c-format
 msgid "Unable to upgrade to %s: you do not have permission to upgrade"
 msgstr "%s में नवीनीकृत करने में असमर्थ: आपके पास नवीनीकरण की अनुमति नहीं है"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1312
+#: src/gs-shell.c:1313
 #, c-format
 msgid "Unable to upgrade to %s: AC power is required"
 msgstr "%s पर अपग्रेड करने में असमर्थ: AC बिजली आवश्यक है"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1321
+#: src/gs-shell.c:1322
 #, c-format
 msgid "Unable to upgrade to %s"
 msgstr "%s में नवीनीकृत करने में असमर्थ"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1363
+#: src/gs-shell.c:1364
 #, c-format
 msgid "Unable to remove %s: authentication was required"
 msgstr "%s को निकालने में असमर्थ: प्रमाणीकरण आवश्यक था"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1369
+#: src/gs-shell.c:1370
 #, c-format
 msgid "Unable to remove %s: authentication was invalid"
 msgstr "%s को निकालने में असमर्थ: प्रमाणीकरण अमान्य था"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1375
+#: src/gs-shell.c:1376
 #, c-format
 msgid "Unable to remove %s: you do not have permission to remove software"
 msgstr "%s को निकालने में असमर्थ: आपके पास सॉफ़्टवेयर को निकालने की अनुमति नहीं है"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1382
+#: src/gs-shell.c:1383
 #, c-format
 msgid "Unable to remove %s: AC power is required"
 msgstr "%s हटाने में असमर्थ: सॉफ्टवेयर"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1391
+#: src/gs-shell.c:1392
 #, c-format
 msgid "Unable to remove %s"
 msgstr "%s को निकालने में असमर्थ"
@@ -2583,48 +2627,48 @@ msgstr "%s को निकालने में असमर्थ"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1437
+#: src/gs-shell.c:1438
 #, c-format
 msgid "Unable to launch %s: %s is not installed"
 msgstr "%s को लॉन्च करने में असमर्थ: %s स्थापित नहीं है"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1444 src/gs-shell.c:1492 src/gs-shell.c:1540
+#: src/gs-shell.c:1445 src/gs-shell.c:1493 src/gs-shell.c:1541
 msgid "Not enough disk space — free up some space and try again"
 msgstr "पर्याप्त डिस्क स्थान नहीं — कृपया कुछ स्थान रिक्त करें और पुनः प्रयास करें"
 
 #. TRANSLATORS: we failed to get a proper error code
-#: src/gs-shell.c:1452 src/gs-shell.c:1500 src/gs-shell.c:1567
+#: src/gs-shell.c:1453 src/gs-shell.c:1501 src/gs-shell.c:1568
 msgid "Sorry, something went wrong"
 msgstr "क्षमा करें, कुछ गलत हुआ"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1487
+#: src/gs-shell.c:1488
 msgid "Failed to install file: authentication failed"
 msgstr "फ़ाइल स्थापित करने में विफल: प्रमाणीकरण विफल रहा"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1534
+#: src/gs-shell.c:1535
 #, c-format
 msgid "Unable to contact %s"
 msgstr "%s से संपर्क करने में असमर्थ"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1549
+#: src/gs-shell.c:1550
 #, c-format
 msgid "%s needs to be restarted to use new plugins."
 msgstr "नए प्लग-इन्स का उपयोग करने के लिए %s को पुनरारंभ किए जाने की आवश्यकता है."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1554
+#: src/gs-shell.c:1555
 msgid "This application needs to be restarted to use new plugins."
 msgstr "नए प्लग-इन्स का उपयोग करने के लिए एप्लिकेशन को पुनरारंभ करने की आवश्यकता है."
 
 #. TRANSLATORS: need to be connected to the AC power
-#: src/gs-shell.c:1561
+#: src/gs-shell.c:1562
 msgid "AC power is required"
 msgstr "AC बिजली आवश्यक है"
 
@@ -2686,7 +2730,8 @@ msgstr[1] "%s और %s स्थापित"
 #. TRANSLATORS: nonfree software
 #: src/gs-sources-dialog.c:257
 msgid "Typically has restrictions on use and access to source code."
-msgstr "आमतौर पर सोर्स कोड का उपयोग करने और उस तक पहुँच प्राप्त करने पर प्रतिबंध होता है."
+msgstr ""
+"आमतौर पर सोर्स कोड का उपयोग करने और उस तक पहुँच प्राप्त करने पर प्रतिबंध होता है."
 
 #. TRANSLATORS: list header
 #: src/gs-sources-dialog.c:278
@@ -2711,7 +2756,9 @@ msgstr "ऑपरेटिंग सिस्टम"
 msgid ""
 "Software sources can be downloaded from the internet. They give you access "
 "to additional software that is not provided by %s."
-msgstr "सॉफ़्टवेयर स्रोत इंटरनेट से डाउनलोड किए जा सकते हैं. वे आपको अतिरिक्त सॉफ़्टवेयर पर पहुँच देते हैं जो %s द्वारा प्रदान नहीं किए जाते हैं."
+msgstr ""
+"सॉफ़्टवेयर स्रोत इंटरनेट से डाउनलोड किए जा सकते हैं. वे आपको अतिरिक्त सॉफ़्टवेयर पर पहुँच देते "
+"हैं जो %s द्वारा प्रदान नहीं किए जाते हैं."
 
 #: src/gs-sources-dialog.ui:155
 msgid "Additional Sources"
@@ -2720,7 +2767,8 @@ msgstr "अतिरिक्त सोर्स"
 #: src/gs-sources-dialog.ui:175
 msgid ""
 "Removing a source will also remove any software you have installed from it."
-msgstr "किसी स्रोत को निकालने से आपके द्वारा इससे स्थापित किए गए सॉफ़्टवेयर भी निकल जाएँगे."
+msgstr ""
+"किसी स्रोत को निकालने से आपके द्वारा इससे स्थापित किए गए सॉफ़्टवेयर भी निकल जाएँगे."
 
 #: src/gs-sources-dialog.ui:260
 msgid "No software installed from this source"
@@ -2918,16 +2966,20 @@ msgstr "अपडेट रद्द कर दिया गया था."
 #. * something with no network available
 #: src/gs-update-monitor.c:714
 msgid ""
-"Internet access was required but wasn’t available. Please make sure that you"
-" have internet access and try again."
-msgstr "इंटरनेट पहुँच आवश्यक थी लेकिन उपलब्ध नहीं थी. कृपया सुनिश्चित करें कि आपके पास इंटरनेट पहुँच है और पुनः प्रयास करें."
+"Internet access was required but wasn’t available. Please make sure that you "
+"have internet access and try again."
+msgstr ""
+"इंटरनेट पहुँच आवश्यक थी लेकिन उपलब्ध नहीं थी. कृपया सुनिश्चित करें कि आपके पास इंटरनेट पहुँच है "
+"और पुनः प्रयास करें."
 
 #. TRANSLATORS: if the package is not signed correctly
 #: src/gs-update-monitor.c:720
 msgid ""
 "There were security issues with the update. Please consult your software "
 "provider for more details."
-msgstr "अपडेट के साथ सुरक्षा समस्याएँ थीं. कृपया अधिक विवरण के लिए अपने सॉफ़्टवेयर प्रदाता से परामर्श लें."
+msgstr ""
+"अपडेट के साथ सुरक्षा समस्याएँ थीं. कृपया अधिक विवरण के लिए अपने सॉफ़्टवेयर प्रदाता से "
+"परामर्श लें."
 
 #. TRANSLATORS: we ran out of disk space
 #: src/gs-update-monitor.c:726
@@ -2940,7 +2992,9 @@ msgstr "पर्याप्त डिस्क स्थान नहीं �
 msgid ""
 "We’re sorry: the update failed to install. Please wait for another update "
 "and try again. If the problem persists, contact your software provider."
-msgstr "हमें क्षमा करें: अपडेट स्थापित करना विफल. कृपया अन्य अपडेट के लिए प्रतीक्षा करें और पुनः प्रयास करें. यदि समस्या बनी रहती है, तो अपने सॉफ़्टवेयर प्रदाता से संपर्क करें."
+msgstr ""
+"हमें क्षमा करें: अपडेट स्थापित करना विफल. कृपया अन्य अपडेट के लिए प्रतीक्षा करें और पुनः "
+"प्रयास करें. यदि समस्या बनी रहती है, तो अपने सॉफ़्टवेयर प्रदाता से संपर्क करें."
 
 #. TRANSLATORS: Time in 24h format
 #: src/gs-updates-page.c:297
@@ -3224,22 +3278,27 @@ msgid "App Center"
 msgstr "ऐप सेंटर "
 
 #: src/org.gnome.Software.desktop.in:4
+msgid "More Apps"
+msgstr "अधिक ऐप्स"
+
+#: src/org.gnome.Software.desktop.in:5
 msgid "Add, remove or update software on this computer"
 msgstr "इस कंप्यूटर पर सॉफ़्टवेयर जोड़ें, निकालें या अपडेट करें"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
-#: src/org.gnome.Software.desktop.in:6
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: src/org.gnome.Software.desktop.in:7
 #: src/org.gnome.Software.Editor.desktop.in:6
 msgid "org.gnome.Software"
 msgstr "org.gnome.Software"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
-#: src/org.gnome.Software.desktop.in:12
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: src/org.gnome.Software.desktop.in:13
 msgid ""
-"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;"
-msgstr "अपडेट;नवीनीकरण;स्रोत;भंडार;प्राथमिकताएँ;स्थापित करें;स्थापना रद्द करें;प्रोग्राम;सॉफ़्टवेयर;ऐप;स्टोर;"
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;"
+msgstr ""
+"अपडेट;नवीनीकरण;स्रोत;भंडार;प्राथमिकताएँ;स्थापित करें;स्थापना रद्द करें;प्रोग्राम;सॉफ़्टवेयर;"
+"ऐप;स्टोर;"
 
 #: src/org.gnome.Software.Editor.desktop.in:3
 msgid "Banner Designer"
@@ -3249,8 +3308,7 @@ msgstr "बैनर डिज़ाइनर"
 msgid "Design the featured banners for GNOME Software"
 msgstr "GNOME सॉफ्टवेयर के लिए फ़ीचर होने वाले बैनर डिज़ाइन करें"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: src/org.gnome.Software.Editor.desktop.in:13
 msgid "AppStream;Software;App;"
 msgstr "AppStream;सॉफ्टवेयर;ऐप्लिकेशन;"
@@ -3520,100 +3578,111 @@ msgctxt "Menu of Communication & News"
 msgid "Web Browsers"
 msgstr "वेब ब्राउज़र्स"
 
-#: plugins/core/gs-desktop-common.c:247
-msgctxt "Menu of Reference"
-msgid "All"
-msgstr "सभी"
-
-#: plugins/core/gs-desktop-common.c:250
-msgctxt "Menu of Reference"
-msgid "Featured"
-msgstr "फ़ीचर किए गए"
-
-#: plugins/core/gs-desktop-common.c:253
-msgctxt "Menu of Reference"
-msgid "Art"
-msgstr "कला"
-
-#: plugins/core/gs-desktop-common.c:256
-msgctxt "Menu of Reference"
-msgid "Biography"
-msgstr "जीवनी"
-
-#: plugins/core/gs-desktop-common.c:259
-msgctxt "Menu of Reference"
-msgid "Comics"
-msgstr "कॉमिक्स"
-
-#: plugins/core/gs-desktop-common.c:262
-msgctxt "Menu of Reference"
-msgid "Fiction"
-msgstr "काल्पनिक कहानी"
-
-#: plugins/core/gs-desktop-common.c:265
-msgctxt "Menu of Reference"
-msgid "Health"
-msgstr "स्वास्थ्य"
-
-#: plugins/core/gs-desktop-common.c:268
-msgctxt "Menu of Reference"
-msgid "History"
-msgstr "इतिहास"
-
-#: plugins/core/gs-desktop-common.c:271
-msgctxt "Menu of Reference"
-msgid "Lifestyle"
-msgstr "जीवनशैली"
-
-#: plugins/core/gs-desktop-common.c:274
+#: plugins/core/gs-desktop-common.c:242
 msgctxt "Menu of Communication & News"
 msgid "News"
 msgstr "समाचार"
 
+#: plugins/core/gs-desktop-common.c:251
+msgctxt "Menu of Reference"
+msgid "All"
+msgstr "सभी"
+
+#: plugins/core/gs-desktop-common.c:254
+msgctxt "Menu of Reference"
+msgid "Featured"
+msgstr "फ़ीचर किए गए"
+
+#: plugins/core/gs-desktop-common.c:257
+msgctxt "Menu of Reference"
+msgid "Art"
+msgstr "कला"
+
+#: plugins/core/gs-desktop-common.c:260
+msgctxt "Menu of Reference"
+msgid "Biography"
+msgstr "जीवनी"
+
+#: plugins/core/gs-desktop-common.c:263
+msgctxt "Menu of Reference"
+msgid "Comics"
+msgstr "कॉमिक्स"
+
+#: plugins/core/gs-desktop-common.c:266
+msgctxt "Menu of Reference"
+msgid "Feed"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:269
+msgctxt "Menu of Reference"
+msgid "Fiction"
+msgstr "काल्पनिक कहानी"
+
+#: plugins/core/gs-desktop-common.c:272
+msgctxt "Menu of Reference"
+msgid "Health"
+msgstr "स्वास्थ्य"
+
+#: plugins/core/gs-desktop-common.c:275
+msgctxt "Menu of Reference"
+msgid "History"
+msgstr "इतिहास"
+
 #: plugins/core/gs-desktop-common.c:278
+msgctxt "Menu of Reference"
+msgid "Lifestyle"
+msgstr "जीवनशैली"
+
+#: plugins/core/gs-desktop-common.c:281
+#, fuzzy
+msgctxt "Menu of Reference"
+msgid "News"
+msgstr "समाचार"
+
+#: plugins/core/gs-desktop-common.c:284
 msgctxt "Menu of Reference"
 msgid "Politics"
 msgstr "राजनीति"
 
-#: plugins/core/gs-desktop-common.c:281
+#: plugins/core/gs-desktop-common.c:287
 msgctxt "Menu of Reference"
 msgid "Sports"
 msgstr "खेल"
 
 #. TRANSLATORS: this is the menu spec main category for Learning
-#: plugins/core/gs-desktop-common.c:291
+#: plugins/core/gs-desktop-common.c:297
 msgid "Learning"
 msgstr "शिक्षण"
 
 #. TRANSLATORS: this is the menu spec main category for Game
-#: plugins/core/gs-desktop-common.c:294
+#: plugins/core/gs-desktop-common.c:300
 msgid "Games"
 msgstr "गेम्स"
 
 #. TRANSLATORS: this is the menu spec main category for Multimedia
-#: plugins/core/gs-desktop-common.c:297
+#: plugins/core/gs-desktop-common.c:303
 msgid "Multimedia"
 msgstr "मल्टीमीडिया"
 
 #. TRANSLATORS: this is the menu spec main category for Work
-#: plugins/core/gs-desktop-common.c:300
+#: plugins/core/gs-desktop-common.c:306
 msgid "Work"
 msgstr "कार्य"
 
 #. TRANSLATORS: this is the menu spec main category for Reference
-#: plugins/core/gs-desktop-common.c:303
+#: plugins/core/gs-desktop-common.c:309
 msgid "Reference & News"
 msgstr "संदर्भ और समाचार"
 
 #. TRANSLATORS: this is the menu spec main category for Utilities
-#: plugins/core/gs-desktop-common.c:306
+#: plugins/core/gs-desktop-common.c:312
 msgid "Utilities"
 msgstr "उपयोगिता"
 
 #. TRANSLATORS: this is the menu spec main category for Dev Tools; it
 #. * should be a relatively short label; as an example, in Portuguese and
 #. * Spanish the direct translation of "Programming" (noun) is used
-#: plugins/core/gs-desktop-common.c:311
+#: plugins/core/gs-desktop-common.c:317
 msgid "Dev Tools"
 msgstr "Dev टूल"
 
@@ -3639,16 +3708,16 @@ msgstr "प्रदर्शन, स्थिरता और सुरक्�
 msgid "Downloading featured images…"
 msgstr "फ़ीचर की गई छवियाँ डाउनलोड कर रहा है..."
 
-#: plugins/eos/gs-plugin-eos.c:1249
+#: plugins/eos/gs-plugin-eos.c:1233
 #, c-format
 msgid "Could not launch this application."
 msgstr "इस एप्लिकेशन को लॉन्च नहीं सके."
 
-#: plugins/eos/gs-plugin-eos.c:1305
+#: plugins/eos/gs-plugin-eos.c:1289
 msgid "Endless Platform"
 msgstr "अनंत प्लेटफ़ॉर्म"
 
-#: plugins/eos/gs-plugin-eos.c:1308
+#: plugins/eos/gs-plugin-eos.c:1292
 msgid "Framework for applications"
 msgstr "ऐप्लिकेशन्स के लिए फ़्रेमवर्क"
 
@@ -3708,13 +3777,13 @@ msgid "Flatpak is a framework for desktop applications on Linux"
 msgstr "Flatpak, Linux पर डेस्कटॉप ऐप्लिकेशन्स के लिए एक फ़्रेमवर्क है"
 
 #. TRANSLATORS: status text when downloading new metadata
-#: plugins/flatpak/gs-flatpak.c:821
+#: plugins/flatpak/gs-flatpak.c:815
 #, c-format
 msgid "Getting flatpak metadata for %s…"
 msgstr "%s के लिए flatpak मेटाडेटा प्राप्त कर रहा है…"
 
 #. TRANSLATORS: status text when downloading the RuntimeRepo
-#: plugins/flatpak/gs-flatpak.c:2796
+#: plugins/flatpak/gs-flatpak.c:2803
 msgid "Getting runtime source…"
 msgstr "रनटाइम स्त्रोत प्राप्त कर रहा है..."
 

--- a/po/id.po
+++ b/po/id.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the gnome-software package.
-# 
+#
 # Translators:
 # Andika Triwidada <andika@gmail.com>, 2013-2015,2017
 # Dirgita <dirgitadevina@gmail.com>, 2015
@@ -12,14 +12,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-software\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-12 22:31-0700\n"
+"POT-Creation-Date: 2017-11-02 16:28+0100\n"
 "PO-Revision-Date: 2017-10-13 06:23+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
-"Language-Team: Indonesian (http://www.transifex.com/endless-mobile-inc/gnome-software/language/id/)\n"
+"Language-Team: Indonesian (http://www.transifex.com/endless-mobile-inc/gnome-"
+"software/language/id/)\n"
+"Language: id\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: id\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:7
@@ -34,7 +35,9 @@ msgstr "Manajer aplikasi bagi GNOME"
 msgid ""
 "Software allows you to find and install new applications and system "
 "extensions and remove existing installed applications."
-msgstr "Perangkat Lunak memungkinkan Anda menemukan dan memasang aplikasi dan ekstensi sistem baru dan menghapus aplikasi yang telah dipasang."
+msgstr ""
+"Perangkat Lunak memungkinkan Anda menemukan dan memasang aplikasi dan "
+"ekstensi sistem baru dan menghapus aplikasi yang telah dipasang."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:14
 msgid ""
@@ -42,7 +45,11 @@ msgid ""
 "descriptions and multiple screenshots per application. Applications can be "
 "found either through browsing the list of categories or by searching. It "
 "also allows you to update your system using an offline update."
-msgstr "GNOME Perangkat Lunak memajang aplikasi-aplikasi populer dan pilihan dengan deskripsi yang berguna dan beberapa cuplikan layar per aplikasi. Aplikasi bisa ditemukan dengan meramban daftar kategori atau dengan mencari. Itu juga memungkinkan Anda memutakhirkan sistem Anda memakai pembaruan luring."
+msgstr ""
+"GNOME Perangkat Lunak memajang aplikasi-aplikasi populer dan pilihan dengan "
+"deskripsi yang berguna dan beberapa cuplikan layar per aplikasi. Aplikasi "
+"bisa ditemukan dengan meramban daftar kategori atau dengan mencari. Itu juga "
+"memungkinkan Anda memutakhirkan sistem Anda memakai pembaruan luring."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:25
 msgid "Overview panel"
@@ -76,7 +83,9 @@ msgstr "Daftar proyek yang kompatibel"
 msgid ""
 "This is a list of compatible projects we should show such as GNOME, KDE and "
 "XFCE."
-msgstr "Ini adalah daftar proyek yang kompatible yang mesti kami tampilkan seperti misalnya GNOME, KDE, dan XFCE."
+msgstr ""
+"Ini adalah daftar proyek yang kompatible yang mesti kami tampilkan seperti "
+"misalnya GNOME, KDE, dan XFCE."
 
 #: data/org.gnome.software.gschema.xml:10
 msgid "Whether to manage updates in GNOME Software"
@@ -86,7 +95,9 @@ msgstr "Apakah mengelola pembaruan dalam GNOME Perangkat Lunak"
 msgid ""
 "If disabled, GNOME Software will hide the updates panel and not perform any "
 "automatic updates actions."
-msgstr "Bila tak difungsikan, GNOME Perangkat Lunak akan menyembunyikan panel pembaruan dan tidak melalukan sebarang aksi pemutakhiran otomatis."
+msgstr ""
+"Bila tak difungsikan, GNOME Perangkat Lunak akan menyembunyikan panel "
+"pembaruan dan tidak melalukan sebarang aksi pemutakhiran otomatis."
 
 #: data/org.gnome.software.gschema.xml:15
 msgid "Whether to automatically download updates"
@@ -94,9 +105,12 @@ msgstr "Apakah secara otomatis mengunduh pembaruan"
 
 #: data/org.gnome.software.gschema.xml:16
 msgid ""
-"If enabled, GNOME Software automatically downloads updates in the background"
-" and prompts the user to install them when ready."
-msgstr "Bila difungsikan, GNOME Perangkat Lunak akan secara otomatis mengunduh pembaruan di latar belakang dan meminta ke pengguna untuk memasang mereka ketika siap."
+"If enabled, GNOME Software automatically downloads updates in the background "
+"and prompts the user to install them when ready."
+msgstr ""
+"Bila difungsikan, GNOME Perangkat Lunak akan secara otomatis mengunduh "
+"pembaruan di latar belakang dan meminta ke pengguna untuk memasang mereka "
+"ketika siap."
 
 #: data/org.gnome.software.gschema.xml:20
 msgid "Whether to automatically refresh when on a metered connection"
@@ -107,7 +121,11 @@ msgid ""
 "If enabled, GNOME Software automatically refreshes in the background even "
 "when using a metered connection (eventually downloading some metadata, "
 "checking for updates, etc., which may incur in costs for the user)."
-msgstr "Bila difungsikan, GNOME Perangkat Lunak secara otomatis menyegarkan di latar belakang bahkan ketika memakai koneksi dengan kuota (pada akhirnya mengunduh beberapa metadata, memeriksa pembaruan, dsb., yang mungkin berakibat biaya bagi pengguna)."
+msgstr ""
+"Bila difungsikan, GNOME Perangkat Lunak secara otomatis menyegarkan di latar "
+"belakang bahkan ketika memakai koneksi dengan kuota (pada akhirnya mengunduh "
+"beberapa metadata, memeriksa pembaruan, dsb., yang mungkin berakibat biaya "
+"bagi pengguna)."
 
 #: data/org.gnome.software.gschema.xml:25
 msgid "Whether it’s the very first run of GNOME Software"
@@ -123,13 +141,16 @@ msgstr "Menyaring aplikasi berdasarkan cabang baku yang diatur bagi remote"
 
 #: data/org.gnome.software.gschema.xml:37
 msgid "Non-free applications show a warning dialog before install"
-msgstr "Aplikasi bukan bebas menampilkan suatu dialog peringatan sebelum pemasangan"
+msgstr ""
+"Aplikasi bukan bebas menampilkan suatu dialog peringatan sebelum pemasangan"
 
 #: data/org.gnome.software.gschema.xml:38
 msgid ""
-"When non-free applications are installed a warning dialog can be shown. This"
-" controls if that dialog is suppressed."
-msgstr "Ketika aplikasi bukan-bebas dipasang, suatu dialog peringatan dapat ditampilkan. Ini mengendalikan apakah dialog tersebut dimunculkan."
+"When non-free applications are installed a warning dialog can be shown. This "
+"controls if that dialog is suppressed."
+msgstr ""
+"Ketika aplikasi bukan-bebas dipasang, suatu dialog peringatan dapat "
+"ditampilkan. Ini mengendalikan apakah dialog tersebut dimunculkan."
 
 #: data/org.gnome.software.gschema.xml:42
 msgid "A list of popular applications"
@@ -137,7 +158,9 @@ msgstr "Daftar aplikasi populer"
 
 #: data/org.gnome.software.gschema.xml:43
 msgid "A list of applications to use, overriding the system defined ones."
-msgstr "Suatu daftar aplikasi yang akan dipakai, menimpa yang didefinisikan oleh sistem."
+msgstr ""
+"Suatu daftar aplikasi yang akan dipakai, menimpa yang didefinisikan oleh "
+"sistem."
 
 #: data/org.gnome.software.gschema.xml:47
 msgid "The list of extra sources that have been previously enabled"
@@ -147,7 +170,9 @@ msgstr "Daftar sumber ekstra yang sebelumnya telah pernah difungsikan"
 msgid ""
 "The list of sources that have been previously enabled when installing third-"
 "party applications."
-msgstr "Daftar sumber yang telah pernah difungsikan ketika memasang aplikasi pihak ketiga."
+msgstr ""
+"Daftar sumber yang telah pernah difungsikan ketika memasang aplikasi pihak "
+"ketiga."
 
 #: data/org.gnome.software.gschema.xml:52
 msgid "The last update check timestamp"
@@ -159,7 +184,9 @@ msgstr "Stempel waktu pemberitahuan peningkatan terakhir"
 
 #: data/org.gnome.software.gschema.xml:60
 msgid "The timestamp of the first security update, cleared after update"
-msgstr "Stempel wakti dari pemutakhiran keamanan pertama, dibersihkan setelah pembaruan"
+msgstr ""
+"Stempel wakti dari pemutakhiran keamanan pertama, dibersihkan setelah "
+"pembaruan"
 
 #: data/org.gnome.software.gschema.xml:64
 msgid "The last update timestamp"
@@ -167,14 +194,19 @@ msgstr "Stempel waktu pembaruan terakhir"
 
 #: data/org.gnome.software.gschema.xml:68
 msgid "The age in seconds to verify the upstream screenshot is still valid"
-msgstr "Umur dalam detik untuk verifikasi apakah cuplikan layar hulu masih valid"
+msgstr ""
+"Umur dalam detik untuk verifikasi apakah cuplikan layar hulu masih valid"
 
 #: data/org.gnome.software.gschema.xml:69
 msgid ""
 "Choosing a larger value will mean less round-trips to the remote server but "
-"updates to the screenshots may take longer to show to the user. A value of 0"
-" means to never check the server if the image already exists in the cache."
-msgstr "Memilih nilai yang lebih besar berarti lebih sedikit bolak-balik ke server remote tapi pembaruan ke cuplikan layar mungkin makan waktu lebih lama untuk tampil ke pengguna. Nilai 0 berarti jangan pernah memeriksa ke server apakah citra telah ada dalam singgahan."
+"updates to the screenshots may take longer to show to the user. A value of 0 "
+"means to never check the server if the image already exists in the cache."
+msgstr ""
+"Memilih nilai yang lebih besar berarti lebih sedikit bolak-balik ke server "
+"remote tapi pembaruan ke cuplikan layar mungkin makan waktu lebih lama untuk "
+"tampil ke pengguna. Nilai 0 berarti jangan pernah memeriksa ke server apakah "
+"citra telah ada dalam singgahan."
 
 #: data/org.gnome.software.gschema.xml:78
 msgid "The server to use for application reviews"
@@ -190,21 +222,23 @@ msgstr "Ulasan dengan karma kurang dari angka ini tidak akan ditampilkan."
 
 #: data/org.gnome.software.gschema.xml:87
 msgid "A list of official sources that should not be considered 3rd party"
-msgstr "Daftar sumber-sumber resmi yang tidak perlu dianggap sebagai pihak ke-3"
+msgstr ""
+"Daftar sumber-sumber resmi yang tidak perlu dianggap sebagai pihak ke-3"
 
 #: data/org.gnome.software.gschema.xml:91
 msgid "A list of official sources that should be considered free software"
-msgstr "Daftar sumber-sumber resmi yang tidak perlu dianggap sebagai pihak ke-3"
+msgstr ""
+"Daftar sumber-sumber resmi yang tidak perlu dianggap sebagai pihak ke-3"
 
 #: data/org.gnome.software.gschema.xml:95
 msgid ""
-"The licence URL to use when an application should be considered free "
-"software"
-msgstr "URL lisensi yang dipakai ketika suatu aplikasi mesti dianggap perangkat lunak bebas"
+"The licence URL to use when an application should be considered free software"
+msgstr ""
+"URL lisensi yang dipakai ketika suatu aplikasi mesti dianggap perangkat "
+"lunak bebas"
 
 #: data/org.gnome.software.gschema.xml:99
-msgid ""
-"Install bundled applications for all users on the system where possible"
+msgid "Install bundled applications for all users on the system where possible"
 msgstr "Pasang aplikasi terbundel bagi semua pengguna pada sistem bila mungkin"
 
 #: data/org.gnome.software.gschema.xml:103
@@ -221,7 +255,9 @@ msgstr "Tawarkan peningkatan bagi prarilis"
 
 #: data/org.gnome.software.gschema.xml:115
 msgid "Show some UI elements informing the user that an app is non-free"
-msgstr "Tampilkan beberapa elemen UI yang menginformasikan ke pengguna bahwa app bukan bebas"
+msgstr ""
+"Tampilkan beberapa elemen UI yang menginformasikan ke pengguna bahwa app "
+"bukan bebas"
 
 #: data/org.gnome.software.gschema.xml:119
 msgid "Show the prompt to install nonfree software sources"
@@ -247,15 +283,19 @@ msgstr "Daftar sumber tak bebas yang dapat difungsikan secara opsional"
 msgid ""
 "A list of URLs pointing to appstream files that will be downloaded into an "
 "app-info folder"
-msgstr "Daftar URL yang menunjuk ke berkas appstream yang akan diunduh ke dalam suatu folder app-info"
+msgstr ""
+"Daftar URL yang menunjuk ke berkas appstream yang akan diunduh ke dalam "
+"suatu folder app-info"
 
 #: data/org.gnome.software.gschema.xml:143
 msgid "Install the AppStream files to a system-wide location for all users"
-msgstr "Pasang berkas AppStream ke lokasi keseluruhan sistem untuk semua pengguna"
+msgstr ""
+"Pasang berkas AppStream ke lokasi keseluruhan sistem untuk semua pengguna"
 
 #: data/org.gnome.software.gschema.xml:147
 msgid "Sorts the apps shown in the overview in alphabetical order"
-msgstr "Sortir aplikasi yang ditampilkan di ringkasan berdasarkan urutan abjad."
+msgstr ""
+"Sortir aplikasi yang ditampilkan di ringkasan berdasarkan urutan abjad."
 
 #: data/org.gnome.software.gschema.xml:151
 msgid ""
@@ -271,8 +311,7 @@ msgstr "Pasang Perangkat Lunak"
 msgid "Install selected software on the system"
 msgstr "Pasang perangkat lunak yang dipilih pada sistem"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 #: src/gnome-software-local-file.desktop.in:10
 msgid "system-software-install"
 msgstr "system-software-install"
@@ -299,14 +338,12 @@ msgstr "Kembali"
 msgid "_All"
 msgstr "Semu_a"
 
-#. Translators: A label for a button to show only software which is already
-#. installed.
+#. Translators: A label for a button to show only software which is already installed.
 #: src/gnome-software.ui:104
 msgid "_Installed"
 msgstr "Ter_pasang"
 
-#. Translators: A label for a button to show only updates which are available
-#. to install.
+#. Translators: A label for a button to show only updates which are available to install.
 #: src/gnome-software.ui:155
 msgid "_Updates"
 msgstr "Pembar_uan"
@@ -354,7 +391,7 @@ msgstr "Terpasang"
 
 #. TRANSLATORS: this is a button next to the search results that
 #. * shows the status of an application being installed
-#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:443
+#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:439
 msgid "Installing"
 msgstr "Memasang"
 
@@ -369,7 +406,7 @@ msgid "Folder Name"
 msgstr "Nama Folder"
 
 #: src/gs-app-folder-dialog.c:321 src/gs-app-folder-dialog.ui:16
-#: src/gs-details-page.c:383 src/gs-details-page.ui:342 src/gs-editor.c:623
+#: src/gs-details-page.c:379 src/gs-details-page.ui:342 src/gs-editor.c:623
 #: src/gs-editor.c:655 src/gs-installed-page.c:609 src/gs-removal-dialog.ui:33
 #: src/gs-review-dialog.ui:23 src/gs-upgrade-banner.ui:131
 msgid "_Cancel"
@@ -384,92 +421,99 @@ msgid "Add to Application Folder"
 msgstr "Tambah ke Folder Aplikasi"
 
 #. TRANSLATORS: this is a command line option
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "Start up mode: either ‘updates’, ‘updated’, ‘installed’ or ‘overview’"
-msgstr "Mode awal mula: bisa ‘updates’, ‘updated’, ‘installed’, atau ‘overview’"
+msgstr ""
+"Mode awal mula: bisa ‘updates’, ‘updated’, ‘installed’, atau ‘overview’"
 
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "MODE"
 msgstr "MODE"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "Search for applications"
 msgstr "Cari aplikasi"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "SEARCH"
 msgstr "CARI"
 
-#: src/gs-application.c:105
+#: src/gs-application.c:133
 msgid "Show application details (using application ID)"
 msgstr "Tampilkan rincian aplikasi (memakai ID aplikasi)"
 
-#: src/gs-application.c:105 src/gs-application.c:109
+#: src/gs-application.c:133 src/gs-application.c:137
 msgid "ID"
 msgstr "ID"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "Show application details (using package name)"
 msgstr "Tampilkan rincian aplikasi (memakai nama paket)"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "PKGNAME"
 msgstr "NAMAPAKET"
 
-#: src/gs-application.c:109
+#: src/gs-application.c:137
 msgid "Install the application (using application ID)"
 msgstr "Pasang aplikasi (memakai ID aplikasi)"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "Open a local package file"
 msgstr "Buka suatu berkas paket lokal"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "FILENAME"
 msgstr "NAMABERKAS"
 
-#: src/gs-application.c:113
+#: src/gs-application.c:141
 msgid ""
 "The kind of interaction expected for this action: either ‘none’, ‘notify’, "
 "or ‘full’"
-msgstr "Jenis interaksi yang diharapkan untuk tindakan ini: baik 'tidak ada (none)', 'memberitahu (notify)', atau 'penuh (full)'"
+msgstr ""
+"Jenis interaksi yang diharapkan untuk tindakan ini: baik 'tidak ada (none)', "
+"'memberitahu (notify)', atau 'penuh (full)'"
 
-#: src/gs-application.c:116
+#: src/gs-application.c:144
 msgid "Show verbose debugging information"
 msgstr "Tampilkan informasi pengawakutuan cerewet"
 
-#: src/gs-application.c:118
+#: src/gs-application.c:146
 msgid "Show profiling information for the service"
 msgstr "Tampilkan informasi profil bagi layanan"
 
-#: src/gs-application.c:120
+#: src/gs-application.c:148
 msgid "Quit the running instance"
 msgstr "Keluar dari instansi yang tengah berjalan"
 
-#: src/gs-application.c:122
+#: src/gs-application.c:150
 msgid "Prefer local file sources to AppStream"
 msgstr "Lebih suka sumber berkas lokal daripada AppStream"
 
-#: src/gs-application.c:124
+#: src/gs-application.c:152
 msgid "Show version number"
 msgstr "Tampilkan nomor versi"
 
-#: src/gs-application.c:325
+#: src/gs-application.c:358
 msgid "translator-credits"
-msgstr "Andika Triwidada <andika@gmail.com>, 2013, 2014, 2015, 2017.\nDirgita <dirgitadevina@gmail.com>, 2015.\nKukuh Syafaat <syafaatkukuh@gmail.com>, 2017."
+msgstr ""
+"Andika Triwidada <andika@gmail.com>, 2013, 2014, 2015, 2017.\n"
+"Dirgita <dirgitadevina@gmail.com>, 2015.\n"
+"Kukuh Syafaat <syafaatkukuh@gmail.com>, 2017."
 
 #. TRANSLATORS: this is the title of the about window, e.g.
 #. * 'About Software' or 'About Application Installer' where the %s is
 #. * the application name chosen by the distro
-#: src/gs-application.c:332
+#: src/gs-application.c:365
 #, c-format
 msgid "About %s"
 msgstr "Tentang %s"
 
 #. TRANSLATORS: well, we seem to think so, anyway
-#: src/gs-application.c:336
+#: src/gs-application.c:369
 msgid "A nice way to manage the software on your system."
-msgstr "Suatu cara yang manis untuk mengelola perangkat lunak pada sistem Anda."
+msgstr ""
+"Suatu cara yang manis untuk mengelola perangkat lunak pada sistem Anda."
 
 #. TRANSLATORS: this is a button next to the search results that
 #. * allows the application to be easily installed
@@ -582,7 +626,7 @@ msgid "All"
 msgstr "Semua"
 
 #. TRANSLATORS: this is a subcategory of featured apps
-#: lib/gs-category.c:202 src/gs-shell.c:2180
+#: lib/gs-category.c:202 src/gs-shell.c:2181
 msgid "Featured"
 msgstr "Pilihan"
 
@@ -592,9 +636,11 @@ msgstr "Pengaturan Ekstensi"
 
 #: src/gs-category-page.ui:110
 msgid ""
-"Extensions are used at your own risk. If you have any system problems, it is"
-" recommended to disable them."
-msgstr "Risiko memakai ekstensi Anda tanggung sendiri. Bila Anda mengalami sebarang masalah sistem, disarankan untuk menonaktifkan mereka."
+"Extensions are used at your own risk. If you have any system problems, it is "
+"recommended to disable them."
+msgstr ""
+"Risiko memakai ekstensi Anda tanggung sendiri. Bila Anda mengalami sebarang "
+"masalah sistem, disarankan untuk menonaktifkan mereka."
 
 #. TRANSLATORS: the user isn't reading the question
 #: lib/gs-cmd.c:205
@@ -650,13 +696,16 @@ msgstr "Akhirkan Sumber Perangkat Lunak Pihak Ketiga?"
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
 #. * 2. Software source name, e.g. fedora-optional
+#.
 #: src/gs-common.c:232
 #, c-format
 msgid ""
 "%s is not <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
-"source_software\">free and open source software</a>, and is provided by "
+"source_software\">free and open source software</a>, and is provided by “%s”."
+msgstr ""
+"%s bukanlah <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
+"source_software\">perangkat lunak bebas dan terbuka</a>, dan disediakan oleh "
 "“%s”."
-msgstr "%s bukanlah <a href=\"https://en.wikipedia.org/wiki/Free_and_open-source_software\">perangkat lunak bebas dan terbuka</a>, dan disediakan oleh “%s”."
 
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
@@ -680,7 +729,9 @@ msgstr "Mungkin tak legal untuk memasang atau memakai %s di beberapa negara."
 #. TRANSLATORS: Laws are geographical, urgh...
 #: src/gs-common.c:268
 msgid "It may be illegal to install or use this codec in some countries."
-msgstr "Bisa saja ilegal untuk memasang atau menggunakan kodek ini di sejumlah negara."
+msgstr ""
+"Bisa saja ilegal untuk memasang atau menggunakan kodek ini di sejumlah "
+"negara."
 
 #. TRANSLATORS: this is button text to not ask about non-free content again
 #: src/gs-common.c:275
@@ -731,7 +782,8 @@ msgstr "Tidak ada kekerasan fantasi"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:90
 msgid "Characters in unsafe situations easily distinguishable from reality"
-msgstr "Karakter dalam situasi yang tidak aman dengan mudah dibedakan dari realitas"
+msgstr ""
+"Karakter dalam situasi yang tidak aman dengan mudah dibedakan dari realitas"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:93
@@ -941,7 +993,8 @@ msgstr "Penempatan produk"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:216
 msgid "Explicit references to specific brands or trademarked products"
-msgstr "Referensi eksplisit untuk merek tertentu atau produk dengan merek dagang"
+msgstr ""
+"Referensi eksplisit untuk merek tertentu atau produk dengan merek dagang"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:219
@@ -1038,14 +1091,12 @@ msgstr "Tidak berbagi lokasi fisik ke pengguna lain"
 msgid "Sharing physical location to other users"
 msgstr "Berbagi lokasi fisik ke pengguna lain"
 
-#. TRANSLATORS: this is a what we use in notifications if the app's name is
-#. unknown
+#. TRANSLATORS: this is a what we use in notifications if the app's name is unknown
 #: src/gs-dbus-helper.c:294
 msgid "An application"
 msgstr "Aplikasi"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. MIME types.
+#. TRANSLATORS: this is a notification displayed when an app needs additional MIME types.
 #: src/gs-dbus-helper.c:300
 #, c-format
 msgid "%s is requesting additional file format support."
@@ -1056,8 +1107,7 @@ msgstr "%s meminta dukungan format berkas tambahan."
 msgid "Additional MIME Types Required"
 msgstr "Memerlukan Jenis MIME Tambahan"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. fonts.
+#. TRANSLATORS: this is a notification displayed when an app needs additional fonts.
 #: src/gs-dbus-helper.c:306
 #, c-format
 msgid "%s is requesting additional fonts."
@@ -1068,8 +1118,7 @@ msgstr "%s meminta fonta tambahan."
 msgid "Additional Fonts Required"
 msgstr "Memerlukan Fonta Tambahan"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. codecs.
+#. TRANSLATORS: this is a notification displayed when an app needs additional codecs.
 #: src/gs-dbus-helper.c:312
 #, c-format
 msgid "%s is requesting additional multimedia codecs."
@@ -1080,8 +1129,7 @@ msgstr "%s meminta kodek multimedia tambahan."
 msgid "Additional Multimedia Codecs Required"
 msgstr "Memerlukan Kodek Multimedia Tambahan"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. printer drivers.
+#. TRANSLATORS: this is a notification displayed when an app needs additional printer drivers.
 #: src/gs-dbus-helper.c:318
 #, c-format
 msgid "%s is requesting additional printer drivers."
@@ -1092,8 +1140,7 @@ msgstr "%s meminta pengandar pencetak tambahan."
 msgid "Additional Printer Drivers Required"
 msgstr "Memerlukan Pengandar Pencetak Tambahan"
 
-#. TRANSLATORS: this is a notification displayed when an app wants to install
-#. additional packages.
+#. TRANSLATORS: this is a notification displayed when an app wants to install additional packages.
 #: src/gs-dbus-helper.c:324
 #, c-format
 msgid "%s is requesting additional packages."
@@ -1113,14 +1160,14 @@ msgstr "Cari dalam Perangkat Lunak"
 #. * can be installed
 #. TRANSLATORS: button text in the header when firmware
 #. * can be live-installed
-#: src/gs-details-page.c:281 src/gs-details-page.c:312
-#: src/gs-details-page.ui:206 src/gs-upgrade-banner.ui:146
+#: src/gs-details-page.c:280 src/gs-details-page.c:310
+#: src/gs-details-page.ui:237 src/gs-upgrade-banner.ui:146
 msgid "_Install"
 msgstr "_Pasang"
 
 #. TRANSLATORS: button text in the header when an application
 #. * can be live-updated
-#: src/gs-details-page.c:316
+#: src/gs-details-page.c:314
 msgid "_Update"
 msgstr "Perbar_ui"
 
@@ -1128,66 +1175,66 @@ msgstr "Perbar_ui"
 #. * be installed.
 #. * The ellipsis indicates that further steps are required,
 #. * e.g. enabling software sources or the like
-#: src/gs-details-page.c:330
+#: src/gs-details-page.c:326
 msgid "_Install…"
 msgstr "_Pasang..."
 
 #. TRANSLATORS: button text in the header when an application can be erased
-#: src/gs-details-page.c:377 src/gs-details-page.ui:547
+#: src/gs-details-page.c:373 src/gs-details-page.ui:547
 msgid "_Uninstall"
 msgstr "_Hapus instal"
 
-#: src/gs-details-page.c:438 src/gs-sources-dialog.c:513
+#: src/gs-details-page.c:434 src/gs-sources-dialog.c:513
 msgid "Removing…"
 msgstr "Menghapus…"
 
 #. TRANSLATORS: this is the warning box
-#: src/gs-details-page.c:748
+#: src/gs-details-page.c:744
 msgid ""
 "This application can only be used when there is an active internet "
 "connection."
 msgstr "Aplikasi ini hanya dapat dipakai ketika ada koneksi internet aktif."
 
 #. TRANSLATORS: this is where the version is not known
-#: src/gs-details-page.c:892
+#: src/gs-details-page.c:888
 msgctxt "version"
 msgid "Unknown"
 msgstr "Tak diketahui"
 
 #. TRANSLATORS: this is where we don't know the origin of the
 #. * application
-#: src/gs-details-page.c:971
+#: src/gs-details-page.c:967
 msgctxt "origin"
 msgid "Unknown"
 msgstr "Tak diketahui"
 
 #. TRANSLATORS: we need a remote server to process
-#: src/gs-details-page.c:1378
+#: src/gs-details-page.c:1374
 msgid "You need internet access to write a review"
 msgstr "Anda perlu akses internet untuk menulis ulasan"
 
-#: src/gs-details-page.c:1507
+#: src/gs-details-page.c:1503
 #, c-format
 msgid "Unable to find “%s”"
 msgstr "Tak bisa temukan \"%s\""
 
 #. TRANSLATORS: see the wikipedia page
-#: src/gs-details-page.c:2087
+#: src/gs-details-page.c:2083
 msgid "Public domain"
 msgstr "Domain publik"
 
 #. TRANSLATORS: see GNU page
-#: src/gs-details-page.c:2103 src/gs-details-page.ui:1397
+#: src/gs-details-page.c:2099 src/gs-details-page.ui:1397
 msgid "Free Software"
 msgstr "Perangkat Lunak Bebas"
 
 #. TRANSLATORS: for the free software popover
-#: src/gs-details-page.c:2160
+#: src/gs-details-page.c:2156
 msgid "Users are bound by the following license:"
 msgid_plural "Users are bound by the following licenses:"
 msgstr[0] "Pengguna terikat oleh lisensi-lisensi berikut:"
 
-#: src/gs-details-page.c:2176 src/gs-details-page.ui:1506
+#: src/gs-details-page.c:2172 src/gs-details-page.ui:1506
 msgid "More information"
 msgstr "Informasi lebih lanjut"
 
@@ -1195,15 +1242,13 @@ msgstr "Informasi lebih lanjut"
 msgid "Details page"
 msgstr "Halaman rincian"
 
-#. Translators: A label for a button to add a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:228
+#. Translators: A label for a button to add a shortcut to the selected application.
+#: src/gs-details-page.ui:209
 msgid "_Add to Desktop"
 msgstr "_Tambahkan ke Desktop"
 
-#. Translators: A label for a button to remove a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:245
+#. Translators: A label for a button to remove a shortcut to the selected application.
+#: src/gs-details-page.ui:226
 msgid "_Remove from Desktop"
 msgstr "_Hapus dari Destop"
 
@@ -1224,7 +1269,9 @@ msgstr "Sumber Perangkat Lunak Yang Disertakan"
 msgid ""
 "This application includes a software source which provides updates, as well "
 "as access to other software."
-msgstr "Aplikasi ini termasuk sumber perangkat lunak yang menyediakan pembaruan maupun akses ke perangkat lunak lain."
+msgstr ""
+"Aplikasi ini termasuk sumber perangkat lunak yang menyediakan pembaruan "
+"maupun akses ke perangkat lunak lain."
 
 #: src/gs-details-page.ui:500
 msgid "No Software Source Included"
@@ -1234,16 +1281,18 @@ msgstr "Tak Ada Sumber Perangkat Lunak Yang Disertakan"
 msgid ""
 "This application does not include a software source. It will not be updated "
 "with new versions."
-msgstr "Aplikasi ini tak termasuk sumber perangkat lunak. Ini tak akan diperbarui ke versi baru."
+msgstr ""
+"Aplikasi ini tak termasuk sumber perangkat lunak. Ini tak akan diperbarui ke "
+"versi baru."
 
 #: src/gs-details-page.ui:515
 msgid ""
 "This software is already provided by your distribution and should not be "
 "replaced."
-msgstr "Perangkat lunak ini telah disediakan distribusi Anda dan tak boleh diganti."
+msgstr ""
+"Perangkat lunak ini telah disediakan distribusi Anda dan tak boleh diganti."
 
-#. Translators: a repository file used for installing software has been
-#. discovered.
+#. Translators: a repository file used for installing software has been discovered.
 #: src/gs-details-page.ui:528
 msgid "Software Source Identified"
 msgstr "Sumber Perangkat Lunak Teridentifikasi"
@@ -1252,7 +1301,9 @@ msgstr "Sumber Perangkat Lunak Teridentifikasi"
 msgid ""
 "Adding this software source will give you access to additional software and "
 "upgrades."
-msgstr "Menambahkan sumber perangkat lunak ini akan memberi Anda akses ke perangkat lunak tambahan dan peningkatan."
+msgstr ""
+"Menambahkan sumber perangkat lunak ini akan memberi Anda akses ke perangkat "
+"lunak tambahan dan peningkatan."
 
 #: src/gs-details-page.ui:530
 msgid "Only use software sources that you trust."
@@ -1344,14 +1395,12 @@ msgstr "Tambahan"
 msgid "Selected add-ons will be installed with the application."
 msgstr "Tambahan yang dipilih akan dipasang dengan aplikasi."
 
-#. Translators: Header of the section with other users' opinions about the
-#. app.
+#. Translators: Header of the section with other users' opinions about the app.
 #: src/gs-details-page.ui:1233
 msgid "Reviews"
 msgstr "Ulasan"
 
-#. Translators: Button opening a dialog where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Button opening a dialog where the users can write and publish their opinions about the apps.
 #: src/gs-details-page.ui:1249
 msgid "_Write a Review"
 msgstr "_Tulis Ulasan"
@@ -1363,9 +1412,11 @@ msgstr "Tampilkan _Rinciannya"
 
 #: src/gs-details-page.ui:1414
 msgid ""
-"This means that the software can be freely run, copied, distributed, studied"
-" and modified."
-msgstr "Ini berarti bahwa perangkat lunak dapat secara bebas dijalankan, disalin, didistribusikan, dipelajari, dan dimodifikasi."
+"This means that the software can be freely run, copied, distributed, studied "
+"and modified."
+msgstr ""
+"Ini berarti bahwa perangkat lunak dapat secara bebas dijalankan, disalin, "
+"didistribusikan, dipelajari, dan dimodifikasi."
 
 #: src/gs-details-page.ui:1473
 msgid "Proprietary Software"
@@ -1376,7 +1427,10 @@ msgid ""
 "This means that the software is owned by an individual or a company. There "
 "are often restrictions on its use and its source code cannot usually be "
 "accessed."
-msgstr "Ini berarti bahwa perangkat lunak tersebut dimiliki oleh seorang individu atau perusahaan. Sering ada pembatasan pada penggunaan dan kode sumber biasanya tidak dapat diakses."
+msgstr ""
+"Ini berarti bahwa perangkat lunak tersebut dimiliki oleh seorang individu "
+"atau perusahaan. Sering ada pembatasan pada penggunaan dan kode sumber "
+"biasanya tidak dapat diakses."
 
 #: src/gs-details-page.ui:1535
 msgid "Unknown Software License"
@@ -1460,8 +1514,7 @@ msgstr "Daftar aplikasi memiliki perubahan yang belum disimpan."
 msgid "Use verbose logging"
 msgstr "Gunakan logging verbose"
 
-#. TRANSLATORS: program name, an application to add and remove software
-#. repositories
+#. TRANSLATORS: program name, an application to add and remove software repositories
 #: src/gs-editor.c:1119
 msgid "GNOME Software Banner Designer"
 msgstr "GNOME Perangkat Lunak Perancang Banner"
@@ -1490,8 +1543,7 @@ msgstr "Ringkasan"
 msgid "Editor’s Pick"
 msgstr "Pilihan Penyunting"
 
-#. This check button controls whether the application’s banner appears in the
-#. “Featured” category
+#. This check button controls whether the application’s banner appears in the “Featured” category
 #: src/gs-editor.ui:397
 msgid "Category Featured"
 msgstr "Kategori Pilihan"
@@ -1578,9 +1630,11 @@ msgstr "Tak satupun aplikasi yang ada menyediakan berkas %s."
 #: src/gs-extras-page.c:337 src/gs-extras-page.c:348 src/gs-extras-page.c:359
 #, c-format
 msgid ""
-"Information about %s, as well as options for how to get missing applications"
-" might be found %s."
-msgstr "Informasi tentang %s, maupun opsi tentang bagaimana mendapatkan aplikasi yang kurang mungkin dapat ditemukan %s."
+"Information about %s, as well as options for how to get missing applications "
+"might be found %s."
+msgstr ""
+"Informasi tentang %s, maupun opsi tentang bagaimana mendapatkan aplikasi "
+"yang kurang mungkin dapat ditemukan %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1603,7 +1657,9 @@ msgstr "%s tak tersedia."
 msgid ""
 "Information about %s, as well as options for how to get an application that "
 "can support this format might be found %s."
-msgstr "Informasi tentang %s, maupun opsi tentang bagaimana mendapatkan suatu aplikasi yang dapat mendukung format ini mungkin dapat ditemukan %s."
+msgstr ""
+"Informasi tentang %s, maupun opsi tentang bagaimana mendapatkan suatu "
+"aplikasi yang dapat mendukung format ini mungkin dapat ditemukan %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1619,11 +1675,13 @@ msgstr "Tak ada fonta yang tersedia bagi dukungan skrip %s."
 msgid ""
 "Information about %s, as well as options for how to get additional fonts "
 "might be found %s."
-msgstr "Informasi tentang %s, maupun opsi tentang bagaimana mendapatkan fonta tambahan mungkin dapat ditemukan %s."
+msgstr ""
+"Informasi tentang %s, maupun opsi tentang bagaimana mendapatkan fonta "
+"tambahan mungkin dapat ditemukan %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
-#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1426
+#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1430
 #, c-format
 msgid "No addon codecs are available for the %s format."
 msgstr "Tak ada kodek tambahan yang tersedia bagi format %s."
@@ -1635,7 +1693,9 @@ msgstr "Tak ada kodek tambahan yang tersedia bagi format %s."
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format might be found %s."
-msgstr "Informasi tentang %s, maupun opsi tentang bagaimana mendapatkan suatu kodek yang dapat memutar format ini mungkin dapat ditemukan %s."
+msgstr ""
+"Informasi tentang %s, maupun opsi tentang bagaimana mendapatkan suatu kodek "
+"yang dapat memutar format ini mungkin dapat ditemukan %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1651,7 +1711,9 @@ msgstr "Tak ada sumber daya Plasma yang tersedia bagi dukungan %s."
 msgid ""
 "Information about %s, as well as options for how to get additional Plasma "
 "resources might be found %s."
-msgstr "Informasi tentang %s, maupun opsi tentang bagaimana mendapatkan sumber daya Plasma tambahan mungkin dapat ditemukan %s."
+msgstr ""
+"Informasi tentang %s, maupun opsi tentang bagaimana mendapatkan sumber daya "
+"Plasma tambahan mungkin dapat ditemukan %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1667,15 +1729,16 @@ msgstr "Tak ada penggerak pencetak yang tersedia bagi %s."
 msgid ""
 "Information about %s, as well as options for how to get a driver that "
 "supports this printer might be found %s."
-msgstr "Informasi tentang %s, maupun opsi tentang bagaimana mendapatkan suatu penggerak yang mendukung pencetak ini mungkin dapat ditemukan %s."
+msgstr ""
+"Informasi tentang %s, maupun opsi tentang bagaimana mendapatkan suatu "
+"penggerak yang mendukung pencetak ini mungkin dapat ditemukan %s."
 
 #. TRANSLATORS: hyperlink title
 #: src/gs-extras-page.c:459
 msgid "this website"
 msgstr "laman situs ini"
 
-#. TRANSLATORS: no codecs were found. First %s will be replaced by actual
-#. codec name(s), second %s is a link titled "this website"
+#. TRANSLATORS: no codecs were found. First %s will be replaced by actual codec name(s), second %s is a link titled "this website"
 #: src/gs-extras-page.c:463
 #, c-format
 msgid ""
@@ -1684,7 +1747,9 @@ msgid ""
 msgid_plural ""
 "Unfortunately, the %s you were searching for could not be found. Please see "
 "%s for more information."
-msgstr[0] "Sayangnya, %s yang Anda cari tak dapat kami temukan. Kunjungilah %s untuk informasi lebih lanjut."
+msgstr[0] ""
+"Sayangnya, %s yang Anda cari tak dapat kami temukan. Kunjungilah %s untuk "
+"informasi lebih lanjut."
 
 #: src/gs-extras-page.c:535 src/gs-extras-page.c:591 src/gs-extras-page.c:630
 msgid "Failed to find any search results"
@@ -1709,10 +1774,13 @@ msgstr "Selamat Datang ke Perangkat Lunak"
 
 #: src/gs-first-run-dialog.ui:66
 msgid ""
-"Software lets you install all the software you need, all from one place. See"
-" our recommendations, browse the categories, or search for the applications "
+"Software lets you install all the software you need, all from one place. See "
+"our recommendations, browse the categories, or search for the applications "
 "you want."
-msgstr "Perangkat Lunak memungkinkan Anda memasang semua perangkat lunak yang Anda perlukan, semua dari satu tempat. Lihat rekomendasi kami, ramban kategori, atau cari aplikasi yang Anda inginkan."
+msgstr ""
+"Perangkat Lunak memungkinkan Anda memasang semua perangkat lunak yang Anda "
+"perlukan, semua dari satu tempat. Lihat rekomendasi kami, ramban kategori, "
+"atau cari aplikasi yang Anda inginkan."
 
 #: src/gs-first-run-dialog.ui:85
 msgid "_Let’s Go Shopping"
@@ -1862,13 +1930,16 @@ msgstr "Aplikasi Produktivitas yang Disarankan"
 #: src/gs-overview-page.c:974
 msgid ""
 "Provides access to additional software, including web browsers and games."
-msgstr "Menyediakan akses ke perangkat lunak tambahan, termasuk peramban web dan permainan."
+msgstr ""
+"Menyediakan akses ke perangkat lunak tambahan, termasuk peramban web dan "
+"permainan."
 
 #. TRANSLATORS: this is the proprietary info bar
 #: src/gs-overview-page.c:978
-msgid ""
-"Proprietary software has restrictions on use and access to source code."
-msgstr "Perangkat lunak proprietary memiliki pembatasan pada penggunaan dan akses ke kode sumber."
+msgid "Proprietary software has restrictions on use and access to source code."
+msgstr ""
+"Perangkat lunak proprietary memiliki pembatasan pada penggunaan dan akses ke "
+"kode sumber."
 
 #. TRANSLATORS: this is the clickable
 #. * link on the proprietary info bar
@@ -1897,14 +1968,12 @@ msgstr "Aplikasi Pilihan"
 msgid "Categories"
 msgstr "Kategori"
 
-#. Translators: This is a heading for software which has been featured
-#. ('picked') by the distribution.
+#. Translators: This is a heading for software which has been featured ('picked') by the distribution.
 #: src/gs-overview-page.ui:315
 msgid "Editor’s Picks"
 msgstr "Pilihan Penyunting"
 
-#. Translators: This is a heading for software which has been recently
-#. released upstream.
+#. Translators: This is a heading for software which has been recently released upstream.
 #: src/gs-overview-page.ui:359
 msgid "Recent Releases"
 msgstr "Rilis Terbaru"
@@ -1951,7 +2020,9 @@ msgstr "Anda yakin ingin menghapus sumber %s?"
 msgid ""
 "All applications from %s will be removed, and you will have to re-install "
 "the source to use them again."
-msgstr "Semua aplikasi dari %s akan dihapus, dan Anda perlu memasang ulang sumber untuk memakainya lagi."
+msgstr ""
+"Semua aplikasi dari %s akan dihapus, dan Anda perlu memasang ulang sumber "
+"untuk memakainya lagi."
 
 #. TRANSLATORS: this is a prompt message, and '%s' is an
 #. * application summary, e.g. 'GNOME Clocks'
@@ -1966,12 +2037,14 @@ msgstr "Apakah Anda yakin ingin menghapus %s?"
 msgid "%s will be removed, and you will have to install it to use it again."
 msgstr "%s akan dihapus, dan Anda perlu memasangnya untuk memakainya lagi."
 
-#: lib/gs-plugin-loader.c:1429
+#: lib/gs-plugin-loader.c:1433
 #, c-format
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format can be found on the website."
-msgstr "Informasi tentang %s, maupun opsi tentang bagaimana mendapatkan suatu kodek yang dapat memutar format ini dapat ditemukan pada situs web."
+msgstr ""
+"Informasi tentang %s, maupun opsi tentang bagaimana mendapatkan suatu kodek "
+"yang dapat memutar format ini dapat ditemukan pada situs web."
 
 #: lib/gs-price.c:111
 #, c-format
@@ -2030,7 +2103,10 @@ msgstr "%s %f"
 msgid ""
 "Some of the currently installed software is not compatible with %s. If you "
 "continue, the following will be automatically removed during the upgrade:"
-msgstr "Beberapa perangkat lunak yang kini terpasang tidak kompatibel dengan %s. Bila Anda melanjutkan, yang berikut akan secara otomatis dihapus saat peningkatan:"
+msgstr ""
+"Beberapa perangkat lunak yang kini terpasang tidak kompatibel dengan %s. "
+"Bila Anda melanjutkan, yang berikut akan secara otomatis dihapus saat "
+"peningkatan:"
 
 #: src/gs-removal-dialog.ui:27
 msgid "Incompatible Software"
@@ -2100,8 +2176,7 @@ msgstr "Keterangan terlalu pendek"
 msgid "The description is too long"
 msgstr "Keterangan terlalu panjang"
 
-#. Translators: Title of the dialog box where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Title of the dialog box where the users can write and publish their opinions about the apps.
 #: src/gs-review-dialog.ui:11
 msgid "Post Review"
 msgstr "Kirim Ulasan"
@@ -2119,7 +2194,9 @@ msgstr "Peringkat"
 msgid ""
 "Give a short summary of your review, for example: “Great app, would "
 "recommend”."
-msgstr "Berikan ringkasan ulasan Anda, sebagai contoh: \"App bagus,  akan menyarankan\"."
+msgstr ""
+"Berikan ringkasan ulasan Anda, sebagai contoh: \"App bagus,  akan menyarankan"
+"\"."
 
 #. Translators: This is where the users enter their opinions about the apps.
 #: src/gs-review-dialog.ui:199
@@ -2129,7 +2206,8 @@ msgstr "Ulasan"
 
 #: src/gs-review-dialog.ui:215
 msgid "What do you think of the app? Try to give reasons for your views."
-msgstr "Apa pendapat Anda tentang app? Cobalah memberi alasan tentang pandangan Anda."
+msgstr ""
+"Apa pendapat Anda tentang app? Cobalah memberi alasan tentang pandangan Anda."
 
 #. Translators: A label for the total number of reviews.
 #: src/gs-review-histogram.ui:413
@@ -2139,14 +2217,18 @@ msgstr "total peringkat"
 #. TRANSLATORS: we explain what the action is going to do
 #: src/gs-review-row.c:234
 msgid "You can report reviews for abusive, rude, or discriminatory behavior."
-msgstr "Anda dapat melaporkan ulasan untuk perilaku diskriminatif, kasar, atau abusif."
+msgstr ""
+"Anda dapat melaporkan ulasan untuk perilaku diskriminatif, kasar, atau "
+"abusif."
 
 #. TRANSLATORS: we ask the user if they really want to do this
 #: src/gs-review-row.c:239
 msgid ""
 "Once reported, a review will be hidden until it has been checked by an "
 "administrator."
-msgstr "Sekali dilaporkan, suatu ulasan akan disembunyikan sampai diperiksa oleh seorang administrator."
+msgstr ""
+"Sekali dilaporkan, suatu ulasan akan disembunyikan sampai diperiksa oleh "
+"seorang administrator."
 
 #. TRANSLATORS: window title when
 #. * reporting a user-submitted review
@@ -2161,8 +2243,7 @@ msgstr "Laporkan Ulasan?"
 msgid "Report"
 msgstr "Lapor"
 
-#. Translators: Users can express their opinions about other users' opinions
-#. about the apps.
+#. Translators: Users can express their opinions about other users' opinions about the apps.
 #: src/gs-review-row.ui:112
 msgid "Was this review useful to you?"
 msgstr "Apakah ulasan ini berguna bagi Anda?"
@@ -2250,81 +2331,83 @@ msgstr "Tak Ada Aplikasi Yang Ditemukan"
 #. TRANSLATORS: this is part of the in-app notification,
 #. * where the %s is a multi-word localised app name
 #. * e.g. 'Getting things GNOME!"
-#: src/gs-shell.c:846 src/gs-shell.c:851 src/gs-shell.c:866 src/gs-shell.c:870
+#: src/gs-shell.c:847 src/gs-shell.c:852 src/gs-shell.c:867 src/gs-shell.c:871
 #, c-format
 msgid "“%s”"
 msgstr "\"%s\""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:898
+#: src/gs-shell.c:899
 #, c-format
 msgid "Unable to download firmware updates from %s"
 msgstr "Tidak bisa mengunduh pembaruan perangkat tegar dari %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:904
+#: src/gs-shell.c:905
 #, c-format
 msgid "Unable to download updates from %s"
 msgstr "Tidak bisa mengunduh pembaruan dari %s"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:911
+#: src/gs-shell.c:912
 msgid "Unable to download updates"
 msgstr "Tidak bisa mengunduh pembaruan"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:916
+#: src/gs-shell.c:917
 msgid ""
-"Unable to download updates: internet access was required but wasn’t "
-"available"
-msgstr "Tidak bisa mengunduh pembaruan: akses internet diperlukan tapi tak tersedia"
+"Unable to download updates: internet access was required but wasn’t available"
+msgstr ""
+"Tidak bisa mengunduh pembaruan: akses internet diperlukan tapi tak tersedia"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:925
+#: src/gs-shell.c:926
 #, c-format
 msgid "Unable to download updates from %s: not enough disk space"
 msgstr "Tidak bisa mengunduh pembaruan dari %s: ruang disk tidak cukup"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:930
+#: src/gs-shell.c:931
 msgid "Unable to download updates: not enough disk space"
 msgstr "Tidak bisa mengunduh pembaruan: ruang disk tidak cukup"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:938
+#: src/gs-shell.c:939
 msgid "Unable to download updates: authentication was required"
 msgstr "Tidak bisa mengunduh pembaruan: perlu otentikasi"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:943
+#: src/gs-shell.c:944
 msgid "Unable to download updates: authentication was invalid"
 msgstr "Tidak bisa mengunduh pembaruan: otentikasi tidak valid"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:948
+#: src/gs-shell.c:949
 msgid ""
 "Unable to download updates: you do not have permission to install software"
-msgstr "Tidak bisa mengunduh pembaruan: Anda tidak punya hak untuk memasang perangkat lunak"
+msgstr ""
+"Tidak bisa mengunduh pembaruan: Anda tidak punya hak untuk memasang "
+"perangkat lunak"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:955
+#: src/gs-shell.c:956
 msgid "Unable to get list of updates"
 msgstr "Tidak bisa mendapat daftar pembaruan"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the application name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1001
+#: src/gs-shell.c:1002
 #, c-format
 msgid "Unable to install %s as download failed from %s"
 msgstr "Tidak bisa memasang %s karena pengunduhan gagal dari %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1007
+#: src/gs-shell.c:1008
 #, c-format
 msgid "Unable to install %s as download failed"
 msgstr "Tidak bisa memasang %s karena pengunduhan gagal"
@@ -2333,86 +2416,88 @@ msgstr "Tidak bisa memasang %s karena pengunduhan gagal"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1019
+#: src/gs-shell.c:1020
 #, c-format
 msgid "Unable to install %s as runtime %s not available"
 msgstr "Tidak bisa memasang %s karena runtime %s tidak tersedia"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1025
+#: src/gs-shell.c:1026
 #, c-format
 msgid "Unable to install %s as not supported"
 msgstr "Tidak bisa memasang %s karena tidak didukung"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1032
+#: src/gs-shell.c:1033
 msgid "Unable to install: internet access was required but wasn’t available"
 msgstr "Tidak bisa memasang: akses internet diperlukan tapi tidak tersedia"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1038
+#: src/gs-shell.c:1039
 msgid "Unable to install: the application has an invalid format"
 msgstr "Tidak bisa memasang: aplikasi memiliki format yang tidak valid"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1043
+#: src/gs-shell.c:1044
 #, c-format
 msgid "Unable to install %s: not enough disk space"
 msgstr "Tidak bisa memasang %s: ruang disk tidak cukup"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1051
+#: src/gs-shell.c:1052
 #, c-format
 msgid "Unable to install %s: authentication was required"
 msgstr "Tidak bisa memasang %s: perlu otentikasi"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1058
+#: src/gs-shell.c:1059
 #, c-format
 msgid "Unable to install %s: authentication was invalid"
 msgstr "Tidak bisa memasang %s: otentikasi tidak valid"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1065
+#: src/gs-shell.c:1066
 #, c-format
 msgid "Unable to install %s: you do not have permission to install software"
-msgstr "Tidak bisa memasang %s: Anda tidak punya hak untuk memasang perangkat lunak"
+msgstr ""
+"Tidak bisa memasang %s: Anda tidak punya hak untuk memasang perangkat lunak"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the name of the authentication service,
 #. * e.g. "Ubuntu One"
-#: src/gs-shell.c:1078
+#: src/gs-shell.c:1079
 #, c-format
 msgid "Your %s account has been suspended."
 msgstr "Akun %s Anda telah diskors."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1082
+#: src/gs-shell.c:1083
 msgid "It is not possible to install software until this has been resolved."
-msgstr "Tidak mungkin memasang perangkat lunak sampai hal ini telah diselesaikan."
+msgstr ""
+"Tidak mungkin memasang perangkat lunak sampai hal ini telah diselesaikan."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the clickable link (e.g.
 #. * "http://example.com/what-did-i-do-wrong/")
-#: src/gs-shell.c:1093
+#: src/gs-shell.c:1094
 #, c-format
 msgid "For more information, visit %s."
 msgstr "Untuk informasi lebih banyak, kunjungi %s."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1102
+#: src/gs-shell.c:1103
 #, c-format
 msgid "Unable to install %s: AC power is required"
 msgstr "Tidak bisa memasang %s: perlu daya AC"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1111
+#: src/gs-shell.c:1112
 #, c-format
 msgid "Unable to install %s"
 msgstr "Tidak bisa memasang %s"
@@ -2421,61 +2506,63 @@ msgstr "Tidak bisa memasang %s"
 #. * where the first %s is the app name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1157
+#: src/gs-shell.c:1158
 #, c-format
 msgid "Unable to update %s from %s"
 msgstr "Tidak bisa memperbarui %s dari %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1163
+#: src/gs-shell.c:1164
 #, c-format
 msgid "Unable to update %s as download failed"
 msgstr "Tidak bisa memperbarui %s karena pengunduhan gagal"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1169
+#: src/gs-shell.c:1170
 msgid "Unable to update: internet access was required but wasn’t available"
 msgstr "Tidak bisa memperbarui: akses internet diperlukan tapi tidak tersedia"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1177
+#: src/gs-shell.c:1178
 #, c-format
 msgid "Unable to update %s: not enough disk space"
 msgstr "Tidak bisa memperbarui %s: ruang disk tidak cukup"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1186
+#: src/gs-shell.c:1187
 #, c-format
 msgid "Unable to update %s: authentication was required"
 msgstr "Tidak bisa memperbarui %s: perlu otentikasi"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1193
+#: src/gs-shell.c:1194
 #, c-format
 msgid "Unable to update %s: authentication was invalid"
 msgstr "Tidak bisa memperbarui %s: otentikasi tidak valid"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1200
+#: src/gs-shell.c:1201
 #, c-format
 msgid "Unable to update %s: you do not have permission to update software"
-msgstr "Tidak bisa memperbarui %s: Anda tidak punya hak untuk memperbarui perangkat lunak"
+msgstr ""
+"Tidak bisa memperbarui %s: Anda tidak punya hak untuk memperbarui perangkat "
+"lunak"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1208
+#: src/gs-shell.c:1209
 #, c-format
 msgid "Unable to update %s: AC power is required"
 msgstr "Tidak bisa memperbarui %s: perlu daya AC"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1217
+#: src/gs-shell.c:1218
 #, c-format
 msgid "Unable to update %s"
 msgstr "Tidak bisa memperbarui %s"
@@ -2483,96 +2570,97 @@ msgstr "Tidak bisa memperbarui %s"
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the distro name (e.g. "Fedora 25") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1262
+#: src/gs-shell.c:1263
 #, c-format
 msgid "Unable to upgrade to %s from %s"
 msgstr "Tidak bisa meningkatkan ke %s dari %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the app name (e.g. "GIMP")
-#: src/gs-shell.c:1267
+#: src/gs-shell.c:1268
 #, c-format
 msgid "Unable to upgrade to %s as download failed"
 msgstr "Tidak bisa meningkatkan ke %s karena pengunduhan gagal"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1274
+#: src/gs-shell.c:1275
 msgid "Unable to upgrade: internet access was required but wasn’t available"
 msgstr "Tidak bisa meningkatkan: akses internet diperlukan tapi tidak tersedia"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1282
+#: src/gs-shell.c:1283
 #, c-format
 msgid "Unable to upgrade to %s: not enough disk space"
 msgstr "Tidak bisa meningkatkan ke %s: ruang disk tidak cukup"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1291
+#: src/gs-shell.c:1292
 #, c-format
 msgid "Unable to upgrade to %s: authentication was required"
 msgstr "Tidak bisa meningkatkan ke %s: perlu otentikasi"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1298
+#: src/gs-shell.c:1299
 #, c-format
 msgid "Unable to upgrade to %s: authentication was invalid"
 msgstr "Tidak bisa meningkatkan ke %s: otentikasi tidak valid"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1305
+#: src/gs-shell.c:1306
 #, c-format
 msgid "Unable to upgrade to %s: you do not have permission to upgrade"
 msgstr "Tidak bisa meningkatkan ke %s: Anda tidak punya hak untuk meningkatkan"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1312
+#: src/gs-shell.c:1313
 #, c-format
 msgid "Unable to upgrade to %s: AC power is required"
 msgstr "Tidak bisa meningkatkan ke %s: perlu daya AC"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1321
+#: src/gs-shell.c:1322
 #, c-format
 msgid "Unable to upgrade to %s"
 msgstr "Tidak bisa meningkatkan ke %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1363
+#: src/gs-shell.c:1364
 #, c-format
 msgid "Unable to remove %s: authentication was required"
 msgstr "Tidak bisa menghapus %s: perlu otentikasi"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1369
+#: src/gs-shell.c:1370
 #, c-format
 msgid "Unable to remove %s: authentication was invalid"
 msgstr "Tidak bisa menghapus %s: otentikasi tidak valid"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1375
+#: src/gs-shell.c:1376
 #, c-format
 msgid "Unable to remove %s: you do not have permission to remove software"
-msgstr "Tidak bisa menghapus %s: Anda tidak punya hak untuk menghapus perangkat lunak"
+msgstr ""
+"Tidak bisa menghapus %s: Anda tidak punya hak untuk menghapus perangkat lunak"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1382
+#: src/gs-shell.c:1383
 #, c-format
 msgid "Unable to remove %s: AC power is required"
 msgstr "Tidak bisa menghapus %s: perlu daya AC"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1391
+#: src/gs-shell.c:1392
 #, c-format
 msgid "Unable to remove %s"
 msgstr "Tidak bisa menghapus %s"
@@ -2581,48 +2669,48 @@ msgstr "Tidak bisa menghapus %s"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1437
+#: src/gs-shell.c:1438
 #, c-format
 msgid "Unable to launch %s: %s is not installed"
 msgstr "Tidak dapat meluncurkan %s: %s tidak terpasang"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1444 src/gs-shell.c:1492 src/gs-shell.c:1540
+#: src/gs-shell.c:1445 src/gs-shell.c:1493 src/gs-shell.c:1541
 msgid "Not enough disk space — free up some space and try again"
 msgstr "Ruang disk tidak cukup — kosongkan sebagian dan coba lagi"
 
 #. TRANSLATORS: we failed to get a proper error code
-#: src/gs-shell.c:1452 src/gs-shell.c:1500 src/gs-shell.c:1567
+#: src/gs-shell.c:1453 src/gs-shell.c:1501 src/gs-shell.c:1568
 msgid "Sorry, something went wrong"
 msgstr "Maaf, ada yang tidak beres"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1487
+#: src/gs-shell.c:1488
 msgid "Failed to install file: authentication failed"
 msgstr "Gagal memasang berkas: otentikasi gagal"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1534
+#: src/gs-shell.c:1535
 #, c-format
 msgid "Unable to contact %s"
 msgstr "Tidak bisa mengontak %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1549
+#: src/gs-shell.c:1550
 #, c-format
 msgid "%s needs to be restarted to use new plugins."
 msgstr "%s perlu dijalankan ulang untuk memakai plugin baru."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1554
+#: src/gs-shell.c:1555
 msgid "This application needs to be restarted to use new plugins."
 msgstr "Aplikasi ini perlu dijalankan ulang untuk memakai plugin baru."
 
 #. TRANSLATORS: need to be connected to the AC power
-#: src/gs-shell.c:1561
+#: src/gs-shell.c:1562
 msgid "AC power is required"
 msgstr "Daya AC diperlukan"
 
@@ -2630,7 +2718,9 @@ msgstr "Daya AC diperlukan"
 #. has no software installed from it.
 #: src/gs-sources-dialog.c:98
 msgid "No applications or addons installed; other software might still be"
-msgstr "Tak ada aplikasi atau pengaya yang dipasang; perangkat lunak lain mungkin masih"
+msgstr ""
+"Tak ada aplikasi atau pengaya yang dipasang; perangkat lunak lain mungkin "
+"masih"
 
 #. TRANSLATORS: This string is used to construct the 'X applications
 #. installed' sentence, describing a software source.
@@ -2704,7 +2794,9 @@ msgstr "sistem operasi"
 msgid ""
 "Software sources can be downloaded from the internet. They give you access "
 "to additional software that is not provided by %s."
-msgstr "Sumber perangkat lunak dappat diunduh dari Internet. Mereka memberikan Anda akses terhadap perangkat lunak tambahan lainnya yang tak disediakan oleh %s."
+msgstr ""
+"Sumber perangkat lunak dappat diunduh dari Internet. Mereka memberikan Anda "
+"akses terhadap perangkat lunak tambahan lainnya yang tak disediakan oleh %s."
 
 #: src/gs-sources-dialog.ui:155
 msgid "Additional Sources"
@@ -2713,7 +2805,9 @@ msgstr "Sumber-sumber Tambahan"
 #: src/gs-sources-dialog.ui:175
 msgid ""
 "Removing a source will also remove any software you have installed from it."
-msgstr "Menghapus suatu sumber juga akan menghapus sebarang perangkat lunak yang telah Anda pasang darinya."
+msgstr ""
+"Menghapus suatu sumber juga akan menghapus sebarang perangkat lunak yang "
+"telah Anda pasang darinya."
 
 #: src/gs-sources-dialog.ui:260
 msgid "No software installed from this source"
@@ -2808,7 +2902,8 @@ msgstr "Pembaruan Keamanan Tertunda"
 
 #: src/gs-update-monitor.c:89
 msgid "It is recommended that you install important updates now"
-msgstr "Anda sangat disarankan untuk memasang pembaruan yang penting ini sekarang"
+msgstr ""
+"Anda sangat disarankan untuk memasang pembaruan yang penting ini sekarang"
 
 #: src/gs-update-monitor.c:92
 msgid "Restart & Install"
@@ -2909,29 +3004,36 @@ msgstr "Pembaruan dibatalkan."
 #. * something with no network available
 #: src/gs-update-monitor.c:714
 msgid ""
-"Internet access was required but wasn’t available. Please make sure that you"
-" have internet access and try again."
-msgstr "Akses Internet yang diperlukan tidak tersedia. Pastikan Anda terhubung pada Internet dan coba lagi."
+"Internet access was required but wasn’t available. Please make sure that you "
+"have internet access and try again."
+msgstr ""
+"Akses Internet yang diperlukan tidak tersedia. Pastikan Anda terhubung pada "
+"Internet dan coba lagi."
 
 #. TRANSLATORS: if the package is not signed correctly
 #: src/gs-update-monitor.c:720
 msgid ""
 "There were security issues with the update. Please consult your software "
 "provider for more details."
-msgstr "Terdapat masalah keamanan pada pembaruan perangkat lunak. Konsultasikanlah pada penyedia perangkat lunak Anda untuk informasi lebih rinci."
+msgstr ""
+"Terdapat masalah keamanan pada pembaruan perangkat lunak. Konsultasikanlah "
+"pada penyedia perangkat lunak Anda untuk informasi lebih rinci."
 
 #. TRANSLATORS: we ran out of disk space
 #: src/gs-update-monitor.c:726
 msgid ""
 "There wasn’t enough disk space. Please free up some space and try again."
-msgstr "Tidak tersedia ruang diska yang cukup. Kosongkanlah beberapa dan coba lagi."
+msgstr ""
+"Tidak tersedia ruang diska yang cukup. Kosongkanlah beberapa dan coba lagi."
 
 #. TRANSLATORS: We didn't handle the error type
 #: src/gs-update-monitor.c:731
 msgid ""
 "We’re sorry: the update failed to install. Please wait for another update "
 "and try again. If the problem persists, contact your software provider."
-msgstr "Maaf: pembaruan gagal dipasang. Tunggulah untuk pembaruan yang lain dan coba lagi. Jika terus berlanjut, hubungi penyedia perangkat lunak Anda."
+msgstr ""
+"Maaf: pembaruan gagal dipasang. Tunggulah untuk pembaruan yang lain dan coba "
+"lagi. Jika terus berlanjut, hubungi penyedia perangkat lunak Anda."
 
 #. TRANSLATORS: Time in 24h format
 #: src/gs-updates-page.c:297
@@ -3111,7 +3213,9 @@ msgstr "Mungkin ada biaya"
 msgid ""
 "Checking for updates while using mobile broadband could cause you to incur "
 "charges."
-msgstr "Memeriksa pembaruan ketika memakai data seluler bisa menyebabkan tambahan biaya."
+msgstr ""
+"Memeriksa pembaruan ketika memakai data seluler bisa menyebabkan tambahan "
+"biaya."
 
 #. TRANSLATORS: this is a link to the
 #. * control-center network panel
@@ -3204,7 +3308,9 @@ msgstr "Pelajari _Lebih Jauh"
 #: src/gs-upgrade-banner.ui:98
 msgid ""
 "It is recommended that you back up your data and files before upgrading."
-msgstr "Disarankan untuk membuat salinan cadangan data dan berkas Anda sebelum meningkatkan."
+msgstr ""
+"Disarankan untuk membuat salinan cadangan data dan berkas Anda sebelum "
+"meningkatkan."
 
 #: src/gs-upgrade-banner.ui:116
 msgid "_Download"
@@ -3215,22 +3321,27 @@ msgid "App Center"
 msgstr "Pusat Aplikasi"
 
 #: src/org.gnome.Software.desktop.in:4
+msgid "More Apps"
+msgstr "Pusat Aplikasi"
+
+#: src/org.gnome.Software.desktop.in:5
 msgid "Add, remove or update software on this computer"
 msgstr "Tambah, hapus, atau perbarui perangkat lunak pada komputer ini"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
-#: src/org.gnome.Software.desktop.in:6
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: src/org.gnome.Software.desktop.in:7
 #: src/org.gnome.Software.Editor.desktop.in:6
 msgid "org.gnome.Software"
 msgstr "org.gnome.Software"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
-#: src/org.gnome.Software.desktop.in:12
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: src/org.gnome.Software.desktop.in:13
 msgid ""
-"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;"
-msgstr "Pembaruan;Peningkatan;Sumber;Repositori;Preferensi;Pasang;Bongkar;Program;Perangkat Lunak;App;Toko;"
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;"
+msgstr ""
+"Pembaruan;Peningkatan;Sumber;Repositori;Preferensi;Pasang;Bongkar;Program;"
+"Perangkat Lunak;App;Toko;"
 
 #: src/org.gnome.Software.Editor.desktop.in:3
 msgid "Banner Designer"
@@ -3240,8 +3351,7 @@ msgstr "Perancang Banner"
 msgid "Design the featured banners for GNOME Software"
 msgstr "Rancang banner pilihan untuk Perangkat Lunak GNOME"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: src/org.gnome.Software.Editor.desktop.in:13
 msgid "AppStream;Software;App;"
 msgstr "AppStream:Perangkat Lunak;Aplikasi;"
@@ -3511,100 +3621,111 @@ msgctxt "Menu of Communication & News"
 msgid "Web Browsers"
 msgstr "Peramban Web"
 
-#: plugins/core/gs-desktop-common.c:247
-msgctxt "Menu of Reference"
-msgid "All"
-msgstr "Semua"
-
-#: plugins/core/gs-desktop-common.c:250
-msgctxt "Menu of Reference"
-msgid "Featured"
-msgstr "Pilihan"
-
-#: plugins/core/gs-desktop-common.c:253
-msgctxt "Menu of Reference"
-msgid "Art"
-msgstr "Seni"
-
-#: plugins/core/gs-desktop-common.c:256
-msgctxt "Menu of Reference"
-msgid "Biography"
-msgstr "Biografi"
-
-#: plugins/core/gs-desktop-common.c:259
-msgctxt "Menu of Reference"
-msgid "Comics"
-msgstr "Komik"
-
-#: plugins/core/gs-desktop-common.c:262
-msgctxt "Menu of Reference"
-msgid "Fiction"
-msgstr "Fiksi"
-
-#: plugins/core/gs-desktop-common.c:265
-msgctxt "Menu of Reference"
-msgid "Health"
-msgstr "Kesehatan"
-
-#: plugins/core/gs-desktop-common.c:268
-msgctxt "Menu of Reference"
-msgid "History"
-msgstr "Sejarah"
-
-#: plugins/core/gs-desktop-common.c:271
-msgctxt "Menu of Reference"
-msgid "Lifestyle"
-msgstr "Gaya Hidup"
-
-#: plugins/core/gs-desktop-common.c:274
+#: plugins/core/gs-desktop-common.c:242
 msgctxt "Menu of Communication & News"
 msgid "News"
 msgstr "Berita"
 
+#: plugins/core/gs-desktop-common.c:251
+msgctxt "Menu of Reference"
+msgid "All"
+msgstr "Semua"
+
+#: plugins/core/gs-desktop-common.c:254
+msgctxt "Menu of Reference"
+msgid "Featured"
+msgstr "Pilihan"
+
+#: plugins/core/gs-desktop-common.c:257
+msgctxt "Menu of Reference"
+msgid "Art"
+msgstr "Seni"
+
+#: plugins/core/gs-desktop-common.c:260
+msgctxt "Menu of Reference"
+msgid "Biography"
+msgstr "Biografi"
+
+#: plugins/core/gs-desktop-common.c:263
+msgctxt "Menu of Reference"
+msgid "Comics"
+msgstr "Komik"
+
+#: plugins/core/gs-desktop-common.c:266
+msgctxt "Menu of Reference"
+msgid "Feed"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:269
+msgctxt "Menu of Reference"
+msgid "Fiction"
+msgstr "Fiksi"
+
+#: plugins/core/gs-desktop-common.c:272
+msgctxt "Menu of Reference"
+msgid "Health"
+msgstr "Kesehatan"
+
+#: plugins/core/gs-desktop-common.c:275
+msgctxt "Menu of Reference"
+msgid "History"
+msgstr "Sejarah"
+
 #: plugins/core/gs-desktop-common.c:278
+msgctxt "Menu of Reference"
+msgid "Lifestyle"
+msgstr "Gaya Hidup"
+
+#: plugins/core/gs-desktop-common.c:281
+#, fuzzy
+msgctxt "Menu of Reference"
+msgid "News"
+msgstr "Berita"
+
+#: plugins/core/gs-desktop-common.c:284
 msgctxt "Menu of Reference"
 msgid "Politics"
 msgstr "Politik"
 
-#: plugins/core/gs-desktop-common.c:281
+#: plugins/core/gs-desktop-common.c:287
 msgctxt "Menu of Reference"
 msgid "Sports"
 msgstr "Olah Raga"
 
 #. TRANSLATORS: this is the menu spec main category for Learning
-#: plugins/core/gs-desktop-common.c:291
+#: plugins/core/gs-desktop-common.c:297
 msgid "Learning"
 msgstr "Belajar"
 
 #. TRANSLATORS: this is the menu spec main category for Game
-#: plugins/core/gs-desktop-common.c:294
+#: plugins/core/gs-desktop-common.c:300
 msgid "Games"
 msgstr "Permainan"
 
 #. TRANSLATORS: this is the menu spec main category for Multimedia
-#: plugins/core/gs-desktop-common.c:297
+#: plugins/core/gs-desktop-common.c:303
 msgid "Multimedia"
 msgstr "Multimedia"
 
 #. TRANSLATORS: this is the menu spec main category for Work
-#: plugins/core/gs-desktop-common.c:300
+#: plugins/core/gs-desktop-common.c:306
 msgid "Work"
 msgstr "Kerja"
 
 #. TRANSLATORS: this is the menu spec main category for Reference
-#: plugins/core/gs-desktop-common.c:303
+#: plugins/core/gs-desktop-common.c:309
 msgid "Reference & News"
 msgstr "Referensi & Berita"
 
 #. TRANSLATORS: this is the menu spec main category for Utilities
-#: plugins/core/gs-desktop-common.c:306
+#: plugins/core/gs-desktop-common.c:312
 msgid "Utilities"
 msgstr "Utilitas"
 
 #. TRANSLATORS: this is the menu spec main category for Dev Tools; it
 #. * should be a relatively short label; as an example, in Portuguese and
 #. * Spanish the direct translation of "Programming" (noun) is used
-#: plugins/core/gs-desktop-common.c:311
+#: plugins/core/gs-desktop-common.c:317
 msgid "Dev Tools"
 msgstr "Perangkat pengembang"
 
@@ -3630,16 +3751,16 @@ msgstr "Memuat perbaikan kinerja, stabilitas, dan keamanan."
 msgid "Downloading featured images…"
 msgstr "Mengunduh gambar pilihan..."
 
-#: plugins/eos/gs-plugin-eos.c:1249
+#: plugins/eos/gs-plugin-eos.c:1233
 #, c-format
 msgid "Could not launch this application."
 msgstr "Tidak dapat menjalankan aplikasi ini."
 
-#: plugins/eos/gs-plugin-eos.c:1305
+#: plugins/eos/gs-plugin-eos.c:1289
 msgid "Endless Platform"
 msgstr "Platform Endless"
 
-#: plugins/eos/gs-plugin-eos.c:1308
+#: plugins/eos/gs-plugin-eos.c:1292
 msgid "Framework for applications"
 msgstr "Framework untuk aplikasi"
 
@@ -3699,13 +3820,13 @@ msgid "Flatpak is a framework for desktop applications on Linux"
 msgstr "Flatpak adalah kerangka kerja untuk aplikasi destop di Linux"
 
 #. TRANSLATORS: status text when downloading new metadata
-#: plugins/flatpak/gs-flatpak.c:821
+#: plugins/flatpak/gs-flatpak.c:815
 #, c-format
 msgid "Getting flatpak metadata for %s…"
 msgstr "Mendapatkan metadata flatpak untuk %s…"
 
 #. TRANSLATORS: status text when downloading the RuntimeRepo
-#: plugins/flatpak/gs-flatpak.c:2796
+#: plugins/flatpak/gs-flatpak.c:2803
 msgid "Getting runtime source…"
 msgstr "Mendapatkan sumber runtime..."
 
@@ -3738,7 +3859,9 @@ msgstr "Dukungan Limba"
 
 #: plugins/limba/org.gnome.Software.Plugin.Limba.metainfo.xml.in:7
 msgid "Limba provides developers a way to easily create software bundles"
-msgstr "Limba memberikan pengembang cara untuk membuat bundel perangkat lunak dengan mudah"
+msgstr ""
+"Limba memberikan pengembang cara untuk membuat bundel perangkat lunak dengan "
+"mudah"
 
 #. TRANSLATORS: status text when downloading
 #: plugins/odrs/gs-plugin-odrs.c:205

--- a/po/meson.build
+++ b/po/meson.build
@@ -2,5 +2,6 @@ i18n.gettext(meson.project_name(),
   preset : 'glib',
   args: [
   '--default-domain=' + meson.project_name(),
+  '--keyword=GenericName',
   ]
 )

--- a/po/mr.po
+++ b/po/mr.po
@@ -1,20 +1,21 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the gnome-software package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-software\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-12 22:31-0700\n"
+"POT-Creation-Date: 2017-11-02 16:28+0100\n"
 "PO-Revision-Date: 2017-10-13 05:50+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
-"Language-Team: Marathi (http://www.transifex.com/endless-mobile-inc/gnome-software/language/mr/)\n"
+"Language-Team: Marathi (http://www.transifex.com/endless-mobile-inc/gnome-"
+"software/language/mr/)\n"
+"Language: mr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: mr\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:7
@@ -89,8 +90,8 @@ msgstr ""
 
 #: data/org.gnome.software.gschema.xml:16
 msgid ""
-"If enabled, GNOME Software automatically downloads updates in the background"
-" and prompts the user to install them when ready."
+"If enabled, GNOME Software automatically downloads updates in the background "
+"and prompts the user to install them when ready."
 msgstr ""
 
 #: data/org.gnome.software.gschema.xml:20
@@ -122,8 +123,8 @@ msgstr ""
 
 #: data/org.gnome.software.gschema.xml:38
 msgid ""
-"When non-free applications are installed a warning dialog can be shown. This"
-" controls if that dialog is suppressed."
+"When non-free applications are installed a warning dialog can be shown. This "
+"controls if that dialog is suppressed."
 msgstr ""
 
 #: data/org.gnome.software.gschema.xml:42
@@ -167,8 +168,8 @@ msgstr ""
 #: data/org.gnome.software.gschema.xml:69
 msgid ""
 "Choosing a larger value will mean less round-trips to the remote server but "
-"updates to the screenshots may take longer to show to the user. A value of 0"
-" means to never check the server if the image already exists in the cache."
+"updates to the screenshots may take longer to show to the user. A value of 0 "
+"means to never check the server if the image already exists in the cache."
 msgstr ""
 
 #: data/org.gnome.software.gschema.xml:78
@@ -193,13 +194,11 @@ msgstr ""
 
 #: data/org.gnome.software.gschema.xml:95
 msgid ""
-"The licence URL to use when an application should be considered free "
-"software"
+"The licence URL to use when an application should be considered free software"
 msgstr ""
 
 #: data/org.gnome.software.gschema.xml:99
-msgid ""
-"Install bundled applications for all users on the system where possible"
+msgid "Install bundled applications for all users on the system where possible"
 msgstr ""
 
 #: data/org.gnome.software.gschema.xml:103
@@ -266,8 +265,7 @@ msgstr ""
 msgid "Install selected software on the system"
 msgstr ""
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 #: src/gnome-software-local-file.desktop.in:10
 msgid "system-software-install"
 msgstr ""
@@ -294,14 +292,12 @@ msgstr ""
 msgid "_All"
 msgstr ""
 
-#. Translators: A label for a button to show only software which is already
-#. installed.
+#. Translators: A label for a button to show only software which is already installed.
 #: src/gnome-software.ui:104
 msgid "_Installed"
 msgstr ""
 
-#. Translators: A label for a button to show only updates which are available
-#. to install.
+#. Translators: A label for a button to show only updates which are available to install.
 #: src/gnome-software.ui:155
 msgid "_Updates"
 msgstr ""
@@ -349,7 +345,7 @@ msgstr ""
 
 #. TRANSLATORS: this is a button next to the search results that
 #. * shows the status of an application being installed
-#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:443
+#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:439
 msgid "Installing"
 msgstr ""
 
@@ -364,7 +360,7 @@ msgid "Folder Name"
 msgstr ""
 
 #: src/gs-app-folder-dialog.c:321 src/gs-app-folder-dialog.ui:16
-#: src/gs-details-page.c:383 src/gs-details-page.ui:342 src/gs-editor.c:623
+#: src/gs-details-page.c:379 src/gs-details-page.ui:342 src/gs-editor.c:623
 #: src/gs-editor.c:655 src/gs-installed-page.c:609 src/gs-removal-dialog.ui:33
 #: src/gs-review-dialog.ui:23 src/gs-upgrade-banner.ui:131
 msgid "_Cancel"
@@ -379,90 +375,90 @@ msgid "Add to Application Folder"
 msgstr ""
 
 #. TRANSLATORS: this is a command line option
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "Start up mode: either ‘updates’, ‘updated’, ‘installed’ or ‘overview’"
 msgstr ""
 
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "MODE"
 msgstr ""
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "Search for applications"
 msgstr ""
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "SEARCH"
 msgstr ""
 
-#: src/gs-application.c:105
+#: src/gs-application.c:133
 msgid "Show application details (using application ID)"
 msgstr ""
 
-#: src/gs-application.c:105 src/gs-application.c:109
+#: src/gs-application.c:133 src/gs-application.c:137
 msgid "ID"
 msgstr ""
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "Show application details (using package name)"
 msgstr ""
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "PKGNAME"
 msgstr ""
 
-#: src/gs-application.c:109
+#: src/gs-application.c:137
 msgid "Install the application (using application ID)"
 msgstr ""
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "Open a local package file"
 msgstr ""
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "FILENAME"
 msgstr ""
 
-#: src/gs-application.c:113
+#: src/gs-application.c:141
 msgid ""
 "The kind of interaction expected for this action: either ‘none’, ‘notify’, "
 "or ‘full’"
 msgstr ""
 
-#: src/gs-application.c:116
+#: src/gs-application.c:144
 msgid "Show verbose debugging information"
 msgstr ""
 
-#: src/gs-application.c:118
+#: src/gs-application.c:146
 msgid "Show profiling information for the service"
 msgstr ""
 
-#: src/gs-application.c:120
+#: src/gs-application.c:148
 msgid "Quit the running instance"
 msgstr ""
 
-#: src/gs-application.c:122
+#: src/gs-application.c:150
 msgid "Prefer local file sources to AppStream"
 msgstr ""
 
-#: src/gs-application.c:124
+#: src/gs-application.c:152
 msgid "Show version number"
 msgstr ""
 
-#: src/gs-application.c:325
+#: src/gs-application.c:358
 msgid "translator-credits"
 msgstr ""
 
 #. TRANSLATORS: this is the title of the about window, e.g.
 #. * 'About Software' or 'About Application Installer' where the %s is
 #. * the application name chosen by the distro
-#: src/gs-application.c:332
+#: src/gs-application.c:365
 #, c-format
 msgid "About %s"
 msgstr ""
 
 #. TRANSLATORS: well, we seem to think so, anyway
-#: src/gs-application.c:336
+#: src/gs-application.c:369
 msgid "A nice way to manage the software on your system."
 msgstr ""
 
@@ -577,7 +573,7 @@ msgid "All"
 msgstr ""
 
 #. TRANSLATORS: this is a subcategory of featured apps
-#: lib/gs-category.c:202 src/gs-shell.c:2180
+#: lib/gs-category.c:202 src/gs-shell.c:2181
 msgid "Featured"
 msgstr ""
 
@@ -587,8 +583,8 @@ msgstr ""
 
 #: src/gs-category-page.ui:110
 msgid ""
-"Extensions are used at your own risk. If you have any system problems, it is"
-" recommended to disable them."
+"Extensions are used at your own risk. If you have any system problems, it is "
+"recommended to disable them."
 msgstr ""
 
 #. TRANSLATORS: the user isn't reading the question
@@ -645,12 +641,12 @@ msgstr ""
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
 #. * 2. Software source name, e.g. fedora-optional
+#.
 #: src/gs-common.c:232
 #, c-format
 msgid ""
 "%s is not <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
-"source_software\">free and open source software</a>, and is provided by "
-"“%s”."
+"source_software\">free and open source software</a>, and is provided by “%s”."
 msgstr ""
 
 #. TRANSLATORS: the replacements are as follows:
@@ -1033,14 +1029,12 @@ msgstr ""
 msgid "Sharing physical location to other users"
 msgstr ""
 
-#. TRANSLATORS: this is a what we use in notifications if the app's name is
-#. unknown
+#. TRANSLATORS: this is a what we use in notifications if the app's name is unknown
 #: src/gs-dbus-helper.c:294
 msgid "An application"
 msgstr ""
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. MIME types.
+#. TRANSLATORS: this is a notification displayed when an app needs additional MIME types.
 #: src/gs-dbus-helper.c:300
 #, c-format
 msgid "%s is requesting additional file format support."
@@ -1051,8 +1045,7 @@ msgstr ""
 msgid "Additional MIME Types Required"
 msgstr ""
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. fonts.
+#. TRANSLATORS: this is a notification displayed when an app needs additional fonts.
 #: src/gs-dbus-helper.c:306
 #, c-format
 msgid "%s is requesting additional fonts."
@@ -1063,8 +1056,7 @@ msgstr ""
 msgid "Additional Fonts Required"
 msgstr ""
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. codecs.
+#. TRANSLATORS: this is a notification displayed when an app needs additional codecs.
 #: src/gs-dbus-helper.c:312
 #, c-format
 msgid "%s is requesting additional multimedia codecs."
@@ -1075,8 +1067,7 @@ msgstr ""
 msgid "Additional Multimedia Codecs Required"
 msgstr ""
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. printer drivers.
+#. TRANSLATORS: this is a notification displayed when an app needs additional printer drivers.
 #: src/gs-dbus-helper.c:318
 #, c-format
 msgid "%s is requesting additional printer drivers."
@@ -1087,8 +1078,7 @@ msgstr ""
 msgid "Additional Printer Drivers Required"
 msgstr ""
 
-#. TRANSLATORS: this is a notification displayed when an app wants to install
-#. additional packages.
+#. TRANSLATORS: this is a notification displayed when an app wants to install additional packages.
 #: src/gs-dbus-helper.c:324
 #, c-format
 msgid "%s is requesting additional packages."
@@ -1108,14 +1098,14 @@ msgstr ""
 #. * can be installed
 #. TRANSLATORS: button text in the header when firmware
 #. * can be live-installed
-#: src/gs-details-page.c:281 src/gs-details-page.c:312
-#: src/gs-details-page.ui:206 src/gs-upgrade-banner.ui:146
+#: src/gs-details-page.c:280 src/gs-details-page.c:310
+#: src/gs-details-page.ui:237 src/gs-upgrade-banner.ui:146
 msgid "_Install"
 msgstr ""
 
 #. TRANSLATORS: button text in the header when an application
 #. * can be live-updated
-#: src/gs-details-page.c:316
+#: src/gs-details-page.c:314
 msgid "_Update"
 msgstr ""
 
@@ -1123,67 +1113,67 @@ msgstr ""
 #. * be installed.
 #. * The ellipsis indicates that further steps are required,
 #. * e.g. enabling software sources or the like
-#: src/gs-details-page.c:330
+#: src/gs-details-page.c:326
 msgid "_Install…"
 msgstr ""
 
 #. TRANSLATORS: button text in the header when an application can be erased
-#: src/gs-details-page.c:377 src/gs-details-page.ui:547
+#: src/gs-details-page.c:373 src/gs-details-page.ui:547
 msgid "_Uninstall"
 msgstr ""
 
-#: src/gs-details-page.c:438 src/gs-sources-dialog.c:513
+#: src/gs-details-page.c:434 src/gs-sources-dialog.c:513
 msgid "Removing…"
 msgstr ""
 
 #. TRANSLATORS: this is the warning box
-#: src/gs-details-page.c:748
+#: src/gs-details-page.c:744
 msgid ""
 "This application can only be used when there is an active internet "
 "connection."
 msgstr ""
 
 #. TRANSLATORS: this is where the version is not known
-#: src/gs-details-page.c:892
+#: src/gs-details-page.c:888
 msgctxt "version"
 msgid "Unknown"
 msgstr ""
 
 #. TRANSLATORS: this is where we don't know the origin of the
 #. * application
-#: src/gs-details-page.c:971
+#: src/gs-details-page.c:967
 msgctxt "origin"
 msgid "Unknown"
 msgstr ""
 
 #. TRANSLATORS: we need a remote server to process
-#: src/gs-details-page.c:1378
+#: src/gs-details-page.c:1374
 msgid "You need internet access to write a review"
 msgstr ""
 
-#: src/gs-details-page.c:1507
+#: src/gs-details-page.c:1503
 #, c-format
 msgid "Unable to find “%s”"
 msgstr ""
 
 #. TRANSLATORS: see the wikipedia page
-#: src/gs-details-page.c:2087
+#: src/gs-details-page.c:2083
 msgid "Public domain"
 msgstr ""
 
 #. TRANSLATORS: see GNU page
-#: src/gs-details-page.c:2103 src/gs-details-page.ui:1397
+#: src/gs-details-page.c:2099 src/gs-details-page.ui:1397
 msgid "Free Software"
 msgstr ""
 
 #. TRANSLATORS: for the free software popover
-#: src/gs-details-page.c:2160
+#: src/gs-details-page.c:2156
 msgid "Users are bound by the following license:"
 msgid_plural "Users are bound by the following licenses:"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/gs-details-page.c:2176 src/gs-details-page.ui:1506
+#: src/gs-details-page.c:2172 src/gs-details-page.ui:1506
 msgid "More information"
 msgstr ""
 
@@ -1191,15 +1181,13 @@ msgstr ""
 msgid "Details page"
 msgstr ""
 
-#. Translators: A label for a button to add a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:228
+#. Translators: A label for a button to add a shortcut to the selected application.
+#: src/gs-details-page.ui:209
 msgid "_Add to Desktop"
 msgstr ""
 
-#. Translators: A label for a button to remove a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:245
+#. Translators: A label for a button to remove a shortcut to the selected application.
+#: src/gs-details-page.ui:226
 msgid "_Remove from Desktop"
 msgstr ""
 
@@ -1238,8 +1226,7 @@ msgid ""
 "replaced."
 msgstr ""
 
-#. Translators: a repository file used for installing software has been
-#. discovered.
+#. Translators: a repository file used for installing software has been discovered.
 #: src/gs-details-page.ui:528
 msgid "Software Source Identified"
 msgstr ""
@@ -1340,14 +1327,12 @@ msgstr ""
 msgid "Selected add-ons will be installed with the application."
 msgstr ""
 
-#. Translators: Header of the section with other users' opinions about the
-#. app.
+#. Translators: Header of the section with other users' opinions about the app.
 #: src/gs-details-page.ui:1233
 msgid "Reviews"
 msgstr ""
 
-#. Translators: Button opening a dialog where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Button opening a dialog where the users can write and publish their opinions about the apps.
 #: src/gs-details-page.ui:1249
 msgid "_Write a Review"
 msgstr ""
@@ -1359,8 +1344,8 @@ msgstr ""
 
 #: src/gs-details-page.ui:1414
 msgid ""
-"This means that the software can be freely run, copied, distributed, studied"
-" and modified."
+"This means that the software can be freely run, copied, distributed, studied "
+"and modified."
 msgstr ""
 
 #: src/gs-details-page.ui:1473
@@ -1456,8 +1441,7 @@ msgstr ""
 msgid "Use verbose logging"
 msgstr ""
 
-#. TRANSLATORS: program name, an application to add and remove software
-#. repositories
+#. TRANSLATORS: program name, an application to add and remove software repositories
 #: src/gs-editor.c:1119
 msgid "GNOME Software Banner Designer"
 msgstr ""
@@ -1486,8 +1470,7 @@ msgstr ""
 msgid "Editor’s Pick"
 msgstr ""
 
-#. This check button controls whether the application’s banner appears in the
-#. “Featured” category
+#. This check button controls whether the application’s banner appears in the “Featured” category
 #: src/gs-editor.ui:397
 msgid "Category Featured"
 msgstr ""
@@ -1576,8 +1559,8 @@ msgstr ""
 #: src/gs-extras-page.c:337 src/gs-extras-page.c:348 src/gs-extras-page.c:359
 #, c-format
 msgid ""
-"Information about %s, as well as options for how to get missing applications"
-" might be found %s."
+"Information about %s, as well as options for how to get missing applications "
+"might be found %s."
 msgstr ""
 
 #. TRANSLATORS: this is when we know about an application or
@@ -1621,7 +1604,7 @@ msgstr ""
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
-#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1426
+#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1430
 #, c-format
 msgid "No addon codecs are available for the %s format."
 msgstr ""
@@ -1672,8 +1655,7 @@ msgstr ""
 msgid "this website"
 msgstr ""
 
-#. TRANSLATORS: no codecs were found. First %s will be replaced by actual
-#. codec name(s), second %s is a link titled "this website"
+#. TRANSLATORS: no codecs were found. First %s will be replaced by actual codec name(s), second %s is a link titled "this website"
 #: src/gs-extras-page.c:463
 #, c-format
 msgid ""
@@ -1708,8 +1690,8 @@ msgstr ""
 
 #: src/gs-first-run-dialog.ui:66
 msgid ""
-"Software lets you install all the software you need, all from one place. See"
-" our recommendations, browse the categories, or search for the applications "
+"Software lets you install all the software you need, all from one place. See "
+"our recommendations, browse the categories, or search for the applications "
 "you want."
 msgstr ""
 
@@ -1865,8 +1847,7 @@ msgstr ""
 
 #. TRANSLATORS: this is the proprietary info bar
 #: src/gs-overview-page.c:978
-msgid ""
-"Proprietary software has restrictions on use and access to source code."
+msgid "Proprietary software has restrictions on use and access to source code."
 msgstr ""
 
 #. TRANSLATORS: this is the clickable
@@ -1896,14 +1877,12 @@ msgstr ""
 msgid "Categories"
 msgstr ""
 
-#. Translators: This is a heading for software which has been featured
-#. ('picked') by the distribution.
+#. Translators: This is a heading for software which has been featured ('picked') by the distribution.
 #: src/gs-overview-page.ui:315
 msgid "Editor’s Picks"
 msgstr ""
 
-#. Translators: This is a heading for software which has been recently
-#. released upstream.
+#. Translators: This is a heading for software which has been recently released upstream.
 #: src/gs-overview-page.ui:359
 msgid "Recent Releases"
 msgstr ""
@@ -1965,7 +1944,7 @@ msgstr ""
 msgid "%s will be removed, and you will have to install it to use it again."
 msgstr ""
 
-#: lib/gs-plugin-loader.c:1429
+#: lib/gs-plugin-loader.c:1433
 #, c-format
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
@@ -2099,8 +2078,7 @@ msgstr ""
 msgid "The description is too long"
 msgstr ""
 
-#. Translators: Title of the dialog box where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Title of the dialog box where the users can write and publish their opinions about the apps.
 #: src/gs-review-dialog.ui:11
 msgid "Post Review"
 msgstr ""
@@ -2160,8 +2138,7 @@ msgstr ""
 msgid "Report"
 msgstr ""
 
-#. Translators: Users can express their opinions about other users' opinions
-#. about the apps.
+#. Translators: Users can express their opinions about other users' opinions about the apps.
 #: src/gs-review-row.ui:112
 msgid "Was this review useful to you?"
 msgstr ""
@@ -2250,81 +2227,80 @@ msgstr ""
 #. TRANSLATORS: this is part of the in-app notification,
 #. * where the %s is a multi-word localised app name
 #. * e.g. 'Getting things GNOME!"
-#: src/gs-shell.c:846 src/gs-shell.c:851 src/gs-shell.c:866 src/gs-shell.c:870
+#: src/gs-shell.c:847 src/gs-shell.c:852 src/gs-shell.c:867 src/gs-shell.c:871
 #, c-format
 msgid "“%s”"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:898
+#: src/gs-shell.c:899
 #, c-format
 msgid "Unable to download firmware updates from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:904
+#: src/gs-shell.c:905
 #, c-format
 msgid "Unable to download updates from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:911
+#: src/gs-shell.c:912
 msgid "Unable to download updates"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:916
+#: src/gs-shell.c:917
 msgid ""
-"Unable to download updates: internet access was required but wasn’t "
-"available"
+"Unable to download updates: internet access was required but wasn’t available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:925
+#: src/gs-shell.c:926
 #, c-format
 msgid "Unable to download updates from %s: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:930
+#: src/gs-shell.c:931
 msgid "Unable to download updates: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:938
+#: src/gs-shell.c:939
 msgid "Unable to download updates: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:943
+#: src/gs-shell.c:944
 msgid "Unable to download updates: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:948
+#: src/gs-shell.c:949
 msgid ""
 "Unable to download updates: you do not have permission to install software"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:955
+#: src/gs-shell.c:956
 msgid "Unable to get list of updates"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the application name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1001
+#: src/gs-shell.c:1002
 #, c-format
 msgid "Unable to install %s as download failed from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1007
+#: src/gs-shell.c:1008
 #, c-format
 msgid "Unable to install %s as download failed"
 msgstr ""
@@ -2333,51 +2309,51 @@ msgstr ""
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1019
+#: src/gs-shell.c:1020
 #, c-format
 msgid "Unable to install %s as runtime %s not available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1025
+#: src/gs-shell.c:1026
 #, c-format
 msgid "Unable to install %s as not supported"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1032
+#: src/gs-shell.c:1033
 msgid "Unable to install: internet access was required but wasn’t available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1038
+#: src/gs-shell.c:1039
 msgid "Unable to install: the application has an invalid format"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1043
+#: src/gs-shell.c:1044
 #, c-format
 msgid "Unable to install %s: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1051
+#: src/gs-shell.c:1052
 #, c-format
 msgid "Unable to install %s: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1058
+#: src/gs-shell.c:1059
 #, c-format
 msgid "Unable to install %s: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1065
+#: src/gs-shell.c:1066
 #, c-format
 msgid "Unable to install %s: you do not have permission to install software"
 msgstr ""
@@ -2385,34 +2361,34 @@ msgstr ""
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the name of the authentication service,
 #. * e.g. "Ubuntu One"
-#: src/gs-shell.c:1078
+#: src/gs-shell.c:1079
 #, c-format
 msgid "Your %s account has been suspended."
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1082
+#: src/gs-shell.c:1083
 msgid "It is not possible to install software until this has been resolved."
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the clickable link (e.g.
 #. * "http://example.com/what-did-i-do-wrong/")
-#: src/gs-shell.c:1093
+#: src/gs-shell.c:1094
 #, c-format
 msgid "For more information, visit %s."
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1102
+#: src/gs-shell.c:1103
 #, c-format
 msgid "Unable to install %s: AC power is required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1111
+#: src/gs-shell.c:1112
 #, c-format
 msgid "Unable to install %s"
 msgstr ""
@@ -2421,61 +2397,61 @@ msgstr ""
 #. * where the first %s is the app name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1157
+#: src/gs-shell.c:1158
 #, c-format
 msgid "Unable to update %s from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1163
+#: src/gs-shell.c:1164
 #, c-format
 msgid "Unable to update %s as download failed"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1169
+#: src/gs-shell.c:1170
 msgid "Unable to update: internet access was required but wasn’t available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1177
+#: src/gs-shell.c:1178
 #, c-format
 msgid "Unable to update %s: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1186
+#: src/gs-shell.c:1187
 #, c-format
 msgid "Unable to update %s: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1193
+#: src/gs-shell.c:1194
 #, c-format
 msgid "Unable to update %s: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1200
+#: src/gs-shell.c:1201
 #, c-format
 msgid "Unable to update %s: you do not have permission to update software"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1208
+#: src/gs-shell.c:1209
 #, c-format
 msgid "Unable to update %s: AC power is required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1217
+#: src/gs-shell.c:1218
 #, c-format
 msgid "Unable to update %s"
 msgstr ""
@@ -2483,96 +2459,96 @@ msgstr ""
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the distro name (e.g. "Fedora 25") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1262
+#: src/gs-shell.c:1263
 #, c-format
 msgid "Unable to upgrade to %s from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the app name (e.g. "GIMP")
-#: src/gs-shell.c:1267
+#: src/gs-shell.c:1268
 #, c-format
 msgid "Unable to upgrade to %s as download failed"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1274
+#: src/gs-shell.c:1275
 msgid "Unable to upgrade: internet access was required but wasn’t available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1282
+#: src/gs-shell.c:1283
 #, c-format
 msgid "Unable to upgrade to %s: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1291
+#: src/gs-shell.c:1292
 #, c-format
 msgid "Unable to upgrade to %s: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1298
+#: src/gs-shell.c:1299
 #, c-format
 msgid "Unable to upgrade to %s: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1305
+#: src/gs-shell.c:1306
 #, c-format
 msgid "Unable to upgrade to %s: you do not have permission to upgrade"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1312
+#: src/gs-shell.c:1313
 #, c-format
 msgid "Unable to upgrade to %s: AC power is required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1321
+#: src/gs-shell.c:1322
 #, c-format
 msgid "Unable to upgrade to %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1363
+#: src/gs-shell.c:1364
 #, c-format
 msgid "Unable to remove %s: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1369
+#: src/gs-shell.c:1370
 #, c-format
 msgid "Unable to remove %s: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1375
+#: src/gs-shell.c:1376
 #, c-format
 msgid "Unable to remove %s: you do not have permission to remove software"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1382
+#: src/gs-shell.c:1383
 #, c-format
 msgid "Unable to remove %s: AC power is required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1391
+#: src/gs-shell.c:1392
 #, c-format
 msgid "Unable to remove %s"
 msgstr ""
@@ -2581,48 +2557,48 @@ msgstr ""
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1437
+#: src/gs-shell.c:1438
 #, c-format
 msgid "Unable to launch %s: %s is not installed"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1444 src/gs-shell.c:1492 src/gs-shell.c:1540
+#: src/gs-shell.c:1445 src/gs-shell.c:1493 src/gs-shell.c:1541
 msgid "Not enough disk space — free up some space and try again"
 msgstr ""
 
 #. TRANSLATORS: we failed to get a proper error code
-#: src/gs-shell.c:1452 src/gs-shell.c:1500 src/gs-shell.c:1567
+#: src/gs-shell.c:1453 src/gs-shell.c:1501 src/gs-shell.c:1568
 msgid "Sorry, something went wrong"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1487
+#: src/gs-shell.c:1488
 msgid "Failed to install file: authentication failed"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1534
+#: src/gs-shell.c:1535
 #, c-format
 msgid "Unable to contact %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1549
+#: src/gs-shell.c:1550
 #, c-format
 msgid "%s needs to be restarted to use new plugins."
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1554
+#: src/gs-shell.c:1555
 msgid "This application needs to be restarted to use new plugins."
 msgstr ""
 
 #. TRANSLATORS: need to be connected to the AC power
-#: src/gs-shell.c:1561
+#: src/gs-shell.c:1562
 msgid "AC power is required"
 msgstr ""
 
@@ -2916,8 +2892,8 @@ msgstr ""
 #. * something with no network available
 #: src/gs-update-monitor.c:714
 msgid ""
-"Internet access was required but wasn’t available. Please make sure that you"
-" have internet access and try again."
+"Internet access was required but wasn’t available. Please make sure that you "
+"have internet access and try again."
 msgstr ""
 
 #. TRANSLATORS: if the package is not signed correctly
@@ -3222,21 +3198,24 @@ msgid "App Center"
 msgstr ""
 
 #: src/org.gnome.Software.desktop.in:4
+msgid "More Apps"
+msgstr "अधिक ऍप्स"
+
+#: src/org.gnome.Software.desktop.in:5
 msgid "Add, remove or update software on this computer"
 msgstr ""
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
-#: src/org.gnome.Software.desktop.in:6
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: src/org.gnome.Software.desktop.in:7
 #: src/org.gnome.Software.Editor.desktop.in:6
 msgid "org.gnome.Software"
 msgstr ""
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
-#: src/org.gnome.Software.desktop.in:12
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: src/org.gnome.Software.desktop.in:13
 msgid ""
-"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;"
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;"
 msgstr ""
 
 #: src/org.gnome.Software.Editor.desktop.in:3
@@ -3247,8 +3226,7 @@ msgstr ""
 msgid "Design the featured banners for GNOME Software"
 msgstr ""
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: src/org.gnome.Software.Editor.desktop.in:13
 msgid "AppStream;Software;App;"
 msgstr ""
@@ -3518,100 +3496,110 @@ msgctxt "Menu of Communication & News"
 msgid "Web Browsers"
 msgstr ""
 
-#: plugins/core/gs-desktop-common.c:247
-msgctxt "Menu of Reference"
-msgid "All"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:250
-msgctxt "Menu of Reference"
-msgid "Featured"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:253
-msgctxt "Menu of Reference"
-msgid "Art"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:256
-msgctxt "Menu of Reference"
-msgid "Biography"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:259
-msgctxt "Menu of Reference"
-msgid "Comics"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:262
-msgctxt "Menu of Reference"
-msgid "Fiction"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:265
-msgctxt "Menu of Reference"
-msgid "Health"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:268
-msgctxt "Menu of Reference"
-msgid "History"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:271
-msgctxt "Menu of Reference"
-msgid "Lifestyle"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:274
+#: plugins/core/gs-desktop-common.c:242
 msgctxt "Menu of Communication & News"
 msgid "News"
 msgstr ""
 
+#: plugins/core/gs-desktop-common.c:251
+msgctxt "Menu of Reference"
+msgid "All"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:254
+msgctxt "Menu of Reference"
+msgid "Featured"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:257
+msgctxt "Menu of Reference"
+msgid "Art"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:260
+msgctxt "Menu of Reference"
+msgid "Biography"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:263
+msgctxt "Menu of Reference"
+msgid "Comics"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:266
+msgctxt "Menu of Reference"
+msgid "Feed"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:269
+msgctxt "Menu of Reference"
+msgid "Fiction"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:272
+msgctxt "Menu of Reference"
+msgid "Health"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:275
+msgctxt "Menu of Reference"
+msgid "History"
+msgstr ""
+
 #: plugins/core/gs-desktop-common.c:278
+msgctxt "Menu of Reference"
+msgid "Lifestyle"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:281
+msgctxt "Menu of Reference"
+msgid "News"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:284
 msgctxt "Menu of Reference"
 msgid "Politics"
 msgstr ""
 
-#: plugins/core/gs-desktop-common.c:281
+#: plugins/core/gs-desktop-common.c:287
 msgctxt "Menu of Reference"
 msgid "Sports"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Learning
-#: plugins/core/gs-desktop-common.c:291
+#: plugins/core/gs-desktop-common.c:297
 msgid "Learning"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Game
-#: plugins/core/gs-desktop-common.c:294
+#: plugins/core/gs-desktop-common.c:300
 msgid "Games"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Multimedia
-#: plugins/core/gs-desktop-common.c:297
+#: plugins/core/gs-desktop-common.c:303
 msgid "Multimedia"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Work
-#: plugins/core/gs-desktop-common.c:300
+#: plugins/core/gs-desktop-common.c:306
 msgid "Work"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Reference
-#: plugins/core/gs-desktop-common.c:303
+#: plugins/core/gs-desktop-common.c:309
 msgid "Reference & News"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Utilities
-#: plugins/core/gs-desktop-common.c:306
+#: plugins/core/gs-desktop-common.c:312
 msgid "Utilities"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Dev Tools; it
 #. * should be a relatively short label; as an example, in Portuguese and
 #. * Spanish the direct translation of "Programming" (noun) is used
-#: plugins/core/gs-desktop-common.c:311
+#: plugins/core/gs-desktop-common.c:317
 msgid "Dev Tools"
 msgstr ""
 
@@ -3637,16 +3625,16 @@ msgstr ""
 msgid "Downloading featured images…"
 msgstr ""
 
-#: plugins/eos/gs-plugin-eos.c:1249
+#: plugins/eos/gs-plugin-eos.c:1233
 #, c-format
 msgid "Could not launch this application."
 msgstr ""
 
-#: plugins/eos/gs-plugin-eos.c:1305
+#: plugins/eos/gs-plugin-eos.c:1289
 msgid "Endless Platform"
 msgstr ""
 
-#: plugins/eos/gs-plugin-eos.c:1308
+#: plugins/eos/gs-plugin-eos.c:1292
 msgid "Framework for applications"
 msgstr ""
 
@@ -3706,13 +3694,13 @@ msgid "Flatpak is a framework for desktop applications on Linux"
 msgstr ""
 
 #. TRANSLATORS: status text when downloading new metadata
-#: plugins/flatpak/gs-flatpak.c:821
+#: plugins/flatpak/gs-flatpak.c:815
 #, c-format
 msgid "Getting flatpak metadata for %s…"
 msgstr ""
 
 #. TRANSLATORS: status text when downloading the RuntimeRepo
-#: plugins/flatpak/gs-flatpak.c:2796
+#: plugins/flatpak/gs-flatpak.c:2803
 msgid "Getting runtime source…"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the gnome-software package.
-# 
+#
 # Translators:
 # Pedro Albuquerque <palbuquerque73@gmail.com>, 2015
 # Sérgio Cardeira <scardeira.sergio@gmail.com>, 2016
@@ -9,14 +9,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-software\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-12 22:31-0700\n"
+"POT-Creation-Date: 2017-11-02 16:28+0100\n"
 "PO-Revision-Date: 2017-10-13 05:52+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
-"Language-Team: Portuguese (http://www.transifex.com/endless-mobile-inc/gnome-software/language/pt/)\n"
+"Language-Team: Portuguese (http://www.transifex.com/endless-mobile-inc/gnome-"
+"software/language/pt/)\n"
+"Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pt\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:7
@@ -31,7 +32,9 @@ msgstr "Gestor de aplicações para o GNOME"
 msgid ""
 "Software allows you to find and install new applications and system "
 "extensions and remove existing installed applications."
-msgstr "A aplicação Aplicações permite encontrar e instalar novas aplicações e extensões do sistema, além de remover aplicações já instaladas."
+msgstr ""
+"A aplicação Aplicações permite encontrar e instalar novas aplicações e "
+"extensões do sistema, além de remover aplicações já instaladas."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:14
 msgid ""
@@ -39,7 +42,12 @@ msgid ""
 "descriptions and multiple screenshots per application. Applications can be "
 "found either through browsing the list of categories or by searching. It "
 "also allows you to update your system using an offline update."
-msgstr "O Aplicações GNOME apresenta aplicações populares em destaque com descrições úteis e múltiplas capturas de ecrã por aplicação. Aplicações podem ser encontradas tanto navegando a lista de categorias com procurando. Também permite que atualize o seu sistema utilizando uma atualização sem estar ligado à Internet."
+msgstr ""
+"O Aplicações GNOME apresenta aplicações populares em destaque com descrições "
+"úteis e múltiplas capturas de ecrã por aplicação. Aplicações podem ser "
+"encontradas tanto navegando a lista de categorias com procurando. Também "
+"permite que atualize o seu sistema utilizando uma atualização sem estar "
+"ligado à Internet."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:25
 msgid "Overview panel"
@@ -73,7 +81,9 @@ msgstr "Lista de projetos compatíveis"
 msgid ""
 "This is a list of compatible projects we should show such as GNOME, KDE and "
 "XFCE."
-msgstr "Esta é uma lista de projetos compatíveis que deverão aparecer como GNOME, KDE e XFCE"
+msgstr ""
+"Esta é uma lista de projetos compatíveis que deverão aparecer como GNOME, "
+"KDE e XFCE"
 
 #: data/org.gnome.software.gschema.xml:10
 msgid "Whether to manage updates in GNOME Software"
@@ -91,9 +101,11 @@ msgstr "Se são transferidas atualizações automaticamente"
 
 #: data/org.gnome.software.gschema.xml:16
 msgid ""
-"If enabled, GNOME Software automatically downloads updates in the background"
-" and prompts the user to install them when ready."
-msgstr "Se ligado, Aplicações GNOME faz a descarga automática das atualizações e informa ao utilizador quando estiverem prontas."
+"If enabled, GNOME Software automatically downloads updates in the background "
+"and prompts the user to install them when ready."
+msgstr ""
+"Se ligado, Aplicações GNOME faz a descarga automática das atualizações e "
+"informa ao utilizador quando estiverem prontas."
 
 #: data/org.gnome.software.gschema.xml:20
 msgid "Whether to automatically refresh when on a metered connection"
@@ -124,9 +136,11 @@ msgstr "Aplicações não livres mostram um aviso antes de serem instaladas"
 
 #: data/org.gnome.software.gschema.xml:38
 msgid ""
-"When non-free applications are installed a warning dialog can be shown. This"
-" controls if that dialog is suppressed."
-msgstr "Quando aplicações não livres são instaladas um aviso é mostrado. Isto controla se o aviso é suprimido."
+"When non-free applications are installed a warning dialog can be shown. This "
+"controls if that dialog is suppressed."
+msgstr ""
+"Quando aplicações não livres são instaladas um aviso é mostrado. Isto "
+"controla se o aviso é suprimido."
 
 #: data/org.gnome.software.gschema.xml:42
 msgid "A list of popular applications"
@@ -134,7 +148,9 @@ msgstr "Lista de aplicações populares"
 
 #: data/org.gnome.software.gschema.xml:43
 msgid "A list of applications to use, overriding the system defined ones."
-msgstr "Uma lista de aplicações a serem utilizadas. Substituí as predefinidas pelo sistema."
+msgstr ""
+"Uma lista de aplicações a serem utilizadas. Substituí as predefinidas pelo "
+"sistema."
 
 #: data/org.gnome.software.gschema.xml:47
 msgid "The list of extra sources that have been previously enabled"
@@ -144,7 +160,9 @@ msgstr "Listas de fontes que foram ativadas anteriormente"
 msgid ""
 "The list of sources that have been previously enabled when installing third-"
 "party applications."
-msgstr "Lista de fontes que tenham sido ativadas quando são instaladas aplicações de terceiros."
+msgstr ""
+"Lista de fontes que tenham sido ativadas quando são instaladas aplicações de "
+"terceiros."
 
 #: data/org.gnome.software.gschema.xml:52
 msgid "The last update check timestamp"
@@ -156,7 +174,9 @@ msgstr ""
 
 #: data/org.gnome.software.gschema.xml:60
 msgid "The timestamp of the first security update, cleared after update"
-msgstr "A data e hora da primeira atualização de segurança, limpo depois da atualização"
+msgstr ""
+"A data e hora da primeira atualização de segurança, limpo depois da "
+"atualização"
 
 #: data/org.gnome.software.gschema.xml:64
 msgid "The last update timestamp"
@@ -169,8 +189,8 @@ msgstr ""
 #: data/org.gnome.software.gschema.xml:69
 msgid ""
 "Choosing a larger value will mean less round-trips to the remote server but "
-"updates to the screenshots may take longer to show to the user. A value of 0"
-" means to never check the server if the image already exists in the cache."
+"updates to the screenshots may take longer to show to the user. A value of 0 "
+"means to never check the server if the image already exists in the cache."
 msgstr ""
 
 #: data/org.gnome.software.gschema.xml:78
@@ -187,22 +207,27 @@ msgstr "Análises com karma menor que este número não serão mostradas."
 
 #: data/org.gnome.software.gschema.xml:87
 msgid "A list of official sources that should not be considered 3rd party"
-msgstr "Uma lista oficial de fontes que não deverão ser consideradas como de terceiros"
+msgstr ""
+"Uma lista oficial de fontes que não deverão ser consideradas como de "
+"terceiros"
 
 #: data/org.gnome.software.gschema.xml:91
 msgid "A list of official sources that should be considered free software"
-msgstr "Uma lista oficial de fontes que deverão ser consideradas como software livre"
+msgstr ""
+"Uma lista oficial de fontes que deverão ser consideradas como software livre"
 
 #: data/org.gnome.software.gschema.xml:95
 msgid ""
-"The licence URL to use when an application should be considered free "
-"software"
-msgstr "O URL da licença a ser utilizado quando uma aplicação deve ser considerada como software livre"
+"The licence URL to use when an application should be considered free software"
+msgstr ""
+"O URL da licença a ser utilizado quando uma aplicação deve ser considerada "
+"como software livre"
 
 #: data/org.gnome.software.gschema.xml:99
-msgid ""
-"Install bundled applications for all users on the system where possible"
-msgstr "Instalar aplicações associadas em todos os utilizadores do sistema sempre que possível."
+msgid "Install bundled applications for all users on the system where possible"
+msgstr ""
+"Instalar aplicações associadas em todos os utilizadores do sistema sempre "
+"que possível."
 
 #: data/org.gnome.software.gschema.xml:103
 msgid "Show the folder management UI"
@@ -218,7 +243,9 @@ msgstr "Oferecer atualizações para pré-lançamentos"
 
 #: data/org.gnome.software.gschema.xml:115
 msgid "Show some UI elements informing the user that an app is non-free"
-msgstr "Mostrar alguns elementos do IU a informar o utilizador que a aplicação não é livre"
+msgstr ""
+"Mostrar alguns elementos do IU a informar o utilizador que a aplicação não é "
+"livre"
 
 #: data/org.gnome.software.gschema.xml:119
 msgid "Show the prompt to install nonfree software sources"
@@ -268,8 +295,7 @@ msgstr "Instalação de aplicações"
 msgid "Install selected software on the system"
 msgstr "Instalar as aplicações selecionadas no seu sistema"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 #: src/gnome-software-local-file.desktop.in:10
 msgid "system-software-install"
 msgstr ""
@@ -296,14 +322,12 @@ msgstr "Recuar"
 msgid "_All"
 msgstr "_Todas"
 
-#. Translators: A label for a button to show only software which is already
-#. installed.
+#. Translators: A label for a button to show only software which is already installed.
 #: src/gnome-software.ui:104
 msgid "_Installed"
 msgstr "_Instaladas"
 
-#. Translators: A label for a button to show only updates which are available
-#. to install.
+#. Translators: A label for a button to show only updates which are available to install.
 #: src/gnome-software.ui:155
 msgid "_Updates"
 msgstr "_Atualizações"
@@ -351,7 +375,7 @@ msgstr "Instalada"
 
 #. TRANSLATORS: this is a button next to the search results that
 #. * shows the status of an application being installed
-#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:443
+#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:439
 msgid "Installing"
 msgstr "A instalar"
 
@@ -366,7 +390,7 @@ msgid "Folder Name"
 msgstr "Nome da pasta"
 
 #: src/gs-app-folder-dialog.c:321 src/gs-app-folder-dialog.ui:16
-#: src/gs-details-page.c:383 src/gs-details-page.ui:342 src/gs-editor.c:623
+#: src/gs-details-page.c:379 src/gs-details-page.ui:342 src/gs-editor.c:623
 #: src/gs-editor.c:655 src/gs-installed-page.c:609 src/gs-removal-dialog.ui:33
 #: src/gs-review-dialog.ui:23 src/gs-upgrade-banner.ui:131
 msgid "_Cancel"
@@ -381,90 +405,95 @@ msgid "Add to Application Folder"
 msgstr "Adicionar à pasta da aplicação"
 
 #. TRANSLATORS: this is a command line option
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "Start up mode: either ‘updates’, ‘updated’, ‘installed’ or ‘overview’"
-msgstr "Modo de inicialização: pode ser \"updates\" (para atualizações), \"updated\" (para atualizados), \"installed\" (para instalados) ou \"overview\" (para visão geral)"
+msgstr ""
+"Modo de inicialização: pode ser \"updates\" (para atualizações), \"updated"
+"\" (para atualizados), \"installed\" (para instalados) ou \"overview\" (para "
+"visão geral)"
 
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "MODE"
 msgstr "MODO"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "Search for applications"
 msgstr "Procurar aplicações"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "SEARCH"
 msgstr "PROCURA"
 
-#: src/gs-application.c:105
+#: src/gs-application.c:133
 msgid "Show application details (using application ID)"
 msgstr "Mostrar detalhes da aplicação (utilizando o ID da aplicação)"
 
-#: src/gs-application.c:105 src/gs-application.c:109
+#: src/gs-application.c:133 src/gs-application.c:137
 msgid "ID"
 msgstr "ID"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "Show application details (using package name)"
 msgstr "Mostrar detalhes da aplicação (utilizando o nome do pacote)"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "PKGNAME"
 msgstr "NOMEPACOTE"
 
-#: src/gs-application.c:109
+#: src/gs-application.c:137
 msgid "Install the application (using application ID)"
 msgstr ""
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "Open a local package file"
 msgstr "Abrir um ficheiro de pacote local"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "FILENAME"
 msgstr "NOMEFICHEIRO"
 
-#: src/gs-application.c:113
+#: src/gs-application.c:141
 msgid ""
 "The kind of interaction expected for this action: either ‘none’, ‘notify’, "
 "or ‘full’"
 msgstr ""
 
-#: src/gs-application.c:116
+#: src/gs-application.c:144
 msgid "Show verbose debugging information"
 msgstr "Mostrar informação de depuração verbosa"
 
-#: src/gs-application.c:118
+#: src/gs-application.c:146
 msgid "Show profiling information for the service"
 msgstr "Mostrar informações de criação de perfil para este serviço"
 
-#: src/gs-application.c:120
+#: src/gs-application.c:148
 msgid "Quit the running instance"
 msgstr "Sair da instância atual"
 
-#: src/gs-application.c:122
+#: src/gs-application.c:150
 msgid "Prefer local file sources to AppStream"
 msgstr "Preferir ficheiros locais de origens à AppStream"
 
-#: src/gs-application.c:124
+#: src/gs-application.c:152
 msgid "Show version number"
 msgstr "Mostrar número da versão"
 
-#: src/gs-application.c:325
+#: src/gs-application.c:358
 msgid "translator-credits"
-msgstr "Tiago S. ,2014\nPedro Albuquerque <palbuquerque73@gmail.com>"
+msgstr ""
+"Tiago S. ,2014\n"
+"Pedro Albuquerque <palbuquerque73@gmail.com>"
 
 #. TRANSLATORS: this is the title of the about window, e.g.
 #. * 'About Software' or 'About Application Installer' where the %s is
 #. * the application name chosen by the distro
-#: src/gs-application.c:332
+#: src/gs-application.c:365
 #, c-format
 msgid "About %s"
 msgstr ""
 
 #. TRANSLATORS: well, we seem to think so, anyway
-#: src/gs-application.c:336
+#: src/gs-application.c:369
 msgid "A nice way to manage the software on your system."
 msgstr "Um modo agradável de gerir as aplicações no seu sistema."
 
@@ -579,7 +608,7 @@ msgid "All"
 msgstr "Todas"
 
 #. TRANSLATORS: this is a subcategory of featured apps
-#: lib/gs-category.c:202 src/gs-shell.c:2180
+#: lib/gs-category.c:202 src/gs-shell.c:2181
 msgid "Featured"
 msgstr "Destaques"
 
@@ -589,9 +618,11 @@ msgstr "Definições da extensão"
 
 #: src/gs-category-page.ui:110
 msgid ""
-"Extensions are used at your own risk. If you have any system problems, it is"
-" recommended to disable them."
-msgstr "Use extensões por sua conta e risco. Se o seu sistema tiver problemas, é recomendado que as desative."
+"Extensions are used at your own risk. If you have any system problems, it is "
+"recommended to disable them."
+msgstr ""
+"Use extensões por sua conta e risco. Se o seu sistema tiver problemas, é "
+"recomendado que as desative."
 
 #. TRANSLATORS: the user isn't reading the question
 #: lib/gs-cmd.c:205
@@ -647,13 +678,16 @@ msgstr "Ativar fontes de aplicações de terceiros?"
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
 #. * 2. Software source name, e.g. fedora-optional
+#.
 #: src/gs-common.c:232
 #, c-format
 msgid ""
 "%s is not <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
-"source_software\">free and open source software</a>, and is provided by "
+"source_software\">free and open source software</a>, and is provided by “%s”."
+msgstr ""
+"%s não é um <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
+"source_software\">programa livre e de código aberto</a>, e é fornecido por "
 "“%s”."
-msgstr "%s não é um <a href=\"https://en.wikipedia.org/wiki/Free_and_open-source_software\">programa livre e de código aberto</a>, e é fornecido por “%s”."
 
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
@@ -666,7 +700,8 @@ msgstr "%s é fornecido por “%s”."
 #. TRANSLATORS: a software source is a repo
 #: src/gs-common.c:252
 msgid "This software source must be enabled to continue installation."
-msgstr "Esta fonte de aplicações tem de ser ativada para continuar a instalação."
+msgstr ""
+"Esta fonte de aplicações tem de ser ativada para continuar a instalação."
 
 #. TRANSLATORS: Laws are geographical, urgh...
 #: src/gs-common.c:262
@@ -728,7 +763,8 @@ msgstr ""
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:90
 msgid "Characters in unsafe situations easily distinguishable from reality"
-msgstr "Personagens em situações inseguras facilmente distinguíveis da realidade"
+msgstr ""
+"Personagens em situações inseguras facilmente distinguíveis da realidade"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:93
@@ -923,7 +959,8 @@ msgstr ""
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:207
 msgid "Explicit discrimination based on gender, sexuality, race or religion"
-msgstr "Descriminação explícita baseada em género, sexualidade, raça ou religião"
+msgstr ""
+"Descriminação explícita baseada em género, sexualidade, raça ou religião"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:210
@@ -988,7 +1025,9 @@ msgstr "Interações de jogo entre jogadores sem funcionalidade de conversação
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:246
 msgid "Player-to-player preset interactions without chat functionality"
-msgstr "Interações entre jogadores com mensagens predefinidas sem funcionalidade de conversação."
+msgstr ""
+"Interações entre jogadores com mensagens predefinidas sem funcionalidade de "
+"conversação."
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:249
@@ -1013,7 +1052,8 @@ msgstr ""
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:261
 msgid "Sharing social network usernames or email addresses"
-msgstr "Partilha de nomes de utilizadores de redes sociais e endereços de email"
+msgstr ""
+"Partilha de nomes de utilizadores de redes sociais e endereços de email"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:264
@@ -1035,14 +1075,12 @@ msgstr ""
 msgid "Sharing physical location to other users"
 msgstr "Partilha de localizações físicas de outros utilizadores"
 
-#. TRANSLATORS: this is a what we use in notifications if the app's name is
-#. unknown
+#. TRANSLATORS: this is a what we use in notifications if the app's name is unknown
 #: src/gs-dbus-helper.c:294
 msgid "An application"
 msgstr "Uma aplicação"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. MIME types.
+#. TRANSLATORS: this is a notification displayed when an app needs additional MIME types.
 #: src/gs-dbus-helper.c:300
 #, c-format
 msgid "%s is requesting additional file format support."
@@ -1053,8 +1091,7 @@ msgstr "%s está a pedir suporte adicional a formato de ficheiro."
 msgid "Additional MIME Types Required"
 msgstr "Tipos MIME adicionais necessários"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. fonts.
+#. TRANSLATORS: this is a notification displayed when an app needs additional fonts.
 #: src/gs-dbus-helper.c:306
 #, c-format
 msgid "%s is requesting additional fonts."
@@ -1065,8 +1102,7 @@ msgstr "%s está a pedir letras adicionais."
 msgid "Additional Fonts Required"
 msgstr "Letras adicionais necessárias"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. codecs.
+#. TRANSLATORS: this is a notification displayed when an app needs additional codecs.
 #: src/gs-dbus-helper.c:312
 #, c-format
 msgid "%s is requesting additional multimedia codecs."
@@ -1077,8 +1113,7 @@ msgstr "%s está a pedir codecs multimédia adicionais."
 msgid "Additional Multimedia Codecs Required"
 msgstr "Codecs multimédia adicionais necessários"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. printer drivers.
+#. TRANSLATORS: this is a notification displayed when an app needs additional printer drivers.
 #: src/gs-dbus-helper.c:318
 #, c-format
 msgid "%s is requesting additional printer drivers."
@@ -1089,8 +1124,7 @@ msgstr "%s está a pedir controladores de impressora adicionais."
 msgid "Additional Printer Drivers Required"
 msgstr "Controladores de impressora adicionais necessários"
 
-#. TRANSLATORS: this is a notification displayed when an app wants to install
-#. additional packages.
+#. TRANSLATORS: this is a notification displayed when an app wants to install additional packages.
 #: src/gs-dbus-helper.c:324
 #, c-format
 msgid "%s is requesting additional packages."
@@ -1110,14 +1144,14 @@ msgstr "Localizar nas aplicações"
 #. * can be installed
 #. TRANSLATORS: button text in the header when firmware
 #. * can be live-installed
-#: src/gs-details-page.c:281 src/gs-details-page.c:312
-#: src/gs-details-page.ui:206 src/gs-upgrade-banner.ui:146
+#: src/gs-details-page.c:280 src/gs-details-page.c:310
+#: src/gs-details-page.ui:237 src/gs-upgrade-banner.ui:146
 msgid "_Install"
 msgstr "_Instalar"
 
 #. TRANSLATORS: button text in the header when an application
 #. * can be live-updated
-#: src/gs-details-page.c:316
+#: src/gs-details-page.c:314
 msgid "_Update"
 msgstr "At_ualizar"
 
@@ -1125,67 +1159,68 @@ msgstr "At_ualizar"
 #. * be installed.
 #. * The ellipsis indicates that further steps are required,
 #. * e.g. enabling software sources or the like
-#: src/gs-details-page.c:330
+#: src/gs-details-page.c:326
 msgid "_Install…"
 msgstr "_Instalar…"
 
 #. TRANSLATORS: button text in the header when an application can be erased
-#: src/gs-details-page.c:377 src/gs-details-page.ui:547
+#: src/gs-details-page.c:373 src/gs-details-page.ui:547
 msgid "_Uninstall"
 msgstr ""
 
-#: src/gs-details-page.c:438 src/gs-sources-dialog.c:513
+#: src/gs-details-page.c:434 src/gs-sources-dialog.c:513
 msgid "Removing…"
 msgstr "A remover…"
 
 #. TRANSLATORS: this is the warning box
-#: src/gs-details-page.c:748
+#: src/gs-details-page.c:744
 msgid ""
 "This application can only be used when there is an active internet "
 "connection."
-msgstr "Esta aplicação só pode ser usada se tiver uma ligação à Internet ativa."
+msgstr ""
+"Esta aplicação só pode ser usada se tiver uma ligação à Internet ativa."
 
 #. TRANSLATORS: this is where the version is not known
-#: src/gs-details-page.c:892
+#: src/gs-details-page.c:888
 msgctxt "version"
 msgid "Unknown"
 msgstr "Desconhecido"
 
 #. TRANSLATORS: this is where we don't know the origin of the
 #. * application
-#: src/gs-details-page.c:971
+#: src/gs-details-page.c:967
 msgctxt "origin"
 msgid "Unknown"
 msgstr "Desconhecido"
 
 #. TRANSLATORS: we need a remote server to process
-#: src/gs-details-page.c:1378
+#: src/gs-details-page.c:1374
 msgid "You need internet access to write a review"
 msgstr ""
 
-#: src/gs-details-page.c:1507
+#: src/gs-details-page.c:1503
 #, c-format
 msgid "Unable to find “%s”"
 msgstr ""
 
 #. TRANSLATORS: see the wikipedia page
-#: src/gs-details-page.c:2087
+#: src/gs-details-page.c:2083
 msgid "Public domain"
 msgstr "Domínio público"
 
 #. TRANSLATORS: see GNU page
-#: src/gs-details-page.c:2103 src/gs-details-page.ui:1397
+#: src/gs-details-page.c:2099 src/gs-details-page.ui:1397
 msgid "Free Software"
 msgstr "Software livre"
 
 #. TRANSLATORS: for the free software popover
-#: src/gs-details-page.c:2160
+#: src/gs-details-page.c:2156
 msgid "Users are bound by the following license:"
 msgid_plural "Users are bound by the following licenses:"
 msgstr[0] "Os utilizadores são regidos pela seguinte licença:"
 msgstr[1] "Os utilizadores são regidos pelas seguintes licenças:"
 
-#: src/gs-details-page.c:2176 src/gs-details-page.ui:1506
+#: src/gs-details-page.c:2172 src/gs-details-page.ui:1506
 msgid "More information"
 msgstr "Mais informação"
 
@@ -1193,15 +1228,13 @@ msgstr "Mais informação"
 msgid "Details page"
 msgstr "Página de detalhes"
 
-#. Translators: A label for a button to add a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:228
+#. Translators: A label for a button to add a shortcut to the selected application.
+#: src/gs-details-page.ui:209
 msgid "_Add to Desktop"
 msgstr ""
 
-#. Translators: A label for a button to remove a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:245
+#. Translators: A label for a button to remove a shortcut to the selected application.
+#: src/gs-details-page.ui:226
 msgid "_Remove from Desktop"
 msgstr ""
 
@@ -1222,7 +1255,9 @@ msgstr "Fonte de aplicações incluída"
 msgid ""
 "This application includes a software source which provides updates, as well "
 "as access to other software."
-msgstr "Esta aplicação inclui uma fonte de aplicações que fornece atualizações, assim como acesso a outras aplicações."
+msgstr ""
+"Esta aplicação inclui uma fonte de aplicações que fornece atualizações, "
+"assim como acesso a outras aplicações."
 
 #: src/gs-details-page.ui:500
 msgid "No Software Source Included"
@@ -1232,16 +1267,19 @@ msgstr "Sem fontes de aplicações incluídas"
 msgid ""
 "This application does not include a software source. It will not be updated "
 "with new versions."
-msgstr "Esta aplicação não inclui uma fonte de aplicações. Não será atualizada com novas versões."
+msgstr ""
+"Esta aplicação não inclui uma fonte de aplicações. Não será atualizada com "
+"novas versões."
 
 #: src/gs-details-page.ui:515
 msgid ""
 "This software is already provided by your distribution and should not be "
 "replaced."
-msgstr "Esta aplicação já é fornecida pela sua distribuição e não deve ser substituída."
+msgstr ""
+"Esta aplicação já é fornecida pela sua distribuição e não deve ser "
+"substituída."
 
-#. Translators: a repository file used for installing software has been
-#. discovered.
+#. Translators: a repository file used for installing software has been discovered.
 #: src/gs-details-page.ui:528
 msgid "Software Source Identified"
 msgstr "Fonte de aplicação identificada"
@@ -1250,7 +1288,9 @@ msgstr "Fonte de aplicação identificada"
 msgid ""
 "Adding this software source will give you access to additional software and "
 "upgrades."
-msgstr "Adicionar esta fonte de aplicação dar-lhe-á acesso a aplicações e atualizações adicionais."
+msgstr ""
+"Adicionar esta fonte de aplicação dar-lhe-á acesso a aplicações e "
+"atualizações adicionais."
 
 #: src/gs-details-page.ui:530
 msgid "Only use software sources that you trust."
@@ -1342,14 +1382,12 @@ msgstr "Complementos"
 msgid "Selected add-ons will be installed with the application."
 msgstr "Os complementos selecionados serão instalados com a aplicação."
 
-#. Translators: Header of the section with other users' opinions about the
-#. app.
+#. Translators: Header of the section with other users' opinions about the app.
 #: src/gs-details-page.ui:1233
 msgid "Reviews"
 msgstr "Análises"
 
-#. Translators: Button opening a dialog where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Button opening a dialog where the users can write and publish their opinions about the apps.
 #: src/gs-details-page.ui:1249
 msgid "_Write a Review"
 msgstr "_Escrever uma análise"
@@ -1361,9 +1399,11 @@ msgstr "Mostrar mai_s"
 
 #: src/gs-details-page.ui:1414
 msgid ""
-"This means that the software can be freely run, copied, distributed, studied"
-" and modified."
-msgstr "Isto significa que o software pode ser livremente executado, copiado, distribuído, estudado e modificado."
+"This means that the software can be freely run, copied, distributed, studied "
+"and modified."
+msgstr ""
+"Isto significa que o software pode ser livremente executado, copiado, "
+"distribuído, estudado e modificado."
 
 #: src/gs-details-page.ui:1473
 msgid "Proprietary Software"
@@ -1374,7 +1414,10 @@ msgid ""
 "This means that the software is owned by an individual or a company. There "
 "are often restrictions on its use and its source code cannot usually be "
 "accessed."
-msgstr "Isto significa que este software pertence a um indivíduo ou companhia. Existem frequentemente restrições ao seu uso e o seu código-fonte, por norma, não é acessível."
+msgstr ""
+"Isto significa que este software pertence a um indivíduo ou companhia. "
+"Existem frequentemente restrições ao seu uso e o seu código-fonte, por "
+"norma, não é acessível."
 
 #: src/gs-details-page.ui:1535
 msgid "Unknown Software License"
@@ -1458,8 +1501,7 @@ msgstr ""
 msgid "Use verbose logging"
 msgstr ""
 
-#. TRANSLATORS: program name, an application to add and remove software
-#. repositories
+#. TRANSLATORS: program name, an application to add and remove software repositories
 #: src/gs-editor.c:1119
 msgid "GNOME Software Banner Designer"
 msgstr ""
@@ -1488,8 +1530,7 @@ msgstr "Resumo"
 msgid "Editor’s Pick"
 msgstr ""
 
-#. This check button controls whether the application’s banner appears in the
-#. “Featured” category
+#. This check button controls whether the application’s banner appears in the “Featured” category
 #: src/gs-editor.ui:397
 msgid "Category Featured"
 msgstr ""
@@ -1578,9 +1619,11 @@ msgstr "Não há aplicações disponíveis que forneçam o ficheiro %s."
 #: src/gs-extras-page.c:337 src/gs-extras-page.c:348 src/gs-extras-page.c:359
 #, c-format
 msgid ""
-"Information about %s, as well as options for how to get missing applications"
-" might be found %s."
-msgstr "Informações sobre %s, bem como as opções de como obter aplicações em falta podem ser encontradas %s."
+"Information about %s, as well as options for how to get missing applications "
+"might be found %s."
+msgstr ""
+"Informações sobre %s, bem como as opções de como obter aplicações em falta "
+"podem ser encontradas %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1603,7 +1646,9 @@ msgstr "%s indisponível."
 msgid ""
 "Information about %s, as well as options for how to get an application that "
 "can support this format might be found %s."
-msgstr "Informações sobre %s, bem como as opções de como obter uma aplicação que suporte este formato podem ser encontradas %s."
+msgstr ""
+"Informações sobre %s, bem como as opções de como obter uma aplicação que "
+"suporte este formato podem ser encontradas %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1619,11 +1664,13 @@ msgstr "Sem letras disponíveis para suporte ao script %s."
 msgid ""
 "Information about %s, as well as options for how to get additional fonts "
 "might be found %s."
-msgstr "Informações sobre %s, bem como as opções de como obter letras adicionais podem ser encontradas %s."
+msgstr ""
+"Informações sobre %s, bem como as opções de como obter letras adicionais "
+"podem ser encontradas %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
-#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1426
+#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1430
 #, c-format
 msgid "No addon codecs are available for the %s format."
 msgstr "Não há complementos de codecs disponíveis para o formato %s."
@@ -1635,7 +1682,9 @@ msgstr "Não há complementos de codecs disponíveis para o formato %s."
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format might be found %s."
-msgstr "Informações sobre %s, bem como as opções de como obter um codec que possa reproduzir este formato podem ser encontradas %s."
+msgstr ""
+"Informações sobre %s, bem como as opções de como obter um codec que possa "
+"reproduzir este formato podem ser encontradas %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1651,7 +1700,9 @@ msgstr "Não há recursos de Plasma disponíveis para suporte a %s."
 msgid ""
 "Information about %s, as well as options for how to get additional Plasma "
 "resources might be found %s."
-msgstr "Informações sobre %s, bem como as opções de como obter recursos Plasma adicionais podem ser encontradas %s."
+msgstr ""
+"Informações sobre %s, bem como as opções de como obter recursos Plasma "
+"adicionais podem ser encontradas %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1667,15 +1718,16 @@ msgstr "Não há controladores de impressora disponíveis para %s."
 msgid ""
 "Information about %s, as well as options for how to get a driver that "
 "supports this printer might be found %s."
-msgstr "Informações sobre %s, bem como as opções de como obter um controlador que suporte esta impressora podem ser encontradas %s."
+msgstr ""
+"Informações sobre %s, bem como as opções de como obter um controlador que "
+"suporte esta impressora podem ser encontradas %s."
 
 #. TRANSLATORS: hyperlink title
 #: src/gs-extras-page.c:459
 msgid "this website"
 msgstr "esta página web"
 
-#. TRANSLATORS: no codecs were found. First %s will be replaced by actual
-#. codec name(s), second %s is a link titled "this website"
+#. TRANSLATORS: no codecs were found. First %s will be replaced by actual codec name(s), second %s is a link titled "this website"
 #: src/gs-extras-page.c:463
 #, c-format
 msgid ""
@@ -1684,8 +1736,12 @@ msgid ""
 msgid_plural ""
 "Unfortunately, the %s you were searching for could not be found. Please see "
 "%s for more information."
-msgstr[0] "Infelizmente o %s que procura não foi encontrado. Por favor, veja %s para mais informação."
-msgstr[1] "Infelizmente o %s que procura não foi encontrado. Por favor, veja %s para mais informação."
+msgstr[0] ""
+"Infelizmente o %s que procura não foi encontrado. Por favor, veja %s para "
+"mais informação."
+msgstr[1] ""
+"Infelizmente o %s que procura não foi encontrado. Por favor, veja %s para "
+"mais informação."
 
 #: src/gs-extras-page.c:535 src/gs-extras-page.c:591 src/gs-extras-page.c:630
 msgid "Failed to find any search results"
@@ -1710,10 +1766,13 @@ msgstr "Boas vindas ao Aplicações"
 
 #: src/gs-first-run-dialog.ui:66
 msgid ""
-"Software lets you install all the software you need, all from one place. See"
-" our recommendations, browse the categories, or search for the applications "
+"Software lets you install all the software you need, all from one place. See "
+"our recommendations, browse the categories, or search for the applications "
 "you want."
-msgstr "O Aplicações permite-lhe instalar os programas que necessita num único local. Veja as nossas recomendações, navegue pelas categorias ou procure as aplicações que quiser."
+msgstr ""
+"O Aplicações permite-lhe instalar os programas que necessita num único "
+"local. Veja as nossas recomendações, navegue pelas categorias ou procure as "
+"aplicações que quiser."
 
 #: src/gs-first-run-dialog.ui:85
 msgid "_Let’s Go Shopping"
@@ -1867,8 +1926,7 @@ msgstr ""
 
 #. TRANSLATORS: this is the proprietary info bar
 #: src/gs-overview-page.c:978
-msgid ""
-"Proprietary software has restrictions on use and access to source code."
+msgid "Proprietary software has restrictions on use and access to source code."
 msgstr ""
 
 #. TRANSLATORS: this is the clickable
@@ -1898,14 +1956,12 @@ msgstr ""
 msgid "Categories"
 msgstr "Categorias"
 
-#. Translators: This is a heading for software which has been featured
-#. ('picked') by the distribution.
+#. Translators: This is a heading for software which has been featured ('picked') by the distribution.
 #: src/gs-overview-page.ui:315
 msgid "Editor’s Picks"
 msgstr ""
 
-#. Translators: This is a heading for software which has been recently
-#. released upstream.
+#. Translators: This is a heading for software which has been recently released upstream.
 #: src/gs-overview-page.ui:359
 msgid "Recent Releases"
 msgstr ""
@@ -1967,12 +2023,14 @@ msgstr "Tem certeza que quer remover %s?"
 msgid "%s will be removed, and you will have to install it to use it again."
 msgstr "%s será removido e para utilizá-lo novamente, terá de o instalar."
 
-#: lib/gs-plugin-loader.c:1429
+#: lib/gs-plugin-loader.c:1433
 #, c-format
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format can be found on the website."
-msgstr "Informações sobre %s, bem como as opções de como obter um codec que pode reproduzir este formato podem ser encontradas na paǵina web."
+msgstr ""
+"Informações sobre %s, bem como as opções de como obter um codec que pode "
+"reproduzir este formato podem ser encontradas na paǵina web."
 
 #: lib/gs-price.c:111
 #, c-format
@@ -2031,7 +2089,10 @@ msgstr ""
 msgid ""
 "Some of the currently installed software is not compatible with %s. If you "
 "continue, the following will be automatically removed during the upgrade:"
-msgstr "Parte do software atualmente instalado não é compatível com %s. Se continuar, os programas seguintes serão automaticamente removidos durante a atualização:"
+msgstr ""
+"Parte do software atualmente instalado não é compatível com %s. Se "
+"continuar, os programas seguintes serão automaticamente removidos durante a "
+"atualização:"
 
 #: src/gs-removal-dialog.ui:27
 msgid "Incompatible Software"
@@ -2101,8 +2162,7 @@ msgstr "A descrição é demasiado curta"
 msgid "The description is too long"
 msgstr "A descrição é demasiado longa"
 
-#. Translators: Title of the dialog box where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Title of the dialog box where the users can write and publish their opinions about the apps.
 #: src/gs-review-dialog.ui:11
 msgid "Post Review"
 msgstr "Postar análise"
@@ -2120,7 +2180,9 @@ msgstr "Pontuação"
 msgid ""
 "Give a short summary of your review, for example: “Great app, would "
 "recommend”."
-msgstr "Dar um breve resumo da sua avaliação, por exemplo \"Grande aplicação. Recomento.\" "
+msgstr ""
+"Dar um breve resumo da sua avaliação, por exemplo \"Grande aplicação. "
+"Recomento.\" "
 
 #. Translators: This is where the users enter their opinions about the apps.
 #: src/gs-review-dialog.ui:199
@@ -2130,7 +2192,9 @@ msgstr "Análise"
 
 #: src/gs-review-dialog.ui:215
 msgid "What do you think of the app? Try to give reasons for your views."
-msgstr "O que pensa desta aplicação? Tente dar argumentos para os seus pontos de vista."
+msgstr ""
+"O que pensa desta aplicação? Tente dar argumentos para os seus pontos de "
+"vista."
 
 #. Translators: A label for the total number of reviews.
 #: src/gs-review-histogram.ui:413
@@ -2140,14 +2204,17 @@ msgstr ""
 #. TRANSLATORS: we explain what the action is going to do
 #: src/gs-review-row.c:234
 msgid "You can report reviews for abusive, rude, or discriminatory behavior."
-msgstr "Pode denunciar análises por comportamento abusivo, rude ou discriminatório."
+msgstr ""
+"Pode denunciar análises por comportamento abusivo, rude ou discriminatório."
 
 #. TRANSLATORS: we ask the user if they really want to do this
 #: src/gs-review-row.c:239
 msgid ""
 "Once reported, a review will be hidden until it has been checked by an "
 "administrator."
-msgstr "Assim que denuncie, a análise será escondida até que seja verificada por um administrador."
+msgstr ""
+"Assim que denuncie, a análise será escondida até que seja verificada por um "
+"administrador."
 
 #. TRANSLATORS: window title when
 #. * reporting a user-submitted review
@@ -2162,8 +2229,7 @@ msgstr "Denunciar Análise"
 msgid "Report"
 msgstr "Denunciar"
 
-#. Translators: Users can express their opinions about other users' opinions
-#. about the apps.
+#. Translators: Users can express their opinions about other users' opinions about the apps.
 #: src/gs-review-row.ui:112
 msgid "Was this review useful to you?"
 msgstr "Esta análise foi-lhe útil?"
@@ -2252,81 +2318,80 @@ msgstr "Nenhuma aplicação encontrada"
 #. TRANSLATORS: this is part of the in-app notification,
 #. * where the %s is a multi-word localised app name
 #. * e.g. 'Getting things GNOME!"
-#: src/gs-shell.c:846 src/gs-shell.c:851 src/gs-shell.c:866 src/gs-shell.c:870
+#: src/gs-shell.c:847 src/gs-shell.c:852 src/gs-shell.c:867 src/gs-shell.c:871
 #, c-format
 msgid "“%s”"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:898
+#: src/gs-shell.c:899
 #, c-format
 msgid "Unable to download firmware updates from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:904
+#: src/gs-shell.c:905
 #, c-format
 msgid "Unable to download updates from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:911
+#: src/gs-shell.c:912
 msgid "Unable to download updates"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:916
+#: src/gs-shell.c:917
 msgid ""
-"Unable to download updates: internet access was required but wasn’t "
-"available"
+"Unable to download updates: internet access was required but wasn’t available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:925
+#: src/gs-shell.c:926
 #, c-format
 msgid "Unable to download updates from %s: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:930
+#: src/gs-shell.c:931
 msgid "Unable to download updates: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:938
+#: src/gs-shell.c:939
 msgid "Unable to download updates: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:943
+#: src/gs-shell.c:944
 msgid "Unable to download updates: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:948
+#: src/gs-shell.c:949
 msgid ""
 "Unable to download updates: you do not have permission to install software"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:955
+#: src/gs-shell.c:956
 msgid "Unable to get list of updates"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the application name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1001
+#: src/gs-shell.c:1002
 #, c-format
 msgid "Unable to install %s as download failed from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1007
+#: src/gs-shell.c:1008
 #, c-format
 msgid "Unable to install %s as download failed"
 msgstr ""
@@ -2335,51 +2400,51 @@ msgstr ""
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1019
+#: src/gs-shell.c:1020
 #, c-format
 msgid "Unable to install %s as runtime %s not available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1025
+#: src/gs-shell.c:1026
 #, c-format
 msgid "Unable to install %s as not supported"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1032
+#: src/gs-shell.c:1033
 msgid "Unable to install: internet access was required but wasn’t available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1038
+#: src/gs-shell.c:1039
 msgid "Unable to install: the application has an invalid format"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1043
+#: src/gs-shell.c:1044
 #, c-format
 msgid "Unable to install %s: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1051
+#: src/gs-shell.c:1052
 #, c-format
 msgid "Unable to install %s: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1058
+#: src/gs-shell.c:1059
 #, c-format
 msgid "Unable to install %s: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1065
+#: src/gs-shell.c:1066
 #, c-format
 msgid "Unable to install %s: you do not have permission to install software"
 msgstr ""
@@ -2387,34 +2452,34 @@ msgstr ""
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the name of the authentication service,
 #. * e.g. "Ubuntu One"
-#: src/gs-shell.c:1078
+#: src/gs-shell.c:1079
 #, c-format
 msgid "Your %s account has been suspended."
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1082
+#: src/gs-shell.c:1083
 msgid "It is not possible to install software until this has been resolved."
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the clickable link (e.g.
 #. * "http://example.com/what-did-i-do-wrong/")
-#: src/gs-shell.c:1093
+#: src/gs-shell.c:1094
 #, c-format
 msgid "For more information, visit %s."
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1102
+#: src/gs-shell.c:1103
 #, c-format
 msgid "Unable to install %s: AC power is required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1111
+#: src/gs-shell.c:1112
 #, c-format
 msgid "Unable to install %s"
 msgstr ""
@@ -2423,61 +2488,61 @@ msgstr ""
 #. * where the first %s is the app name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1157
+#: src/gs-shell.c:1158
 #, c-format
 msgid "Unable to update %s from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1163
+#: src/gs-shell.c:1164
 #, c-format
 msgid "Unable to update %s as download failed"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1169
+#: src/gs-shell.c:1170
 msgid "Unable to update: internet access was required but wasn’t available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1177
+#: src/gs-shell.c:1178
 #, c-format
 msgid "Unable to update %s: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1186
+#: src/gs-shell.c:1187
 #, c-format
 msgid "Unable to update %s: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1193
+#: src/gs-shell.c:1194
 #, c-format
 msgid "Unable to update %s: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1200
+#: src/gs-shell.c:1201
 #, c-format
 msgid "Unable to update %s: you do not have permission to update software"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1208
+#: src/gs-shell.c:1209
 #, c-format
 msgid "Unable to update %s: AC power is required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1217
+#: src/gs-shell.c:1218
 #, c-format
 msgid "Unable to update %s"
 msgstr ""
@@ -2485,96 +2550,96 @@ msgstr ""
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the distro name (e.g. "Fedora 25") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1262
+#: src/gs-shell.c:1263
 #, c-format
 msgid "Unable to upgrade to %s from %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the app name (e.g. "GIMP")
-#: src/gs-shell.c:1267
+#: src/gs-shell.c:1268
 #, c-format
 msgid "Unable to upgrade to %s as download failed"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1274
+#: src/gs-shell.c:1275
 msgid "Unable to upgrade: internet access was required but wasn’t available"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1282
+#: src/gs-shell.c:1283
 #, c-format
 msgid "Unable to upgrade to %s: not enough disk space"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1291
+#: src/gs-shell.c:1292
 #, c-format
 msgid "Unable to upgrade to %s: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1298
+#: src/gs-shell.c:1299
 #, c-format
 msgid "Unable to upgrade to %s: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1305
+#: src/gs-shell.c:1306
 #, c-format
 msgid "Unable to upgrade to %s: you do not have permission to upgrade"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1312
+#: src/gs-shell.c:1313
 #, c-format
 msgid "Unable to upgrade to %s: AC power is required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1321
+#: src/gs-shell.c:1322
 #, c-format
 msgid "Unable to upgrade to %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1363
+#: src/gs-shell.c:1364
 #, c-format
 msgid "Unable to remove %s: authentication was required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1369
+#: src/gs-shell.c:1370
 #, c-format
 msgid "Unable to remove %s: authentication was invalid"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1375
+#: src/gs-shell.c:1376
 #, c-format
 msgid "Unable to remove %s: you do not have permission to remove software"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1382
+#: src/gs-shell.c:1383
 #, c-format
 msgid "Unable to remove %s: AC power is required"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1391
+#: src/gs-shell.c:1392
 #, c-format
 msgid "Unable to remove %s"
 msgstr ""
@@ -2583,48 +2648,48 @@ msgstr ""
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1437
+#: src/gs-shell.c:1438
 #, c-format
 msgid "Unable to launch %s: %s is not installed"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1444 src/gs-shell.c:1492 src/gs-shell.c:1540
+#: src/gs-shell.c:1445 src/gs-shell.c:1493 src/gs-shell.c:1541
 msgid "Not enough disk space — free up some space and try again"
 msgstr ""
 
 #. TRANSLATORS: we failed to get a proper error code
-#: src/gs-shell.c:1452 src/gs-shell.c:1500 src/gs-shell.c:1567
+#: src/gs-shell.c:1453 src/gs-shell.c:1501 src/gs-shell.c:1568
 msgid "Sorry, something went wrong"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1487
+#: src/gs-shell.c:1488
 msgid "Failed to install file: authentication failed"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1534
+#: src/gs-shell.c:1535
 #, c-format
 msgid "Unable to contact %s"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1549
+#: src/gs-shell.c:1550
 #, c-format
 msgid "%s needs to be restarted to use new plugins."
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1554
+#: src/gs-shell.c:1555
 msgid "This application needs to be restarted to use new plugins."
 msgstr ""
 
 #. TRANSLATORS: need to be connected to the AC power
-#: src/gs-shell.c:1561
+#: src/gs-shell.c:1562
 msgid "AC power is required"
 msgstr ""
 
@@ -2632,7 +2697,8 @@ msgstr ""
 #. has no software installed from it.
 #: src/gs-sources-dialog.c:98
 msgid "No applications or addons installed; other software might still be"
-msgstr "Sem aplicações ou extensões instaladas; outro programa pode ainda estar"
+msgstr ""
+"Sem aplicações ou extensões instaladas; outro programa pode ainda estar"
 
 #. TRANSLATORS: This string is used to construct the 'X applications
 #. installed' sentence, describing a software source.
@@ -2711,7 +2777,9 @@ msgstr "o sistema operativo"
 msgid ""
 "Software sources can be downloaded from the internet. They give you access "
 "to additional software that is not provided by %s."
-msgstr "Fontes de aplicações podem ser transferidas da Internet. Dão-lhe acesso a programas adicionais que não são fornecidos por %s."
+msgstr ""
+"Fontes de aplicações podem ser transferidas da Internet. Dão-lhe acesso a "
+"programas adicionais que não são fornecidos por %s."
 
 #: src/gs-sources-dialog.ui:155
 msgid "Additional Sources"
@@ -2720,7 +2788,8 @@ msgstr ""
 #: src/gs-sources-dialog.ui:175
 msgid ""
 "Removing a source will also remove any software you have installed from it."
-msgstr "Remover a fonte também removerá qualquer aplicação instalada a partir dela."
+msgstr ""
+"Remover a fonte também removerá qualquer aplicação instalada a partir dela."
 
 #: src/gs-sources-dialog.ui:260
 msgid "No software installed from this source"
@@ -2827,7 +2896,9 @@ msgstr "Atualizações de aplicações disponíveis"
 
 #: src/gs-update-monitor.c:97
 msgid "Important OS and application updates are ready to be installed"
-msgstr "Atualizações importantes do sistema operativo e de aplicações estão prontas para serem instaladas"
+msgstr ""
+"Atualizações importantes do sistema operativo e de aplicações estão prontas "
+"para serem instaladas"
 
 #. TRANSLATORS: button text
 #: src/gs-update-monitor.c:100 src/gs-updates-page.c:775
@@ -2918,29 +2989,38 @@ msgstr "A atualização foi cancelada."
 #. * something with no network available
 #: src/gs-update-monitor.c:714
 msgid ""
-"Internet access was required but wasn’t available. Please make sure that you"
-" have internet access and try again."
-msgstr "Foi pedido acesso à Internet mas não estava disponível. Por favor, assegure-se que tem acesso à Internet e tente novamente."
+"Internet access was required but wasn’t available. Please make sure that you "
+"have internet access and try again."
+msgstr ""
+"Foi pedido acesso à Internet mas não estava disponível. Por favor, assegure-"
+"se que tem acesso à Internet e tente novamente."
 
 #. TRANSLATORS: if the package is not signed correctly
 #: src/gs-update-monitor.c:720
 msgid ""
 "There were security issues with the update. Please consult your software "
 "provider for more details."
-msgstr "Houve problemas de segurança com a atualização. Por favor, consulte o seu fornecedor de programas para mais detalhes."
+msgstr ""
+"Houve problemas de segurança com a atualização. Por favor, consulte o seu "
+"fornecedor de programas para mais detalhes."
 
 #. TRANSLATORS: we ran out of disk space
 #: src/gs-update-monitor.c:726
 msgid ""
 "There wasn’t enough disk space. Please free up some space and try again."
-msgstr "Não houve espaço suficiente em disco. Por favor, liberte algum e tente novamente."
+msgstr ""
+"Não houve espaço suficiente em disco. Por favor, liberte algum e tente "
+"novamente."
 
 #. TRANSLATORS: We didn't handle the error type
 #: src/gs-update-monitor.c:731
 msgid ""
 "We’re sorry: the update failed to install. Please wait for another update "
 "and try again. If the problem persists, contact your software provider."
-msgstr "Lamentamos: a atualização falhou a instalação. Por favor, espere por outra atualização e tente novamente. Se o problema persistir, contacte o seu fornecedor de programas."
+msgstr ""
+"Lamentamos: a atualização falhou a instalação. Por favor, espere por outra "
+"atualização e tente novamente. Se o problema persistir, contacte o seu "
+"fornecedor de programas."
 
 #. TRANSLATORS: Time in 24h format
 #: src/gs-updates-page.c:297
@@ -3120,7 +3200,8 @@ msgstr "Podem ser aplicados custos adicionais"
 msgid ""
 "Checking for updates while using mobile broadband could cause you to incur "
 "charges."
-msgstr "Procurar atualizações em redes móveis de banda larga pode incorrer em custos."
+msgstr ""
+"Procurar atualizações em redes móveis de banda larga pode incorrer em custos."
 
 #. TRANSLATORS: this is a link to the
 #. * control-center network panel
@@ -3159,7 +3240,8 @@ msgstr "As aplicações estão atualizadas"
 msgid ""
 "Checking for updates when using mobile broadband could cause you to incur "
 "charges"
-msgstr "Procurar atualizações em redes móveis de banda larga pode incorrer em custos."
+msgstr ""
+"Procurar atualizações em redes móveis de banda larga pode incorrer em custos."
 
 #: src/gs-updates-page.ui:257
 msgid "_Check Anyway"
@@ -3224,22 +3306,27 @@ msgid "App Center"
 msgstr ""
 
 #: src/org.gnome.Software.desktop.in:4
+msgid "More Apps"
+msgstr "Mais Programas"
+
+#: src/org.gnome.Software.desktop.in:5
 msgid "Add, remove or update software on this computer"
 msgstr "Adiciona, remove ou atualiza aplicações neste computador"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
-#: src/org.gnome.Software.desktop.in:6
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: src/org.gnome.Software.desktop.in:7
 #: src/org.gnome.Software.Editor.desktop.in:6
 msgid "org.gnome.Software"
 msgstr ""
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
-#: src/org.gnome.Software.desktop.in:12
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: src/org.gnome.Software.desktop.in:13
 msgid ""
-"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;"
-msgstr "Atualizações;Fontes;Origens;Repositórios;Preferências;Instalar;Desinstalar;Programa;Software;App;Loja;"
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;"
+msgstr ""
+"Atualizações;Fontes;Origens;Repositórios;Preferências;Instalar;Desinstalar;"
+"Programa;Software;App;Loja;"
 
 #: src/org.gnome.Software.Editor.desktop.in:3
 msgid "Banner Designer"
@@ -3249,8 +3336,7 @@ msgstr ""
 msgid "Design the featured banners for GNOME Software"
 msgstr ""
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: src/org.gnome.Software.Editor.desktop.in:13
 msgid "AppStream;Software;App;"
 msgstr ""
@@ -3520,100 +3606,110 @@ msgctxt "Menu of Communication & News"
 msgid "Web Browsers"
 msgstr ""
 
-#: plugins/core/gs-desktop-common.c:247
-msgctxt "Menu of Reference"
-msgid "All"
-msgstr "Todas"
-
-#: plugins/core/gs-desktop-common.c:250
-msgctxt "Menu of Reference"
-msgid "Featured"
-msgstr "Destaques"
-
-#: plugins/core/gs-desktop-common.c:253
-msgctxt "Menu of Reference"
-msgid "Art"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:256
-msgctxt "Menu of Reference"
-msgid "Biography"
-msgstr "Biografia"
-
-#: plugins/core/gs-desktop-common.c:259
-msgctxt "Menu of Reference"
-msgid "Comics"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:262
-msgctxt "Menu of Reference"
-msgid "Fiction"
-msgstr "Ficção"
-
-#: plugins/core/gs-desktop-common.c:265
-msgctxt "Menu of Reference"
-msgid "Health"
-msgstr "Saúde"
-
-#: plugins/core/gs-desktop-common.c:268
-msgctxt "Menu of Reference"
-msgid "History"
-msgstr "História"
-
-#: plugins/core/gs-desktop-common.c:271
-msgctxt "Menu of Reference"
-msgid "Lifestyle"
-msgstr "Estilo de vida"
-
-#: plugins/core/gs-desktop-common.c:274
+#: plugins/core/gs-desktop-common.c:242
 msgctxt "Menu of Communication & News"
 msgid "News"
 msgstr ""
 
+#: plugins/core/gs-desktop-common.c:251
+msgctxt "Menu of Reference"
+msgid "All"
+msgstr "Todas"
+
+#: plugins/core/gs-desktop-common.c:254
+msgctxt "Menu of Reference"
+msgid "Featured"
+msgstr "Destaques"
+
+#: plugins/core/gs-desktop-common.c:257
+msgctxt "Menu of Reference"
+msgid "Art"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:260
+msgctxt "Menu of Reference"
+msgid "Biography"
+msgstr "Biografia"
+
+#: plugins/core/gs-desktop-common.c:263
+msgctxt "Menu of Reference"
+msgid "Comics"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:266
+msgctxt "Menu of Reference"
+msgid "Feed"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:269
+msgctxt "Menu of Reference"
+msgid "Fiction"
+msgstr "Ficção"
+
+#: plugins/core/gs-desktop-common.c:272
+msgctxt "Menu of Reference"
+msgid "Health"
+msgstr "Saúde"
+
+#: plugins/core/gs-desktop-common.c:275
+msgctxt "Menu of Reference"
+msgid "History"
+msgstr "História"
+
 #: plugins/core/gs-desktop-common.c:278
+msgctxt "Menu of Reference"
+msgid "Lifestyle"
+msgstr "Estilo de vida"
+
+#: plugins/core/gs-desktop-common.c:281
+msgctxt "Menu of Reference"
+msgid "News"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:284
 msgctxt "Menu of Reference"
 msgid "Politics"
 msgstr "Política"
 
-#: plugins/core/gs-desktop-common.c:281
+#: plugins/core/gs-desktop-common.c:287
 msgctxt "Menu of Reference"
 msgid "Sports"
 msgstr "Desporto"
 
 #. TRANSLATORS: this is the menu spec main category for Learning
-#: plugins/core/gs-desktop-common.c:291
+#: plugins/core/gs-desktop-common.c:297
 msgid "Learning"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Game
-#: plugins/core/gs-desktop-common.c:294
+#: plugins/core/gs-desktop-common.c:300
 msgid "Games"
 msgstr "Jogos"
 
 #. TRANSLATORS: this is the menu spec main category for Multimedia
-#: plugins/core/gs-desktop-common.c:297
+#: plugins/core/gs-desktop-common.c:303
 msgid "Multimedia"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Work
-#: plugins/core/gs-desktop-common.c:300
+#: plugins/core/gs-desktop-common.c:306
 msgid "Work"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Reference
-#: plugins/core/gs-desktop-common.c:303
+#: plugins/core/gs-desktop-common.c:309
 msgid "Reference & News"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Utilities
-#: plugins/core/gs-desktop-common.c:306
+#: plugins/core/gs-desktop-common.c:312
 msgid "Utilities"
 msgstr "Utilitários"
 
 #. TRANSLATORS: this is the menu spec main category for Dev Tools; it
 #. * should be a relatively short label; as an example, in Portuguese and
 #. * Spanish the direct translation of "Programming" (noun) is used
-#: plugins/core/gs-desktop-common.c:311
+#: plugins/core/gs-desktop-common.c:317
 msgid "Dev Tools"
 msgstr "Ferramentas de desenvolvimento"
 
@@ -3639,16 +3735,16 @@ msgstr "Inclui melhorias de desempenho, estabilidade e segurança."
 msgid "Downloading featured images…"
 msgstr ""
 
-#: plugins/eos/gs-plugin-eos.c:1249
+#: plugins/eos/gs-plugin-eos.c:1233
 #, c-format
 msgid "Could not launch this application."
 msgstr ""
 
-#: plugins/eos/gs-plugin-eos.c:1305
+#: plugins/eos/gs-plugin-eos.c:1289
 msgid "Endless Platform"
 msgstr ""
 
-#: plugins/eos/gs-plugin-eos.c:1308
+#: plugins/eos/gs-plugin-eos.c:1292
 msgid "Framework for applications"
 msgstr ""
 
@@ -3708,13 +3804,13 @@ msgid "Flatpak is a framework for desktop applications on Linux"
 msgstr ""
 
 #. TRANSLATORS: status text when downloading new metadata
-#: plugins/flatpak/gs-flatpak.c:821
+#: plugins/flatpak/gs-flatpak.c:815
 #, c-format
 msgid "Getting flatpak metadata for %s…"
 msgstr ""
 
 #. TRANSLATORS: status text when downloading the RuntimeRepo
-#: plugins/flatpak/gs-flatpak.c:2796
+#: plugins/flatpak/gs-flatpak.c:2803
 msgid "Getting runtime source…"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the gnome-software package.
-# 
+#
 # Translators:
 # Artur de Aquino Morais <artur.morais93@outlook.com>, 2016
 # Enrico Nicoletto <liverig@gmail.com>, 2013-2016
@@ -19,14 +19,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-software\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-12 22:31-0700\n"
+"POT-Creation-Date: 2017-11-02 16:28+0100\n"
 "PO-Revision-Date: 2017-10-13 06:24+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
-"Language-Team: Portuguese (Brazil) (http://www.transifex.com/endless-mobile-inc/gnome-software/language/pt_BR/)\n"
+"Language-Team: Portuguese (Brazil) (http://www.transifex.com/endless-mobile-"
+"inc/gnome-software/language/pt_BR/)\n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pt_BR\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:7
@@ -41,7 +42,9 @@ msgstr "Gerenciador de aplicativos para o GNOME"
 msgid ""
 "Software allows you to find and install new applications and system "
 "extensions and remove existing installed applications."
-msgstr "O aplicativo Programas permite que você encontre e instale novos aplicativos e extensões do sistema, além de remover aplicativos já instalados."
+msgstr ""
+"O aplicativo Programas permite que você encontre e instale novos aplicativos "
+"e extensões do sistema, além de remover aplicativos já instalados."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:14
 msgid ""
@@ -49,7 +52,12 @@ msgid ""
 "descriptions and multiple screenshots per application. Applications can be "
 "found either through browsing the list of categories or by searching. It "
 "also allows you to update your system using an offline update."
-msgstr "Programas do GNOME mostra aplicativos populares em destaque com descrições úteis e múltiplas capturas de tela per aplicativo. Aplicativos podem ser encontradas tanto navegando a lista de categorias quanto pesquisando. Ele também permite que você atualize seu sistema usando uma atualização sem estar conectado a internet."
+msgstr ""
+"Programas do GNOME mostra aplicativos populares em destaque com descrições "
+"úteis e múltiplas capturas de tela per aplicativo. Aplicativos podem ser "
+"encontradas tanto navegando a lista de categorias quanto pesquisando. Ele "
+"também permite que você atualize seu sistema usando uma atualização sem "
+"estar conectado a internet."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:25
 msgid "Overview panel"
@@ -83,7 +91,9 @@ msgstr "Uma lista de projetos compatíveis"
 msgid ""
 "This is a list of compatible projects we should show such as GNOME, KDE and "
 "XFCE."
-msgstr "Esta é uma lista de projetos compatíveis que devemos mostrar como GNOME, KDE e XFCE."
+msgstr ""
+"Esta é uma lista de projetos compatíveis que devemos mostrar como GNOME, KDE "
+"e XFCE."
 
 #: data/org.gnome.software.gschema.xml:10
 msgid "Whether to manage updates in GNOME Software"
@@ -93,7 +103,9 @@ msgstr "Se atualizações devem ser gerenciadas no GNOME Software"
 msgid ""
 "If disabled, GNOME Software will hide the updates panel and not perform any "
 "automatic updates actions."
-msgstr "Se desativado, GNOME Software ocultará o painel de atualizações e não executará quaisquer ações de atualizações automáticas."
+msgstr ""
+"Se desativado, GNOME Software ocultará o painel de atualizações e não "
+"executará quaisquer ações de atualizações automáticas."
 
 #: data/org.gnome.software.gschema.xml:15
 msgid "Whether to automatically download updates"
@@ -101,9 +113,11 @@ msgstr "Seja para baixar automaticamente as atualizações"
 
 #: data/org.gnome.software.gschema.xml:16
 msgid ""
-"If enabled, GNOME Software automatically downloads updates in the background"
-" and prompts the user to install them when ready."
-msgstr "Se habilitado, GNOME Software baixa automaticamente atualizações em segundo plano e solicita ao usuário para instalá-las quando estiver pronto."
+"If enabled, GNOME Software automatically downloads updates in the background "
+"and prompts the user to install them when ready."
+msgstr ""
+"Se habilitado, GNOME Software baixa automaticamente atualizações em segundo "
+"plano e solicita ao usuário para instalá-las quando estiver pronto."
 
 #: data/org.gnome.software.gschema.xml:20
 msgid "Whether to automatically refresh when on a metered connection"
@@ -114,7 +128,11 @@ msgid ""
 "If enabled, GNOME Software automatically refreshes in the background even "
 "when using a metered connection (eventually downloading some metadata, "
 "checking for updates, etc., which may incur in costs for the user)."
-msgstr "Se habilitado, GNOME Software atualiza automaticamente em segundo plano mesmo quando estiver sendo executado em uma conexão limitada (eventualmente, baixar alguns metadados, verificar atualizações, etc., o que pode resultar em custos para o usuário)."
+msgstr ""
+"Se habilitado, GNOME Software atualiza automaticamente em segundo plano "
+"mesmo quando estiver sendo executado em uma conexão limitada (eventualmente, "
+"baixar alguns metadados, verificar atualizações, etc., o que pode resultar "
+"em custos para o usuário)."
 
 #: data/org.gnome.software.gschema.xml:25
 msgid "Whether it’s the very first run of GNOME Software"
@@ -134,9 +152,11 @@ msgstr "Aplicações não-livres mostram um diálogo de aviso antes de instalar"
 
 #: data/org.gnome.software.gschema.xml:38
 msgid ""
-"When non-free applications are installed a warning dialog can be shown. This"
-" controls if that dialog is suppressed."
-msgstr "Quando as aplicações não-livres estão instaladas um diálogo de aviso pode ser mostrado. Isto controla se esse diálogo é suprimido."
+"When non-free applications are installed a warning dialog can be shown. This "
+"controls if that dialog is suppressed."
+msgstr ""
+"Quando as aplicações não-livres estão instaladas um diálogo de aviso pode "
+"ser mostrado. Isto controla se esse diálogo é suprimido."
 
 #: data/org.gnome.software.gschema.xml:42
 msgid "A list of popular applications"
@@ -144,7 +164,9 @@ msgstr "Uma lista de aplicações populares"
 
 #: data/org.gnome.software.gschema.xml:43
 msgid "A list of applications to use, overriding the system defined ones."
-msgstr "Uma lista de aplicativos para usar, substituindo aqueles definidos pelo sistema."
+msgstr ""
+"Uma lista de aplicativos para usar, substituindo aqueles definidos pelo "
+"sistema."
 
 #: data/org.gnome.software.gschema.xml:47
 msgid "The list of extra sources that have been previously enabled"
@@ -154,7 +176,9 @@ msgstr "A lista de fontes adicionais que tenham sido previamente habilitadas"
 msgid ""
 "The list of sources that have been previously enabled when installing third-"
 "party applications."
-msgstr "A lista de fontes que foram habilitadas anteriormente ao instalar aplicativos de terceiros."
+msgstr ""
+"A lista de fontes que foram habilitadas anteriormente ao instalar "
+"aplicativos de terceiros."
 
 #: data/org.gnome.software.gschema.xml:52
 msgid "The last update check timestamp"
@@ -166,7 +190,9 @@ msgstr "A marca de tempo da notificação da última atualização"
 
 #: data/org.gnome.software.gschema.xml:60
 msgid "The timestamp of the first security update, cleared after update"
-msgstr "A marca de tempo da primeira atualização de segurança, apagada após atualização"
+msgstr ""
+"A marca de tempo da primeira atualização de segurança, apagada após "
+"atualização"
 
 #: data/org.gnome.software.gschema.xml:64
 msgid "The last update timestamp"
@@ -174,14 +200,19 @@ msgstr "A marca de tempo da última atualização"
 
 #: data/org.gnome.software.gschema.xml:68
 msgid "The age in seconds to verify the upstream screenshot is still valid"
-msgstr "A idade em segundos para verificar se a captura de tela ainda está válida"
+msgstr ""
+"A idade em segundos para verificar se a captura de tela ainda está válida"
 
 #: data/org.gnome.software.gschema.xml:69
 msgid ""
 "Choosing a larger value will mean less round-trips to the remote server but "
-"updates to the screenshots may take longer to show to the user. A value of 0"
-" means to never check the server if the image already exists in the cache."
-msgstr "Escolher um valor maior significará menos conexões com o servidor remoto, mas atualizações para as capturas de tela podem levar mais tempo para serem mostradas ao usuário. Um valor igual a 0 significa nunca verificar no servidor se a imagem já existir no cache."
+"updates to the screenshots may take longer to show to the user. A value of 0 "
+"means to never check the server if the image already exists in the cache."
+msgstr ""
+"Escolher um valor maior significará menos conexões com o servidor remoto, "
+"mas atualizações para as capturas de tela podem levar mais tempo para serem "
+"mostradas ao usuário. Um valor igual a 0 significa nunca verificar no "
+"servidor se a imagem já existir no cache."
 
 #: data/org.gnome.software.gschema.xml:78
 msgid "The server to use for application reviews"
@@ -197,22 +228,28 @@ msgstr "Avaliações com carma menor do que este número não serão mostradas."
 
 #: data/org.gnome.software.gschema.xml:87
 msgid "A list of official sources that should not be considered 3rd party"
-msgstr "Uma lista de fontes oficiais que não deveriam ser consideradas como de terceiros"
+msgstr ""
+"Uma lista de fontes oficiais que não deveriam ser consideradas como de "
+"terceiros"
 
 #: data/org.gnome.software.gschema.xml:91
 msgid "A list of official sources that should be considered free software"
-msgstr "Uma lista de fontes oficiais que deveriam ser consideradas como programa livre"
+msgstr ""
+"Uma lista de fontes oficiais que deveriam ser consideradas como programa "
+"livre"
 
 #: data/org.gnome.software.gschema.xml:95
 msgid ""
-"The licence URL to use when an application should be considered free "
-"software"
-msgstr "A URL da licença a ser usada quando um aplicativo deveria ser considerado como um programa livre"
+"The licence URL to use when an application should be considered free software"
+msgstr ""
+"A URL da licença a ser usada quando um aplicativo deveria ser considerado "
+"como um programa livre"
 
 #: data/org.gnome.software.gschema.xml:99
-msgid ""
-"Install bundled applications for all users on the system where possible"
-msgstr "Instalar aplicativos empacotados para os todos usuários no sistema, se possível"
+msgid "Install bundled applications for all users on the system where possible"
+msgstr ""
+"Instalar aplicativos empacotados para os todos usuários no sistema, se "
+"possível"
 
 #: data/org.gnome.software.gschema.xml:103
 msgid "Show the folder management UI"
@@ -228,7 +265,9 @@ msgstr "Oferecer atualizações para pré-lançamentos"
 
 #: data/org.gnome.software.gschema.xml:115
 msgid "Show some UI elements informing the user that an app is non-free"
-msgstr "Mostrar alguns elementos de interface gráfica informando ao usuário que um aplicativo é não-livre"
+msgstr ""
+"Mostrar alguns elementos de interface gráfica informando ao usuário que um "
+"aplicativo é não-livre"
 
 #: data/org.gnome.software.gschema.xml:119
 msgid "Show the prompt to install nonfree software sources"
@@ -240,7 +279,9 @@ msgstr "Mostrar programas não-livres nos resultados de pesquisa"
 
 #: data/org.gnome.software.gschema.xml:127
 msgid "Show the installed size for apps in the list of installed applications"
-msgstr "Mostrar o tamanho instalado para aplicativos na lista de aplicativos instalados"
+msgstr ""
+"Mostrar o tamanho instalado para aplicativos na lista de aplicativos "
+"instalados"
 
 #: data/org.gnome.software.gschema.xml:131
 msgid "The URI that explains nonfree and proprietary software"
@@ -248,17 +289,22 @@ msgstr "A URI que explica programas não-livres e proprietários"
 
 #: data/org.gnome.software.gschema.xml:135
 msgid "A list of non-free sources that can be optionally enabled"
-msgstr "Uma lista de fontes não-livres que tenham sido opcionalmente habilitadas"
+msgstr ""
+"Uma lista de fontes não-livres que tenham sido opcionalmente habilitadas"
 
 #: data/org.gnome.software.gschema.xml:139
 msgid ""
 "A list of URLs pointing to appstream files that will be downloaded into an "
 "app-info folder"
-msgstr "Uma lista de URLs apontando para os arquivos appstream que serão baixados para uma pasta de app-info"
+msgstr ""
+"Uma lista de URLs apontando para os arquivos appstream que serão baixados "
+"para uma pasta de app-info"
 
 #: data/org.gnome.software.gschema.xml:143
 msgid "Install the AppStream files to a system-wide location for all users"
-msgstr "Instalar os arquivos AppStream em uma localização global do sistema para todos os usuários"
+msgstr ""
+"Instalar os arquivos AppStream em uma localização global do sistema para "
+"todos os usuários"
 
 #: data/org.gnome.software.gschema.xml:147
 msgid "Sorts the apps shown in the overview in alphabetical order"
@@ -268,7 +314,9 @@ msgstr "Organiza em ordem alfabética os programas mostrados no panorama geral"
 msgid ""
 "Overrides the name of the \"Featured\" entry in the side-filter (category "
 "list)"
-msgstr "Substitui o nome da entrada \"Em destaque\" no filtro-lateral (lista de categoria)"
+msgstr ""
+"Substitui o nome da entrada \"Em destaque\" no filtro-lateral (lista de "
+"categoria)"
 
 #: src/gnome-software-local-file.desktop.in:3
 msgid "Software Install"
@@ -278,8 +326,7 @@ msgstr "Instalação de programa"
 msgid "Install selected software on the system"
 msgstr "Instala programas selecionados no sistema"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 #: src/gnome-software-local-file.desktop.in:10
 msgid "system-software-install"
 msgstr "system-software-install"
@@ -306,14 +353,12 @@ msgstr "Voltar"
 msgid "_All"
 msgstr "_Todos"
 
-#. Translators: A label for a button to show only software which is already
-#. installed.
+#. Translators: A label for a button to show only software which is already installed.
 #: src/gnome-software.ui:104
 msgid "_Installed"
 msgstr "_Instalados"
 
-#. Translators: A label for a button to show only updates which are available
-#. to install.
+#. Translators: A label for a button to show only updates which are available to install.
 #: src/gnome-software.ui:155
 msgid "_Updates"
 msgstr "_Atualizações"
@@ -361,7 +406,7 @@ msgstr "Instalado"
 
 #. TRANSLATORS: this is a button next to the search results that
 #. * shows the status of an application being installed
-#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:443
+#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:439
 msgid "Installing"
 msgstr "Instalando"
 
@@ -376,7 +421,7 @@ msgid "Folder Name"
 msgstr "Nome da pasta"
 
 #: src/gs-app-folder-dialog.c:321 src/gs-app-folder-dialog.ui:16
-#: src/gs-details-page.c:383 src/gs-details-page.ui:342 src/gs-editor.c:623
+#: src/gs-details-page.c:379 src/gs-details-page.ui:342 src/gs-editor.c:623
 #: src/gs-editor.c:655 src/gs-installed-page.c:609 src/gs-removal-dialog.ui:33
 #: src/gs-review-dialog.ui:23 src/gs-upgrade-banner.ui:131
 msgid "_Cancel"
@@ -391,90 +436,98 @@ msgid "Add to Application Folder"
 msgstr "Adicionar à pasta de aplicativo"
 
 #. TRANSLATORS: this is a command line option
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "Start up mode: either ‘updates’, ‘updated’, ‘installed’ or ‘overview’"
-msgstr "Modo de inicialização, podendo ser “updates” (para atualizações), “updated” (para atualizados), “installed” (para instalados) ou “overview” (para visão geral)"
+msgstr ""
+"Modo de inicialização, podendo ser “updates” (para atualizações), "
+"“updated” (para atualizados), “installed” (para instalados) ou "
+"“overview” (para visão geral)"
 
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "MODE"
 msgstr "MODO"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "Search for applications"
 msgstr "Pesquisa por aplicativos"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "SEARCH"
 msgstr "PESQUISA"
 
-#: src/gs-application.c:105
+#: src/gs-application.c:133
 msgid "Show application details (using application ID)"
 msgstr "Mostra detalhes do aplicativo (usando o ID do aplicativo)"
 
-#: src/gs-application.c:105 src/gs-application.c:109
+#: src/gs-application.c:133 src/gs-application.c:137
 msgid "ID"
 msgstr "ID"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "Show application details (using package name)"
 msgstr "Mostra detalhes do aplicativo (usando o nome do pacote)"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "PKGNAME"
 msgstr "NOMEPACOTE"
 
-#: src/gs-application.c:109
+#: src/gs-application.c:137
 msgid "Install the application (using application ID)"
 msgstr "Instala o aplicativo (usando o ID do aplicativo)"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "Open a local package file"
 msgstr "Abre um arquivo de pacote local"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "FILENAME"
 msgstr "NOMEDOARQUIVO"
 
-#: src/gs-application.c:113
+#: src/gs-application.c:141
 msgid ""
 "The kind of interaction expected for this action: either ‘none’, ‘notify’, "
 "or ‘full’"
-msgstr "O tipo de interação para essa ação: pode ser ‘none’, ‘notify’ ou ‘full’"
+msgstr ""
+"O tipo de interação para essa ação: pode ser ‘none’, ‘notify’ ou ‘full’"
 
-#: src/gs-application.c:116
+#: src/gs-application.c:144
 msgid "Show verbose debugging information"
 msgstr "Mostra informações detalhadas de depuração"
 
-#: src/gs-application.c:118
+#: src/gs-application.c:146
 msgid "Show profiling information for the service"
 msgstr "Mostra informações de criação de perfil para este serviço"
 
-#: src/gs-application.c:120
+#: src/gs-application.c:148
 msgid "Quit the running instance"
 msgstr "Sair da instância atual"
 
-#: src/gs-application.c:122
+#: src/gs-application.c:150
 msgid "Prefer local file sources to AppStream"
 msgstr "Preferência a fontes locais de arquivos ao AppStream"
 
-#: src/gs-application.c:124
+#: src/gs-application.c:152
 msgid "Show version number"
 msgstr "Mostra o número da versão"
 
-#: src/gs-application.c:325
+#: src/gs-application.c:358
 msgid "translator-credits"
-msgstr "Rafael Fontenelle <rafaelff@gnome.org>\nEnrico Nicoletto <liverig@gmail.com>\nGeorges Basile Stavracas Neto <georges.stavracas@gmail.com>\nGustavo Marques <gutodisse@gmail.com>"
+msgstr ""
+"Rafael Fontenelle <rafaelff@gnome.org>\n"
+"Enrico Nicoletto <liverig@gmail.com>\n"
+"Georges Basile Stavracas Neto <georges.stavracas@gmail.com>\n"
+"Gustavo Marques <gutodisse@gmail.com>"
 
 #. TRANSLATORS: this is the title of the about window, e.g.
 #. * 'About Software' or 'About Application Installer' where the %s is
 #. * the application name chosen by the distro
-#: src/gs-application.c:332
+#: src/gs-application.c:365
 #, c-format
 msgid "About %s"
 msgstr "Sobre o %s"
 
 #. TRANSLATORS: well, we seem to think so, anyway
-#: src/gs-application.c:336
+#: src/gs-application.c:369
 msgid "A nice way to manage the software on your system."
 msgstr "Um modo agradável de gerenciar programas no seu sistema."
 
@@ -589,7 +642,7 @@ msgid "All"
 msgstr "Todos"
 
 #. TRANSLATORS: this is a subcategory of featured apps
-#: lib/gs-category.c:202 src/gs-shell.c:2180
+#: lib/gs-category.c:202 src/gs-shell.c:2181
 msgid "Featured"
 msgstr "Destaques"
 
@@ -599,9 +652,11 @@ msgstr "Configurações de extensão"
 
 #: src/gs-category-page.ui:110
 msgid ""
-"Extensions are used at your own risk. If you have any system problems, it is"
-" recommended to disable them."
-msgstr "Extensões são usadas em seu próprio risco. Se você tiver quaisquer problemas, é recomendado desativá-las."
+"Extensions are used at your own risk. If you have any system problems, it is "
+"recommended to disable them."
+msgstr ""
+"Extensões são usadas em seu próprio risco. Se você tiver quaisquer "
+"problemas, é recomendado desativá-las."
 
 #. TRANSLATORS: the user isn't reading the question
 #: lib/gs-cmd.c:205
@@ -624,7 +679,8 @@ msgstr "Atualizações do SO estão agora instaladas"
 #. * have been successfully installed
 #: src/gs-common.c:138
 msgid "Recently installed updates are available to review"
-msgstr "As atualizações recentemente instaladas estão disponíveis para avaliação"
+msgstr ""
+"As atualizações recentemente instaladas estão disponíveis para avaliação"
 
 #. TRANSLATORS: this is the summary of a notification that an application
 #. * has been successfully installed
@@ -657,13 +713,16 @@ msgstr "Habilitar fontes de programas adicionais?"
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
 #. * 2. Software source name, e.g. fedora-optional
+#.
 #: src/gs-common.c:232
 #, c-format
 msgid ""
 "%s is not <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
-"source_software\">free and open source software</a>, and is provided by "
+"source_software\">free and open source software</a>, and is provided by “%s”."
+msgstr ""
+"%s não é um <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
+"source_software\">programa de código aberto e livre</a>, e é fornecido por "
 "“%s”."
-msgstr "%s não é um <a href=\"https://en.wikipedia.org/wiki/Free_and_open-source_software\">programa de código aberto e livre</a>, e é fornecido por “%s”."
 
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
@@ -676,7 +735,8 @@ msgstr "%s é fornecido por “%s”."
 #. TRANSLATORS: a software source is a repo
 #: src/gs-common.c:252
 msgid "This software source must be enabled to continue installation."
-msgstr "Esta fonte de programas deve estar habilitada para continuar a instalação."
+msgstr ""
+"Esta fonte de programas deve estar habilitada para continuar a instalação."
 
 #. TRANSLATORS: Laws are geographical, urgh...
 #: src/gs-common.c:262
@@ -738,17 +798,21 @@ msgstr "Sem violência de fantasia"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:90
 msgid "Characters in unsafe situations easily distinguishable from reality"
-msgstr "Personagens em situações inseguras facilmente distinguíveis da realidade"
+msgstr ""
+"Personagens em situações inseguras facilmente distinguíveis da realidade"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:93
 msgid "Characters in aggressive conflict easily distinguishable from reality"
-msgstr "Personagens em conflito agressivo facilmente distinguíveis da realidade"
+msgstr ""
+"Personagens em conflito agressivo facilmente distinguíveis da realidade"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:96
 msgid "Graphic violence easily distinguishable from reality"
-msgstr "Cenas fortes com violência envolvendo situações facilmente distinguíveis da realidade"
+msgstr ""
+"Cenas fortes com violência envolvendo situações facilmente distinguíveis da "
+"realidade"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:99
@@ -788,7 +852,8 @@ msgstr "Derramamento de sangue realista"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:120
 msgid "Depictions of bloodshed and the mutilation of body parts"
-msgstr "Representações de derramamento de sangue e mutilação de partes do corpo"
+msgstr ""
+"Representações de derramamento de sangue e mutilação de partes do corpo"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:123
@@ -933,7 +998,8 @@ msgstr "Discriminação projetada a causa ofensa emocional"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:207
 msgid "Explicit discrimination based on gender, sexuality, race or religion"
-msgstr "Discriminação explícita baseada em gênero, sexualidade, raça ou religião"
+msgstr ""
+"Discriminação explícita baseada em gênero, sexualidade, raça ou religião"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:210
@@ -998,7 +1064,8 @@ msgstr "Interações entre jogadores sem funcionalidade de bate-papo"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:246
 msgid "Player-to-player preset interactions without chat functionality"
-msgstr "Interações predefinidas entre jogadores sem funcionalidade de bate-papo"
+msgstr ""
+"Interações predefinidas entre jogadores sem funcionalidade de bate-papo"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:249
@@ -1013,17 +1080,21 @@ msgstr "Impossível falar com outros jogadores"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:255
 msgid "Uncontrolled audio or video chat functionality between players"
-msgstr "Funcionalidade de chamada de vídeo ou de áudio sem controle entre jogadores"
+msgstr ""
+"Funcionalidade de chamada de vídeo ou de áudio sem controle entre jogadores"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:258
 msgid "No sharing of social network usernames or email addresses"
-msgstr "Sem compartilhamento de nomes de usuários ou endereços de e-mail de rede social"
+msgstr ""
+"Sem compartilhamento de nomes de usuários ou endereços de e-mail de rede "
+"social"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:261
 msgid "Sharing social network usernames or email addresses"
-msgstr "Compartilhamento de nomes de usuários ou endereços de e-mail de rede social"
+msgstr ""
+"Compartilhamento de nomes de usuários ou endereços de e-mail de rede social"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:264
@@ -1045,14 +1116,12 @@ msgstr "Sem compartilhamento de localização física com outros usuários"
 msgid "Sharing physical location to other users"
 msgstr "Compartilhamento de localização física com outros usuários"
 
-#. TRANSLATORS: this is a what we use in notifications if the app's name is
-#. unknown
+#. TRANSLATORS: this is a what we use in notifications if the app's name is unknown
 #: src/gs-dbus-helper.c:294
 msgid "An application"
 msgstr "Um aplicativo"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. MIME types.
+#. TRANSLATORS: this is a notification displayed when an app needs additional MIME types.
 #: src/gs-dbus-helper.c:300
 #, c-format
 msgid "%s is requesting additional file format support."
@@ -1063,8 +1132,7 @@ msgstr "%s está requisitando suporte a formato do arquivo adicional."
 msgid "Additional MIME Types Required"
 msgstr "Tipos MIME adicionais necessárias"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. fonts.
+#. TRANSLATORS: this is a notification displayed when an app needs additional fonts.
 #: src/gs-dbus-helper.c:306
 #, c-format
 msgid "%s is requesting additional fonts."
@@ -1075,8 +1143,7 @@ msgstr "%s está requisitando fontes adicionais."
 msgid "Additional Fonts Required"
 msgstr "Fontes adicionais necessárias"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. codecs.
+#. TRANSLATORS: this is a notification displayed when an app needs additional codecs.
 #: src/gs-dbus-helper.c:312
 #, c-format
 msgid "%s is requesting additional multimedia codecs."
@@ -1087,8 +1154,7 @@ msgstr "%s está requisitando codecs de multimídia adicionais."
 msgid "Additional Multimedia Codecs Required"
 msgstr "Codecs multimídia adicionais necessários"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. printer drivers.
+#. TRANSLATORS: this is a notification displayed when an app needs additional printer drivers.
 #: src/gs-dbus-helper.c:318
 #, c-format
 msgid "%s is requesting additional printer drivers."
@@ -1099,8 +1165,7 @@ msgstr "%s está requisitando drivers de impressora adicionais."
 msgid "Additional Printer Drivers Required"
 msgstr "Drivers de impressora adicionais necessários"
 
-#. TRANSLATORS: this is a notification displayed when an app wants to install
-#. additional packages.
+#. TRANSLATORS: this is a notification displayed when an app wants to install additional packages.
 #: src/gs-dbus-helper.c:324
 #, c-format
 msgid "%s is requesting additional packages."
@@ -1120,14 +1185,14 @@ msgstr "Localizar em Programas"
 #. * can be installed
 #. TRANSLATORS: button text in the header when firmware
 #. * can be live-installed
-#: src/gs-details-page.c:281 src/gs-details-page.c:312
-#: src/gs-details-page.ui:206 src/gs-upgrade-banner.ui:146
+#: src/gs-details-page.c:280 src/gs-details-page.c:310
+#: src/gs-details-page.ui:237 src/gs-upgrade-banner.ui:146
 msgid "_Install"
 msgstr "_Instalar"
 
 #. TRANSLATORS: button text in the header when an application
 #. * can be live-updated
-#: src/gs-details-page.c:316
+#: src/gs-details-page.c:314
 msgid "_Update"
 msgstr "_Atualizar"
 
@@ -1135,67 +1200,68 @@ msgstr "_Atualizar"
 #. * be installed.
 #. * The ellipsis indicates that further steps are required,
 #. * e.g. enabling software sources or the like
-#: src/gs-details-page.c:330
+#: src/gs-details-page.c:326
 msgid "_Install…"
 msgstr "_Instalar…"
 
 #. TRANSLATORS: button text in the header when an application can be erased
-#: src/gs-details-page.c:377 src/gs-details-page.ui:547
+#: src/gs-details-page.c:373 src/gs-details-page.ui:547
 msgid "_Uninstall"
 msgstr "_Desinstalar"
 
-#: src/gs-details-page.c:438 src/gs-sources-dialog.c:513
+#: src/gs-details-page.c:434 src/gs-sources-dialog.c:513
 msgid "Removing…"
 msgstr "Removendo…"
 
 #. TRANSLATORS: this is the warning box
-#: src/gs-details-page.c:748
+#: src/gs-details-page.c:744
 msgid ""
 "This application can only be used when there is an active internet "
 "connection."
-msgstr "Este aplicativo só pode ser usado quando há uma conexão ativa com a Internet."
+msgstr ""
+"Este aplicativo só pode ser usado quando há uma conexão ativa com a Internet."
 
 #. TRANSLATORS: this is where the version is not known
-#: src/gs-details-page.c:892
+#: src/gs-details-page.c:888
 msgctxt "version"
 msgid "Unknown"
 msgstr "Desconhecido"
 
 #. TRANSLATORS: this is where we don't know the origin of the
 #. * application
-#: src/gs-details-page.c:971
+#: src/gs-details-page.c:967
 msgctxt "origin"
 msgid "Unknown"
 msgstr "Desconhecido"
 
 #. TRANSLATORS: we need a remote server to process
-#: src/gs-details-page.c:1378
+#: src/gs-details-page.c:1374
 msgid "You need internet access to write a review"
 msgstr "Você precisa de acesso à Internet para escrever uma avaliação"
 
-#: src/gs-details-page.c:1507
+#: src/gs-details-page.c:1503
 #, c-format
 msgid "Unable to find “%s”"
 msgstr "Não foi possível localizar “%s”"
 
 #. TRANSLATORS: see the wikipedia page
-#: src/gs-details-page.c:2087
+#: src/gs-details-page.c:2083
 msgid "Public domain"
 msgstr "Domínio público"
 
 #. TRANSLATORS: see GNU page
-#: src/gs-details-page.c:2103 src/gs-details-page.ui:1397
+#: src/gs-details-page.c:2099 src/gs-details-page.ui:1397
 msgid "Free Software"
 msgstr "Programa livre"
 
 #. TRANSLATORS: for the free software popover
-#: src/gs-details-page.c:2160
+#: src/gs-details-page.c:2156
 msgid "Users are bound by the following license:"
 msgid_plural "Users are bound by the following licenses:"
 msgstr[0] "Usuários estão vinculados pela seguinte licença:"
 msgstr[1] "Usuários estão vinculados pelas seguintes licenças:"
 
-#: src/gs-details-page.c:2176 src/gs-details-page.ui:1506
+#: src/gs-details-page.c:2172 src/gs-details-page.ui:1506
 msgid "More information"
 msgstr "Mais informações"
 
@@ -1203,15 +1269,13 @@ msgstr "Mais informações"
 msgid "Details page"
 msgstr "Página de detalhes"
 
-#. Translators: A label for a button to add a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:228
+#. Translators: A label for a button to add a shortcut to the selected application.
+#: src/gs-details-page.ui:209
 msgid "_Add to Desktop"
 msgstr "_Adicionar à Área de Trabalho"
 
-#. Translators: A label for a button to remove a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:245
+#. Translators: A label for a button to remove a shortcut to the selected application.
+#: src/gs-details-page.ui:226
 msgid "_Remove from Desktop"
 msgstr "_Remover da Área de Trabalho"
 
@@ -1232,7 +1296,9 @@ msgstr "Fontes de programas incluídas"
 msgid ""
 "This application includes a software source which provides updates, as well "
 "as access to other software."
-msgstr "Esse aplicativo inclui uma fonte de programas que fornece atualizações, assim como acesso a outros programas."
+msgstr ""
+"Esse aplicativo inclui uma fonte de programas que fornece atualizações, "
+"assim como acesso a outros programas."
 
 #: src/gs-details-page.ui:500
 msgid "No Software Source Included"
@@ -1242,16 +1308,19 @@ msgstr "Nenhuma fonte de programas incluída"
 msgid ""
 "This application does not include a software source. It will not be updated "
 "with new versions."
-msgstr "Esse aplicativo não inclui uma fonte de programas. Ele não será atualizado com novas versões."
+msgstr ""
+"Esse aplicativo não inclui uma fonte de programas. Ele não será atualizado "
+"com novas versões."
 
 #: src/gs-details-page.ui:515
 msgid ""
 "This software is already provided by your distribution and should not be "
 "replaced."
-msgstr "Esse programa já é fornecido por sua distribuição e não deveria ser substituído."
+msgstr ""
+"Esse programa já é fornecido por sua distribuição e não deveria ser "
+"substituído."
 
-#. Translators: a repository file used for installing software has been
-#. discovered.
+#. Translators: a repository file used for installing software has been discovered.
 #: src/gs-details-page.ui:528
 msgid "Software Source Identified"
 msgstr "Fonte de programas identificada"
@@ -1260,7 +1329,9 @@ msgstr "Fonte de programas identificada"
 msgid ""
 "Adding this software source will give you access to additional software and "
 "upgrades."
-msgstr "Adicionar essa fonte de programas lhe fornecerá acesso a programas e atualizações adicionais."
+msgstr ""
+"Adicionar essa fonte de programas lhe fornecerá acesso a programas e "
+"atualizações adicionais."
 
 #: src/gs-details-page.ui:530
 msgid "Only use software sources that you trust."
@@ -1352,14 +1423,12 @@ msgstr "Complementos"
 msgid "Selected add-ons will be installed with the application."
 msgstr "Os complementos selecionados serão instalados com o aplicativo."
 
-#. Translators: Header of the section with other users' opinions about the
-#. app.
+#. Translators: Header of the section with other users' opinions about the app.
 #: src/gs-details-page.ui:1233
 msgid "Reviews"
 msgstr "Avaliações"
 
-#. Translators: Button opening a dialog where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Button opening a dialog where the users can write and publish their opinions about the apps.
 #: src/gs-details-page.ui:1249
 msgid "_Write a Review"
 msgstr "_Escrever uma avaliação"
@@ -1371,9 +1440,11 @@ msgstr "_Mostrar mais"
 
 #: src/gs-details-page.ui:1414
 msgid ""
-"This means that the software can be freely run, copied, distributed, studied"
-" and modified."
-msgstr "Isso significa que o programa pode ser livremente executado, copiado, distribuído, estudado e modificado."
+"This means that the software can be freely run, copied, distributed, studied "
+"and modified."
+msgstr ""
+"Isso significa que o programa pode ser livremente executado, copiado, "
+"distribuído, estudado e modificado."
 
 #: src/gs-details-page.ui:1473
 msgid "Proprietary Software"
@@ -1384,7 +1455,10 @@ msgid ""
 "This means that the software is owned by an individual or a company. There "
 "are often restrictions on its use and its source code cannot usually be "
 "accessed."
-msgstr "Isso significa que o programa é propriedade de um indivíduo ou uma empresa. Com frequência há restrições a seu uso e seu código fonte geralmente não pode ser acessado."
+msgstr ""
+"Isso significa que o programa é propriedade de um indivíduo ou uma empresa. "
+"Com frequência há restrições a seu uso e seu código fonte geralmente não "
+"pode ser acessado."
 
 #: src/gs-details-page.ui:1535
 msgid "Unknown Software License"
@@ -1468,8 +1542,7 @@ msgstr "A lista de aplicativos possui alterações não salvas."
 msgid "Use verbose logging"
 msgstr "Usa registro verboso"
 
-#. TRANSLATORS: program name, an application to add and remove software
-#. repositories
+#. TRANSLATORS: program name, an application to add and remove software repositories
 #: src/gs-editor.c:1119
 msgid "GNOME Software Banner Designer"
 msgstr "Designer de banner do GNOME Software"
@@ -1498,8 +1571,7 @@ msgstr "Resenha"
 msgid "Editor’s Pick"
 msgstr "Escolha do editor"
 
-#. This check button controls whether the application’s banner appears in the
-#. “Featured” category
+#. This check button controls whether the application’s banner appears in the “Featured” category
 #: src/gs-editor.ui:397
 msgid "Category Featured"
 msgstr "Categoria em destaque"
@@ -1588,9 +1660,11 @@ msgstr "Não há aplicativos disponíveis que forneçam o arquivo %s."
 #: src/gs-extras-page.c:337 src/gs-extras-page.c:348 src/gs-extras-page.c:359
 #, c-format
 msgid ""
-"Information about %s, as well as options for how to get missing applications"
-" might be found %s."
-msgstr "Informações sobre %s, bem como as opções de como obter aplicativos que estejam faltando podem ser encontradas %s."
+"Information about %s, as well as options for how to get missing applications "
+"might be found %s."
+msgstr ""
+"Informações sobre %s, bem como as opções de como obter aplicativos que "
+"estejam faltando podem ser encontradas %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1613,7 +1687,9 @@ msgstr "%s não está disponível."
 msgid ""
 "Information about %s, as well as options for how to get an application that "
 "can support this format might be found %s."
-msgstr "Informações sobre %s, bem como as opções de como obter um aplicativo que pode oferecer suporte a este formato pode ser encontrado %s."
+msgstr ""
+"Informações sobre %s, bem como as opções de como obter um aplicativo que "
+"pode oferecer suporte a este formato pode ser encontrado %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1629,11 +1705,13 @@ msgstr "Não há fontes disponíveis com suporte ao script %s."
 msgid ""
 "Information about %s, as well as options for how to get additional fonts "
 "might be found %s."
-msgstr "Informações sobre %s, bem como as opções de como obter fontes adicionais podem ser encontradas %s."
+msgstr ""
+"Informações sobre %s, bem como as opções de como obter fontes adicionais "
+"podem ser encontradas %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
-#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1426
+#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1430
 #, c-format
 msgid "No addon codecs are available for the %s format."
 msgstr "Não há complementos de codecs disponíveis para o formato %s."
@@ -1645,7 +1723,9 @@ msgstr "Não há complementos de codecs disponíveis para o formato %s."
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format might be found %s."
-msgstr "Informações sobre %s, bem como as opções de como obter um codec que possa reproduzir este formato podem ser encontradas %s."
+msgstr ""
+"Informações sobre %s, bem como as opções de como obter um codec que possa "
+"reproduzir este formato podem ser encontradas %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1661,7 +1741,9 @@ msgstr "Não há recursos Plasma disponíveis para suporte a %s."
 msgid ""
 "Information about %s, as well as options for how to get additional Plasma "
 "resources might be found %s."
-msgstr "Informações sobre %s, bem como as opções de como obter recursos Plasma adicionais podem ser encontradas %s."
+msgstr ""
+"Informações sobre %s, bem como as opções de como obter recursos Plasma "
+"adicionais podem ser encontradas %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1677,15 +1759,16 @@ msgstr "Não há drivers de impressora disponíveis para %s."
 msgid ""
 "Information about %s, as well as options for how to get a driver that "
 "supports this printer might be found %s."
-msgstr "Informações sobre %s, bem como as opções de como obter um driver que ofereça suporte a esta impressora podem ser encontradas %s."
+msgstr ""
+"Informações sobre %s, bem como as opções de como obter um driver que ofereça "
+"suporte a esta impressora podem ser encontradas %s."
 
 #. TRANSLATORS: hyperlink title
 #: src/gs-extras-page.c:459
 msgid "this website"
 msgstr "este site"
 
-#. TRANSLATORS: no codecs were found. First %s will be replaced by actual
-#. codec name(s), second %s is a link titled "this website"
+#. TRANSLATORS: no codecs were found. First %s will be replaced by actual codec name(s), second %s is a link titled "this website"
 #: src/gs-extras-page.c:463
 #, c-format
 msgid ""
@@ -1694,8 +1777,12 @@ msgid ""
 msgid_plural ""
 "Unfortunately, the %s you were searching for could not be found. Please see "
 "%s for more information."
-msgstr[0] "Infelizmente, o %s que você estava procurando não pôde ser encontrado. Por favor veja %s para mais informações."
-msgstr[1] "Infelizmente, os %s que você estava procurando não puderam ser encontrados. Por favor veja %s para mais informações."
+msgstr[0] ""
+"Infelizmente, o %s que você estava procurando não pôde ser encontrado. Por "
+"favor veja %s para mais informações."
+msgstr[1] ""
+"Infelizmente, os %s que você estava procurando não puderam ser encontrados. "
+"Por favor veja %s para mais informações."
 
 #: src/gs-extras-page.c:535 src/gs-extras-page.c:591 src/gs-extras-page.c:630
 msgid "Failed to find any search results"
@@ -1720,10 +1807,13 @@ msgstr "Bem-vindo ao Software"
 
 #: src/gs-first-run-dialog.ui:66
 msgid ""
-"Software lets you install all the software you need, all from one place. See"
-" our recommendations, browse the categories, or search for the applications "
+"Software lets you install all the software you need, all from one place. See "
+"our recommendations, browse the categories, or search for the applications "
 "you want."
-msgstr "O aplicativo Software permite a você instalar todos os programas que você precisa, tudo de um só lugar. Consulte nossas recomendações, navegue pelas categorias ou pesquise pelos aplicativos que desejar."
+msgstr ""
+"O aplicativo Software permite a você instalar todos os programas que você "
+"precisa, tudo de um só lugar. Consulte nossas recomendações, navegue pelas "
+"categorias ou pesquise pelos aplicativos que desejar."
 
 #: src/gs-first-run-dialog.ui:85
 msgid "_Let’s Go Shopping"
@@ -1873,13 +1963,14 @@ msgstr "Aplicativos de produtividade recomendados"
 #: src/gs-overview-page.c:974
 msgid ""
 "Provides access to additional software, including web browsers and games."
-msgstr "Fornece acesso a programas adicionais, incluindo navegadores web e jogos."
+msgstr ""
+"Fornece acesso a programas adicionais, incluindo navegadores web e jogos."
 
 #. TRANSLATORS: this is the proprietary info bar
 #: src/gs-overview-page.c:978
-msgid ""
-"Proprietary software has restrictions on use and access to source code."
-msgstr "Programas proprietários possuem restrição de uso e acesso ao código fonte."
+msgid "Proprietary software has restrictions on use and access to source code."
+msgstr ""
+"Programas proprietários possuem restrição de uso e acesso ao código fonte."
 
 #. TRANSLATORS: this is the clickable
 #. * link on the proprietary info bar
@@ -1908,14 +1999,12 @@ msgstr "Aplicativo em destaque"
 msgid "Categories"
 msgstr "Categorias"
 
-#. Translators: This is a heading for software which has been featured
-#. ('picked') by the distribution.
+#. Translators: This is a heading for software which has been featured ('picked') by the distribution.
 #: src/gs-overview-page.ui:315
 msgid "Editor’s Picks"
 msgstr "Escolha do editor"
 
-#. Translators: This is a heading for software which has been recently
-#. released upstream.
+#. Translators: This is a heading for software which has been recently released upstream.
 #: src/gs-overview-page.ui:359
 msgid "Recent Releases"
 msgstr "Lançamentos recentes"
@@ -1962,7 +2051,9 @@ msgstr "Você tem certeza de que deseja remover a fonte %s?"
 msgid ""
 "All applications from %s will be removed, and you will have to re-install "
 "the source to use them again."
-msgstr "Todos os aplicativos de %s serão removidos e você precisará reinstalar a fonte para usá-los novamente."
+msgstr ""
+"Todos os aplicativos de %s serão removidos e você precisará reinstalar a "
+"fonte para usá-los novamente."
 
 #. TRANSLATORS: this is a prompt message, and '%s' is an
 #. * application summary, e.g. 'GNOME Clocks'
@@ -1977,12 +2068,14 @@ msgstr "Você tem certeza de que deseja remover %s?"
 msgid "%s will be removed, and you will have to install it to use it again."
 msgstr "%s será removido e para usá-lo novamente, você precisará instalá-lo."
 
-#: lib/gs-plugin-loader.c:1429
+#: lib/gs-plugin-loader.c:1433
 #, c-format
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format can be found on the website."
-msgstr "Informações sobre %s, bem como as opções de como obter um codec que pode reproduzir este formato podem ser encontradas no site da web."
+msgstr ""
+"Informações sobre %s, bem como as opções de como obter um codec que pode "
+"reproduzir este formato podem ser encontradas no site da web."
 
 #: lib/gs-price.c:111
 #, c-format
@@ -2041,7 +2134,10 @@ msgstr "%s %f"
 msgid ""
 "Some of the currently installed software is not compatible with %s. If you "
 "continue, the following will be automatically removed during the upgrade:"
-msgstr "Alguns dos programas atualmente instalados não são compatíveis com %s. Se você continuar, o seguinte será automaticamente removido durante a atualização:"
+msgstr ""
+"Alguns dos programas atualmente instalados não são compatíveis com %s. Se "
+"você continuar, o seguinte será automaticamente removido durante a "
+"atualização:"
 
 #: src/gs-removal-dialog.ui:27
 msgid "Incompatible Software"
@@ -2111,8 +2207,7 @@ msgstr "A descrição está curta demais"
 msgid "The description is too long"
 msgstr "A descrição está grande demais"
 
-#. Translators: Title of the dialog box where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Title of the dialog box where the users can write and publish their opinions about the apps.
 #: src/gs-review-dialog.ui:11
 msgid "Post Review"
 msgstr "Publicar avaliação"
@@ -2130,7 +2225,9 @@ msgstr "Classificação"
 msgid ""
 "Give a short summary of your review, for example: “Great app, would "
 "recommend”."
-msgstr "Forneça uma breve resenha da sua avaliação, por exemplo: “Ótimo aplicativo, eu recomendo”."
+msgstr ""
+"Forneça uma breve resenha da sua avaliação, por exemplo: “Ótimo aplicativo, "
+"eu recomendo”."
 
 #. Translators: This is where the users enter their opinions about the apps.
 #: src/gs-review-dialog.ui:199
@@ -2150,14 +2247,18 @@ msgstr "classificações no total"
 #. TRANSLATORS: we explain what the action is going to do
 #: src/gs-review-row.c:234
 msgid "You can report reviews for abusive, rude, or discriminatory behavior."
-msgstr "Você pode relatar avaliações para comportamento abusivo, rude ou discriminatório."
+msgstr ""
+"Você pode relatar avaliações para comportamento abusivo, rude ou "
+"discriminatório."
 
 #. TRANSLATORS: we ask the user if they really want to do this
 #: src/gs-review-row.c:239
 msgid ""
 "Once reported, a review will be hidden until it has been checked by an "
 "administrator."
-msgstr "Uma vez relatada, uma avaliação será ocultada até que seja verificada por um administrador."
+msgstr ""
+"Uma vez relatada, uma avaliação será ocultada até que seja verificada por um "
+"administrador."
 
 #. TRANSLATORS: window title when
 #. * reporting a user-submitted review
@@ -2172,8 +2273,7 @@ msgstr "Relatar avaliação?"
 msgid "Report"
 msgstr "Relatar"
 
-#. Translators: Users can express their opinions about other users' opinions
-#. about the apps.
+#. Translators: Users can express their opinions about other users' opinions about the apps.
 #: src/gs-review-row.ui:112
 msgid "Was this review useful to you?"
 msgstr "A avaliação foi útil para você?"
@@ -2262,81 +2362,87 @@ msgstr "Nenhum aplicativo encontrado"
 #. TRANSLATORS: this is part of the in-app notification,
 #. * where the %s is a multi-word localised app name
 #. * e.g. 'Getting things GNOME!"
-#: src/gs-shell.c:846 src/gs-shell.c:851 src/gs-shell.c:866 src/gs-shell.c:870
+#: src/gs-shell.c:847 src/gs-shell.c:852 src/gs-shell.c:867 src/gs-shell.c:871
 #, c-format
 msgid "“%s”"
 msgstr "“%s”"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:898
+#: src/gs-shell.c:899
 #, c-format
 msgid "Unable to download firmware updates from %s"
 msgstr "Não foi possível baixar atualizações de firmware de %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:904
+#: src/gs-shell.c:905
 #, c-format
 msgid "Unable to download updates from %s"
 msgstr "Não foi possível baixar atualizações de %s"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:911
+#: src/gs-shell.c:912
 msgid "Unable to download updates"
 msgstr "Não foi possível baixar as atualizações"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:916
+#: src/gs-shell.c:917
 msgid ""
-"Unable to download updates: internet access was required but wasn’t "
-"available"
-msgstr "Não foi possível baixar as atualizações: foi solicitado acesso à Internet, mas a mesma não está disponível"
+"Unable to download updates: internet access was required but wasn’t available"
+msgstr ""
+"Não foi possível baixar as atualizações: foi solicitado acesso à Internet, "
+"mas a mesma não está disponível"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:925
+#: src/gs-shell.c:926
 #, c-format
 msgid "Unable to download updates from %s: not enough disk space"
-msgstr "Não foi possível baixar as atualizações de %s: não há espaço suficiente em disco"
+msgstr ""
+"Não foi possível baixar as atualizações de %s: não há espaço suficiente em "
+"disco"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:930
+#: src/gs-shell.c:931
 msgid "Unable to download updates: not enough disk space"
-msgstr "Não foi possível baixar as atualizações: não há espaço suficiente em disco"
+msgstr ""
+"Não foi possível baixar as atualizações: não há espaço suficiente em disco"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:938
+#: src/gs-shell.c:939
 msgid "Unable to download updates: authentication was required"
 msgstr "Não foi possível baixar atualizações: requer autenticação"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:943
+#: src/gs-shell.c:944
 msgid "Unable to download updates: authentication was invalid"
 msgstr "Não foi possível baixar atualizações: autenticação inválida"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:948
+#: src/gs-shell.c:949
 msgid ""
 "Unable to download updates: you do not have permission to install software"
-msgstr "Não foi baixar atualizações: você não tem permissão para instalar esse software"
+msgstr ""
+"Não foi baixar atualizações: você não tem permissão para instalar esse "
+"software"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:955
+#: src/gs-shell.c:956
 msgid "Unable to get list of updates"
 msgstr "Não foi possível obter a lista de atualizações"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the application name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1001
+#: src/gs-shell.c:1002
 #, c-format
 msgid "Unable to install %s as download failed from %s"
 msgstr "Não foi possível instalar %s, pois o download de %s falhou"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1007
+#: src/gs-shell.c:1008
 #, c-format
 msgid "Unable to install %s as download failed"
 msgstr "Não foi possível instalar %s, pois o download falhou"
@@ -2345,86 +2451,90 @@ msgstr "Não foi possível instalar %s, pois o download falhou"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1019
+#: src/gs-shell.c:1020
 #, c-format
 msgid "Unable to install %s as runtime %s not available"
 msgstr "Não foi possível instalar %s, pois o runtime %s não está disponível"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1025
+#: src/gs-shell.c:1026
 #, c-format
 msgid "Unable to install %s as not supported"
 msgstr "Não foi possível instalar %s, pois não há suporte"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1032
+#: src/gs-shell.c:1033
 msgid "Unable to install: internet access was required but wasn’t available"
-msgstr "Não foi possível instalar: foi solicitado acesso à Internet, mas o mesmo não está disponível"
+msgstr ""
+"Não foi possível instalar: foi solicitado acesso à Internet, mas o mesmo não "
+"está disponível"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1038
+#: src/gs-shell.c:1039
 msgid "Unable to install: the application has an invalid format"
 msgstr "Não foi possível instalar: o aplicativo tem um formato inválido"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1043
+#: src/gs-shell.c:1044
 #, c-format
 msgid "Unable to install %s: not enough disk space"
 msgstr "Não foi possível instalar %s: não há espaço suficiente em disco"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1051
+#: src/gs-shell.c:1052
 #, c-format
 msgid "Unable to install %s: authentication was required"
 msgstr "Não foi possível instalar %s: requer autenticação"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1058
+#: src/gs-shell.c:1059
 #, c-format
 msgid "Unable to install %s: authentication was invalid"
 msgstr "Não foi possível instalar %s: autenticação inválida"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1065
+#: src/gs-shell.c:1066
 #, c-format
 msgid "Unable to install %s: you do not have permission to install software"
-msgstr "Não foi possível instalar %s: você não tem permissão para instalar esse software"
+msgstr ""
+"Não foi possível instalar %s: você não tem permissão para instalar esse "
+"software"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the name of the authentication service,
 #. * e.g. "Ubuntu One"
-#: src/gs-shell.c:1078
+#: src/gs-shell.c:1079
 #, c-format
 msgid "Your %s account has been suspended."
 msgstr "Sua conta %s foi suspensa."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1082
+#: src/gs-shell.c:1083
 msgid "It is not possible to install software until this has been resolved."
 msgstr "Não é possível instalar o software até que isso tenha sido resolvido."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the clickable link (e.g.
 #. * "http://example.com/what-did-i-do-wrong/")
-#: src/gs-shell.c:1093
+#: src/gs-shell.c:1094
 #, c-format
 msgid "For more information, visit %s."
 msgstr "Para mais informações, visite %s."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1102
+#: src/gs-shell.c:1103
 #, c-format
 msgid "Unable to install %s: AC power is required"
 msgstr "Não foi possível instalar %s: requer energia AC"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1111
+#: src/gs-shell.c:1112
 #, c-format
 msgid "Unable to install %s"
 msgstr "Não foi possível instalar %s"
@@ -2433,61 +2543,65 @@ msgstr "Não foi possível instalar %s"
 #. * where the first %s is the app name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1157
+#: src/gs-shell.c:1158
 #, c-format
 msgid "Unable to update %s from %s"
 msgstr "Não foi possível atualizar %s de %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1163
+#: src/gs-shell.c:1164
 #, c-format
 msgid "Unable to update %s as download failed"
 msgstr "Não foi possível atualizar %s, pois o download falhou"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1169
+#: src/gs-shell.c:1170
 msgid "Unable to update: internet access was required but wasn’t available"
-msgstr "Não foi possível atualizar: foi solicitado acesso à Internet, mas a mesma não está disponível"
+msgstr ""
+"Não foi possível atualizar: foi solicitado acesso à Internet, mas a mesma "
+"não está disponível"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1177
+#: src/gs-shell.c:1178
 #, c-format
 msgid "Unable to update %s: not enough disk space"
 msgstr "Não foi possível atualizar %s: não há espaço suficiente em disco"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1186
+#: src/gs-shell.c:1187
 #, c-format
 msgid "Unable to update %s: authentication was required"
 msgstr "Não foi possível atualizar %s: requer autenticação"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1193
+#: src/gs-shell.c:1194
 #, c-format
 msgid "Unable to update %s: authentication was invalid"
 msgstr "Não foi possível atualizar %s: autenticação inválida"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1200
+#: src/gs-shell.c:1201
 #, c-format
 msgid "Unable to update %s: you do not have permission to update software"
-msgstr "Não foi possível atualizar %s: você não tem permissão para atualizar esse software"
+msgstr ""
+"Não foi possível atualizar %s: você não tem permissão para atualizar esse "
+"software"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1208
+#: src/gs-shell.c:1209
 #, c-format
 msgid "Unable to update %s: AC power is required"
 msgstr "Não foi possível atualizar %s: requer energia AC"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1217
+#: src/gs-shell.c:1218
 #, c-format
 msgid "Unable to update %s"
 msgstr "Não foi possível atualizar %s"
@@ -2495,96 +2609,101 @@ msgstr "Não foi possível atualizar %s"
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the distro name (e.g. "Fedora 25") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1262
+#: src/gs-shell.c:1263
 #, c-format
 msgid "Unable to upgrade to %s from %s"
 msgstr "Não foi possível atualizar para %s de %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the app name (e.g. "GIMP")
-#: src/gs-shell.c:1267
+#: src/gs-shell.c:1268
 #, c-format
 msgid "Unable to upgrade to %s as download failed"
 msgstr "Não foi possível atualizar %s pois o download falhou"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1274
+#: src/gs-shell.c:1275
 msgid "Unable to upgrade: internet access was required but wasn’t available"
-msgstr "Não foi possível atualizar: foi solicitado acesso à Internet, mas a mesma não está disponível"
+msgstr ""
+"Não foi possível atualizar: foi solicitado acesso à Internet, mas a mesma "
+"não está disponível"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1282
+#: src/gs-shell.c:1283
 #, c-format
 msgid "Unable to upgrade to %s: not enough disk space"
 msgstr "Não foi possível atualizar para %s: não há espaço suficiente em disco"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1291
+#: src/gs-shell.c:1292
 #, c-format
 msgid "Unable to upgrade to %s: authentication was required"
 msgstr "Não foi possível atualizar para %s: requer autenticação"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1298
+#: src/gs-shell.c:1299
 #, c-format
 msgid "Unable to upgrade to %s: authentication was invalid"
 msgstr "Não foi possível atualizar para %s: autenticação inválida"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1305
+#: src/gs-shell.c:1306
 #, c-format
 msgid "Unable to upgrade to %s: you do not have permission to upgrade"
-msgstr "Não foi possível atualizar para %s: você não tem permissão para atualizar"
+msgstr ""
+"Não foi possível atualizar para %s: você não tem permissão para atualizar"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1312
+#: src/gs-shell.c:1313
 #, c-format
 msgid "Unable to upgrade to %s: AC power is required"
 msgstr "Não foi possível atualizar para %s: requer energia AC"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1321
+#: src/gs-shell.c:1322
 #, c-format
 msgid "Unable to upgrade to %s"
 msgstr "Não foi possível atualizar para %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1363
+#: src/gs-shell.c:1364
 #, c-format
 msgid "Unable to remove %s: authentication was required"
 msgstr "Não foi possível remover %s: requer autenticação"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1369
+#: src/gs-shell.c:1370
 #, c-format
 msgid "Unable to remove %s: authentication was invalid"
 msgstr "Não foi possível remover %s: autenticação inválida"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1375
+#: src/gs-shell.c:1376
 #, c-format
 msgid "Unable to remove %s: you do not have permission to remove software"
-msgstr "Não foi possível remover %s: você não tem permissão para remover esse software"
+msgstr ""
+"Não foi possível remover %s: você não tem permissão para remover esse "
+"software"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1382
+#: src/gs-shell.c:1383
 #, c-format
 msgid "Unable to remove %s: AC power is required"
 msgstr "Não foi possível remover %s: requer energia AC"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1391
+#: src/gs-shell.c:1392
 #, c-format
 msgid "Unable to remove %s"
 msgstr "Não foi possível remover %s"
@@ -2593,48 +2712,49 @@ msgstr "Não foi possível remover %s"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1437
+#: src/gs-shell.c:1438
 #, c-format
 msgid "Unable to launch %s: %s is not installed"
 msgstr "Não é possível iniciar %s: %s não está instalado"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1444 src/gs-shell.c:1492 src/gs-shell.c:1540
+#: src/gs-shell.c:1445 src/gs-shell.c:1493 src/gs-shell.c:1541
 msgid "Not enough disk space — free up some space and try again"
-msgstr "Não há espaço suficiente em disco — libere algum espaço e tente novamente"
+msgstr ""
+"Não há espaço suficiente em disco — libere algum espaço e tente novamente"
 
 #. TRANSLATORS: we failed to get a proper error code
-#: src/gs-shell.c:1452 src/gs-shell.c:1500 src/gs-shell.c:1567
+#: src/gs-shell.c:1453 src/gs-shell.c:1501 src/gs-shell.c:1568
 msgid "Sorry, something went wrong"
 msgstr "Desculpe, alguma coisa deu errado"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1487
+#: src/gs-shell.c:1488
 msgid "Failed to install file: authentication failed"
 msgstr "Falha ao instalar o arquivo: a autenticação falhou"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1534
+#: src/gs-shell.c:1535
 #, c-format
 msgid "Unable to contact %s"
 msgstr "Não foi possível entrar em contato com %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1549
+#: src/gs-shell.c:1550
 #, c-format
 msgid "%s needs to be restarted to use new plugins."
 msgstr "%s precisa ser reiniciado para usar novos plug-ins."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1554
+#: src/gs-shell.c:1555
 msgid "This application needs to be restarted to use new plugins."
 msgstr "Esse aplicativo precisa ser reiniciado para usar novos plug-ins."
 
 #. TRANSLATORS: need to be connected to the AC power
-#: src/gs-shell.c:1561
+#: src/gs-shell.c:1562
 msgid "AC power is required"
 msgstr "Energia AC é necessária"
 
@@ -2642,7 +2762,9 @@ msgstr "Energia AC é necessária"
 #. has no software installed from it.
 #: src/gs-sources-dialog.c:98
 msgid "No applications or addons installed; other software might still be"
-msgstr "Sem aplicativos ou complementos instalados; também pode ser o caso de outro software"
+msgstr ""
+"Sem aplicativos ou complementos instalados; também pode ser o caso de outro "
+"software"
 
 #. TRANSLATORS: This string is used to construct the 'X applications
 #. installed' sentence, describing a software source.
@@ -2721,7 +2843,9 @@ msgstr "o sistema operacional"
 msgid ""
 "Software sources can be downloaded from the internet. They give you access "
 "to additional software that is not provided by %s."
-msgstr "Fontes de programas podem ser carregadas da internet. Elas lhe dão acesso a programas e atualizações adicionais que não são providos por %s."
+msgstr ""
+"Fontes de programas podem ser carregadas da internet. Elas lhe dão acesso a "
+"programas e atualizações adicionais que não são providos por %s."
 
 #: src/gs-sources-dialog.ui:155
 msgid "Additional Sources"
@@ -2730,7 +2854,9 @@ msgstr "Fontes adicionais"
 #: src/gs-sources-dialog.ui:175
 msgid ""
 "Removing a source will also remove any software you have installed from it."
-msgstr "Remover uma fonte também vai remover qualquer programa que você tenha instalado dela."
+msgstr ""
+"Remover uma fonte também vai remover qualquer programa que você tenha "
+"instalado dela."
 
 #: src/gs-sources-dialog.ui:260
 msgid "No software installed from this source"
@@ -2837,7 +2963,9 @@ msgstr "Atualizações de softwares disponíveis"
 
 #: src/gs-update-monitor.c:97
 msgid "Important OS and application updates are ready to be installed"
-msgstr "Atualizações importantes do sistema operacional e de aplicativos estão prontas para serem instaladas"
+msgstr ""
+"Atualizações importantes do sistema operacional e de aplicativos estão "
+"prontas para serem instaladas"
 
 #. TRANSLATORS: button text
 #: src/gs-update-monitor.c:100 src/gs-updates-page.c:775
@@ -2928,29 +3056,38 @@ msgstr "A atualização foi cancelada."
 #. * something with no network available
 #: src/gs-update-monitor.c:714
 msgid ""
-"Internet access was required but wasn’t available. Please make sure that you"
-" have internet access and try again."
-msgstr "Era necessário acesso à internet, mas que não estava disponível. Por favor, certifique-se de que você possui acesso à internet e tente novamente."
+"Internet access was required but wasn’t available. Please make sure that you "
+"have internet access and try again."
+msgstr ""
+"Era necessário acesso à internet, mas que não estava disponível. Por favor, "
+"certifique-se de que você possui acesso à internet e tente novamente."
 
 #. TRANSLATORS: if the package is not signed correctly
 #: src/gs-update-monitor.c:720
 msgid ""
 "There were security issues with the update. Please consult your software "
 "provider for more details."
-msgstr "Ocorreram problemas de segurança com a atualização. Por favor consulte o seu fornecedor de software para mais detalhes."
+msgstr ""
+"Ocorreram problemas de segurança com a atualização. Por favor consulte o seu "
+"fornecedor de software para mais detalhes."
 
 #. TRANSLATORS: we ran out of disk space
 #: src/gs-update-monitor.c:726
 msgid ""
 "There wasn’t enough disk space. Please free up some space and try again."
-msgstr "Não há espaço suficiente em disco. Por favor libere algum espaço e tente novamente."
+msgstr ""
+"Não há espaço suficiente em disco. Por favor libere algum espaço e tente "
+"novamente."
 
 #. TRANSLATORS: We didn't handle the error type
 #: src/gs-update-monitor.c:731
 msgid ""
 "We’re sorry: the update failed to install. Please wait for another update "
 "and try again. If the problem persists, contact your software provider."
-msgstr "Desculpe-nos: ocorreu falha na instalação da atualização. Por favor aguarde por outra atualização e tente novamente. Se o problema continuar, entre em contato com seu fornecedor de software."
+msgstr ""
+"Desculpe-nos: ocorreu falha na instalação da atualização. Por favor aguarde "
+"por outra atualização e tente novamente. Se o problema continuar, entre em "
+"contato com seu fornecedor de software."
 
 #. TRANSLATORS: Time in 24h format
 #: src/gs-updates-page.c:297
@@ -3130,7 +3267,9 @@ msgstr "Podem ser feitas cobranças"
 msgid ""
 "Checking for updates while using mobile broadband could cause you to incur "
 "charges."
-msgstr "Verificar atualizações quando se está usando conexão móvel pode resultar em cobranças extras."
+msgstr ""
+"Verificar atualizações quando se está usando conexão móvel pode resultar em "
+"cobranças extras."
 
 #. TRANSLATORS: this is a link to the
 #. * control-center network panel
@@ -3169,7 +3308,9 @@ msgstr "Os programas estão atualizados"
 msgid ""
 "Checking for updates when using mobile broadband could cause you to incur "
 "charges"
-msgstr "Verificar atualizações quando se está usando conexão móvel pode resultar em cobranças extras"
+msgstr ""
+"Verificar atualizações quando se está usando conexão móvel pode resultar em "
+"cobranças extras"
 
 #: src/gs-updates-page.ui:257
 msgid "_Check Anyway"
@@ -3223,7 +3364,9 @@ msgstr "A_prenda mais"
 #: src/gs-upgrade-banner.ui:98
 msgid ""
 "It is recommended that you back up your data and files before upgrading."
-msgstr "É recomendável que faça uma cópia de segurança dos seus dados e arquivos antes de atualizar."
+msgstr ""
+"É recomendável que faça uma cópia de segurança dos seus dados e arquivos "
+"antes de atualizar."
 
 #: src/gs-upgrade-banner.ui:116
 msgid "_Download"
@@ -3234,22 +3377,27 @@ msgid "App Center"
 msgstr "Central de Programas"
 
 #: src/org.gnome.Software.desktop.in:4
+msgid "More Apps"
+msgstr "Mais Programas"
+
+#: src/org.gnome.Software.desktop.in:5
 msgid "Add, remove or update software on this computer"
 msgstr "Adiciona, remove ou atualiza programas neste computador"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
-#: src/org.gnome.Software.desktop.in:6
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: src/org.gnome.Software.desktop.in:7
 #: src/org.gnome.Software.Editor.desktop.in:6
 msgid "org.gnome.Software"
 msgstr "org.gnome.Software"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
-#: src/org.gnome.Software.desktop.in:12
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: src/org.gnome.Software.desktop.in:13
 msgid ""
-"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;"
-msgstr "Atualizações;Upgrade;Atualização;Fontes;Repositórios;Preferências;Instalação;Instalar;Desinstalar;Programa;Software;Aplicativo;App;Loja;Store;"
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;"
+msgstr ""
+"Atualizações;Upgrade;Atualização;Fontes;Repositórios;Preferências;Instalação;"
+"Instalar;Desinstalar;Programa;Software;Aplicativo;App;Loja;Store;"
 
 #: src/org.gnome.Software.Editor.desktop.in:3
 msgid "Banner Designer"
@@ -3259,8 +3407,7 @@ msgstr "Designer de banner"
 msgid "Design the featured banners for GNOME Software"
 msgstr "Crie seus banners de destaque para o GNOME Software"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: src/org.gnome.Software.Editor.desktop.in:13
 msgid "AppStream;Software;App;"
 msgstr "AppStream;Software;App;Aplicativo;"
@@ -3530,100 +3677,111 @@ msgctxt "Menu of Communication & News"
 msgid "Web Browsers"
 msgstr "Navegadores web"
 
-#: plugins/core/gs-desktop-common.c:247
-msgctxt "Menu of Reference"
-msgid "All"
-msgstr "Todos"
-
-#: plugins/core/gs-desktop-common.c:250
-msgctxt "Menu of Reference"
-msgid "Featured"
-msgstr "Destaques"
-
-#: plugins/core/gs-desktop-common.c:253
-msgctxt "Menu of Reference"
-msgid "Art"
-msgstr "Artes"
-
-#: plugins/core/gs-desktop-common.c:256
-msgctxt "Menu of Reference"
-msgid "Biography"
-msgstr "Biografia"
-
-#: plugins/core/gs-desktop-common.c:259
-msgctxt "Menu of Reference"
-msgid "Comics"
-msgstr "História em quadrinhos"
-
-#: plugins/core/gs-desktop-common.c:262
-msgctxt "Menu of Reference"
-msgid "Fiction"
-msgstr "Ficção"
-
-#: plugins/core/gs-desktop-common.c:265
-msgctxt "Menu of Reference"
-msgid "Health"
-msgstr "Saúde"
-
-#: plugins/core/gs-desktop-common.c:268
-msgctxt "Menu of Reference"
-msgid "History"
-msgstr "História"
-
-#: plugins/core/gs-desktop-common.c:271
-msgctxt "Menu of Reference"
-msgid "Lifestyle"
-msgstr "Estilo de vida"
-
-#: plugins/core/gs-desktop-common.c:274
+#: plugins/core/gs-desktop-common.c:242
 msgctxt "Menu of Communication & News"
 msgid "News"
 msgstr "Notícias"
 
+#: plugins/core/gs-desktop-common.c:251
+msgctxt "Menu of Reference"
+msgid "All"
+msgstr "Todos"
+
+#: plugins/core/gs-desktop-common.c:254
+msgctxt "Menu of Reference"
+msgid "Featured"
+msgstr "Destaques"
+
+#: plugins/core/gs-desktop-common.c:257
+msgctxt "Menu of Reference"
+msgid "Art"
+msgstr "Artes"
+
+#: plugins/core/gs-desktop-common.c:260
+msgctxt "Menu of Reference"
+msgid "Biography"
+msgstr "Biografia"
+
+#: plugins/core/gs-desktop-common.c:263
+msgctxt "Menu of Reference"
+msgid "Comics"
+msgstr "História em quadrinhos"
+
+#: plugins/core/gs-desktop-common.c:266
+msgctxt "Menu of Reference"
+msgid "Feed"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:269
+msgctxt "Menu of Reference"
+msgid "Fiction"
+msgstr "Ficção"
+
+#: plugins/core/gs-desktop-common.c:272
+msgctxt "Menu of Reference"
+msgid "Health"
+msgstr "Saúde"
+
+#: plugins/core/gs-desktop-common.c:275
+msgctxt "Menu of Reference"
+msgid "History"
+msgstr "História"
+
 #: plugins/core/gs-desktop-common.c:278
+msgctxt "Menu of Reference"
+msgid "Lifestyle"
+msgstr "Estilo de vida"
+
+#: plugins/core/gs-desktop-common.c:281
+#, fuzzy
+msgctxt "Menu of Reference"
+msgid "News"
+msgstr "Notícias"
+
+#: plugins/core/gs-desktop-common.c:284
 msgctxt "Menu of Reference"
 msgid "Politics"
 msgstr "Política"
 
-#: plugins/core/gs-desktop-common.c:281
+#: plugins/core/gs-desktop-common.c:287
 msgctxt "Menu of Reference"
 msgid "Sports"
 msgstr "Esportes"
 
 #. TRANSLATORS: this is the menu spec main category for Learning
-#: plugins/core/gs-desktop-common.c:291
+#: plugins/core/gs-desktop-common.c:297
 msgid "Learning"
 msgstr "Aprendizagem"
 
 #. TRANSLATORS: this is the menu spec main category for Game
-#: plugins/core/gs-desktop-common.c:294
+#: plugins/core/gs-desktop-common.c:300
 msgid "Games"
 msgstr "Jogos"
 
 #. TRANSLATORS: this is the menu spec main category for Multimedia
-#: plugins/core/gs-desktop-common.c:297
+#: plugins/core/gs-desktop-common.c:303
 msgid "Multimedia"
 msgstr "Multimídia"
 
 #. TRANSLATORS: this is the menu spec main category for Work
-#: plugins/core/gs-desktop-common.c:300
+#: plugins/core/gs-desktop-common.c:306
 msgid "Work"
 msgstr "Trabalho"
 
 #. TRANSLATORS: this is the menu spec main category for Reference
-#: plugins/core/gs-desktop-common.c:303
+#: plugins/core/gs-desktop-common.c:309
 msgid "Reference & News"
 msgstr "Notícias e Informações"
 
 #. TRANSLATORS: this is the menu spec main category for Utilities
-#: plugins/core/gs-desktop-common.c:306
+#: plugins/core/gs-desktop-common.c:312
 msgid "Utilities"
 msgstr "Utilitários"
 
 #. TRANSLATORS: this is the menu spec main category for Dev Tools; it
 #. * should be a relatively short label; as an example, in Portuguese and
 #. * Spanish the direct translation of "Programming" (noun) is used
-#: plugins/core/gs-desktop-common.c:311
+#: plugins/core/gs-desktop-common.c:317
 msgid "Dev Tools"
 msgstr "Programação"
 
@@ -3649,16 +3807,16 @@ msgstr "Inclui melhorias de desempenho, estabilidade e segurança."
 msgid "Downloading featured images…"
 msgstr "Baixando imagens de destaques…"
 
-#: plugins/eos/gs-plugin-eos.c:1249
+#: plugins/eos/gs-plugin-eos.c:1233
 #, c-format
 msgid "Could not launch this application."
 msgstr "Não foi possível abrir este aplicativo"
 
-#: plugins/eos/gs-plugin-eos.c:1305
+#: plugins/eos/gs-plugin-eos.c:1289
 msgid "Endless Platform"
 msgstr "Plataforma Endless"
 
-#: plugins/eos/gs-plugin-eos.c:1308
+#: plugins/eos/gs-plugin-eos.c:1292
 msgid "Framework for applications"
 msgstr "Framework para aplicações"
 
@@ -3718,13 +3876,13 @@ msgid "Flatpak is a framework for desktop applications on Linux"
 msgstr "Flatpak é um framework para aplicativos no Linux"
 
 #. TRANSLATORS: status text when downloading new metadata
-#: plugins/flatpak/gs-flatpak.c:821
+#: plugins/flatpak/gs-flatpak.c:815
 #, c-format
 msgid "Getting flatpak metadata for %s…"
 msgstr "Obtendo metadados de flatpak para %s…"
 
 #. TRANSLATORS: status text when downloading the RuntimeRepo
-#: plugins/flatpak/gs-flatpak.c:2796
+#: plugins/flatpak/gs-flatpak.c:2803
 msgid "Getting runtime source…"
 msgstr "Obtendo fontes de runtime…"
 
@@ -3757,7 +3915,9 @@ msgstr "Suporte limba"
 
 #: plugins/limba/org.gnome.Software.Plugin.Limba.metainfo.xml.in:7
 msgid "Limba provides developers a way to easily create software bundles"
-msgstr "Limba permite aos desenvolvedores uma forma fácil de criar pacotes de softwares"
+msgstr ""
+"Limba permite aos desenvolvedores uma forma fácil de criar pacotes de "
+"softwares"
 
 #. TRANSLATORS: status text when downloading
 #: plugins/odrs/gs-plugin-odrs.c:205

--- a/po/ro.po
+++ b/po/ro.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the gnome-software package.
-# 
+#
 # Translators:
 # Bogdan Mințoi <mintoi.bogdan@gmail.com>, 2014
 # Daniel Șerbănescu <daniel [at] serbanescu [dot] dk>, 2014-2015
@@ -11,15 +11,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-software\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-12 22:31-0700\n"
+"POT-Creation-Date: 2017-11-02 16:28+0100\n"
 "PO-Revision-Date: 2017-10-13 06:27+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
-"Language-Team: Romanian (http://www.transifex.com/endless-mobile-inc/gnome-software/language/ro/)\n"
+"Language-Team: Romanian (http://www.transifex.com/endless-mobile-inc/gnome-"
+"software/language/ro/)\n"
+"Language: ro\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ro\n"
-"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?"
+"2:1));\n"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:7
 msgid "GNOME Software"
@@ -33,7 +35,9 @@ msgstr "Administrator de aplicații pentru GNOME"
 msgid ""
 "Software allows you to find and install new applications and system "
 "extensions and remove existing installed applications."
-msgstr "Aplicații vă permite să gasiți și să instalați aplicații noi și extensii de sistem sau să eliminați altele deja instalate."
+msgstr ""
+"Aplicații vă permite să gasiți și să instalați aplicații noi și extensii de "
+"sistem sau să eliminați altele deja instalate."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:14
 msgid ""
@@ -41,7 +45,12 @@ msgid ""
 "descriptions and multiple screenshots per application. Applications can be "
 "found either through browsing the list of categories or by searching. It "
 "also allows you to update your system using an offline update."
-msgstr "Aplicații GNOME prezintă aplicații recomandate și populare care conțin descrieri folositoare și capturi de ecran multiple pentru fiecare aplicație. Acestea pot fi găsite fie prin răsfoirea listei categoriilor fie printr-o simplă căutare. Vă permite, de asemenea, să actualizați sistemul prin intermediul unei actualizări în modul deconectat."
+msgstr ""
+"Aplicații GNOME prezintă aplicații recomandate și populare care conțin "
+"descrieri folositoare și capturi de ecran multiple pentru fiecare aplicație. "
+"Acestea pot fi găsite fie prin răsfoirea listei categoriilor fie printr-o "
+"simplă căutare. Vă permite, de asemenea, să actualizați sistemul prin "
+"intermediul unei actualizări în modul deconectat."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:25
 msgid "Overview panel"
@@ -85,7 +94,9 @@ msgstr "Daca sa administrezi actualizarile in softul GNOME"
 msgid ""
 "If disabled, GNOME Software will hide the updates panel and not perform any "
 "automatic updates actions."
-msgstr "Daca este dezactivat,softul GNOME va ascunde actualizarile si nu va actualiza automat softul"
+msgstr ""
+"Daca este dezactivat,softul GNOME va ascunde actualizarile si nu va "
+"actualiza automat softul"
 
 #: data/org.gnome.software.gschema.xml:15
 msgid "Whether to automatically download updates"
@@ -93,9 +104,11 @@ msgstr "Daca descarci actualizari automat"
 
 #: data/org.gnome.software.gschema.xml:16
 msgid ""
-"If enabled, GNOME Software automatically downloads updates in the background"
-" and prompts the user to install them when ready."
-msgstr "Daca este activat,softul GNOME descarca automat in fundal actualizarile si informeaza utilizatorul cand sa le instaleze"
+"If enabled, GNOME Software automatically downloads updates in the background "
+"and prompts the user to install them when ready."
+msgstr ""
+"Daca este activat,softul GNOME descarca automat in fundal actualizarile si "
+"informeaza utilizatorul cand sa le instaleze"
 
 #: data/org.gnome.software.gschema.xml:20
 msgid "Whether to automatically refresh when on a metered connection"
@@ -106,7 +119,10 @@ msgid ""
 "If enabled, GNOME Software automatically refreshes in the background even "
 "when using a metered connection (eventually downloading some metadata, "
 "checking for updates, etc., which may incur in costs for the user)."
-msgstr "Cand este activat,Softul GNOME se reimprospateaza automat in fundal chiar si cand se foloseste o conexiune masurata (se descarca unele metadate,se cauta actualizari,etc..,care poate cauza unele costuri)"
+msgstr ""
+"Cand este activat,Softul GNOME se reimprospateaza automat in fundal chiar si "
+"cand se foloseste o conexiune masurata (se descarca unele metadate,se cauta "
+"actualizari,etc..,care poate cauza unele costuri)"
 
 #: data/org.gnome.software.gschema.xml:25
 msgid "Whether it’s the very first run of GNOME Software"
@@ -118,17 +134,22 @@ msgstr "Arata evaluari langa aplicatii"
 
 #: data/org.gnome.software.gschema.xml:33
 msgid "Filter applications based on the default branch set for the remote"
-msgstr "Aplicatii de filtrare bazate pe setul implicit pentru ramura de la distanță"
+msgstr ""
+"Aplicatii de filtrare bazate pe setul implicit pentru ramura de la distanță"
 
 #: data/org.gnome.software.gschema.xml:37
 msgid "Non-free applications show a warning dialog before install"
-msgstr "Aplicatiile care nu sunt gratuite arata un dialog de avertizare inainte de instalare"
+msgstr ""
+"Aplicatiile care nu sunt gratuite arata un dialog de avertizare inainte de "
+"instalare"
 
 #: data/org.gnome.software.gschema.xml:38
 msgid ""
-"When non-free applications are installed a warning dialog can be shown. This"
-" controls if that dialog is suppressed."
-msgstr "Cand aplicatiile non-free se instaleaza,un dialog de avertizare poate fi afișat.Acest lucru controlează în cazul în care dialogul este suprimat."
+"When non-free applications are installed a warning dialog can be shown. This "
+"controls if that dialog is suppressed."
+msgstr ""
+"Cand aplicatiile non-free se instaleaza,un dialog de avertizare poate fi "
+"afișat.Acest lucru controlează în cazul în care dialogul este suprimat."
 
 #: data/org.gnome.software.gschema.xml:42
 msgid "A list of popular applications"
@@ -146,7 +167,9 @@ msgstr "Lista surselor suplimentare care au fost activate în prealabil"
 msgid ""
 "The list of sources that have been previously enabled when installing third-"
 "party applications."
-msgstr "Lista de surse care au fost activate în prealabil atunci când instalați aplicații de la terți."
+msgstr ""
+"Lista de surse care au fost activate în prealabil atunci când instalați "
+"aplicații de la terți."
 
 #: data/org.gnome.software.gschema.xml:52
 msgid "The last update check timestamp"
@@ -166,14 +189,19 @@ msgstr "Data de la ultima actualizare"
 
 #: data/org.gnome.software.gschema.xml:68
 msgid "The age in seconds to verify the upstream screenshot is still valid"
-msgstr "Vârsta în secunde pentru a verifica daca captura de ecran  este încă valabilă"
+msgstr ""
+"Vârsta în secunde pentru a verifica daca captura de ecran  este încă valabilă"
 
 #: data/org.gnome.software.gschema.xml:69
 msgid ""
 "Choosing a larger value will mean less round-trips to the remote server but "
-"updates to the screenshots may take longer to show to the user. A value of 0"
-" means to never check the server if the image already exists in the cache."
-msgstr "Alegand o valoare mai mare va însemna mai puține  drumuri la serverul de la distanță, dar actualizările la screenshot-uri poate dura mai mult pentru a le arăta utilizatorului. O valoare de 0 înseamnă să nu verifice serverul dacă există deja imaginea în cache."
+"updates to the screenshots may take longer to show to the user. A value of 0 "
+"means to never check the server if the image already exists in the cache."
+msgstr ""
+"Alegand o valoare mai mare va însemna mai puține  drumuri la serverul de la "
+"distanță, dar actualizările la screenshot-uri poate dura mai mult pentru a "
+"le arăta utilizatorului. O valoare de 0 înseamnă să nu verifice serverul "
+"dacă există deja imaginea în cache."
 
 #: data/org.gnome.software.gschema.xml:78
 msgid "The server to use for application reviews"
@@ -189,22 +217,27 @@ msgstr "Review-uri cu karma mai mică decât acest număr nu vor fi afișate."
 
 #: data/org.gnome.software.gschema.xml:87
 msgid "A list of official sources that should not be considered 3rd party"
-msgstr "O listă de surse oficiale, care ar trebui să fie luate în considerare ca a 3-a parte"
+msgstr ""
+"O listă de surse oficiale, care ar trebui să fie luate în considerare ca a 3-"
+"a parte"
 
 #: data/org.gnome.software.gschema.xml:91
 msgid "A list of official sources that should be considered free software"
-msgstr "O listă de surse oficiale, care ar trebui să fie luate în considerare gratuite"
+msgstr ""
+"O listă de surse oficiale, care ar trebui să fie luate în considerare "
+"gratuite"
 
 #: data/org.gnome.software.gschema.xml:95
 msgid ""
-"The licence URL to use when an application should be considered free "
-"software"
-msgstr "Licența de a utiliza URL-ul atunci când o aplicatie este considerata gratuita"
+"The licence URL to use when an application should be considered free software"
+msgstr ""
+"Licența de a utiliza URL-ul atunci când o aplicatie este considerata gratuita"
 
 #: data/org.gnome.software.gschema.xml:99
-msgid ""
-"Install bundled applications for all users on the system where possible"
-msgstr "Instalati pachetele de aplicații pentru toți utilizatorii de sistem în cazul în care este posibil"
+msgid "Install bundled applications for all users on the system where possible"
+msgstr ""
+"Instalati pachetele de aplicații pentru toți utilizatorii de sistem în cazul "
+"în care este posibil"
 
 #: data/org.gnome.software.gschema.xml:103
 msgid "Show the folder management UI"
@@ -220,7 +253,9 @@ msgstr "Ofera actualizari pentru pre-lansare"
 
 #: data/org.gnome.software.gschema.xml:115
 msgid "Show some UI elements informing the user that an app is non-free"
-msgstr "Prezintă unele elemente UI care informează utilizatorul că o aplicație nu este gratuita"
+msgstr ""
+"Prezintă unele elemente UI care informează utilizatorul că o aplicație nu "
+"este gratuita"
 
 #: data/org.gnome.software.gschema.xml:119
 msgid "Show the prompt to install nonfree software sources"
@@ -232,7 +267,9 @@ msgstr "Arata software non-gratuit in rezultatele cautarii"
 
 #: data/org.gnome.software.gschema.xml:127
 msgid "Show the installed size for apps in the list of installed applications"
-msgstr "Afișați dimensiunea instalata pentru aplicațiile din lista de aplicații instalate"
+msgstr ""
+"Afișați dimensiunea instalata pentru aplicațiile din lista de aplicații "
+"instalate"
 
 #: data/org.gnome.software.gschema.xml:131
 msgid "The URI that explains nonfree and proprietary software"
@@ -246,7 +283,9 @@ msgstr "O listă de surse non-gratuite, care pot fi activate în mod opțional"
 msgid ""
 "A list of URLs pointing to appstream files that will be downloaded into an "
 "app-info folder"
-msgstr "O listă de URL-uri care indică fișiere appstream care vor fi descărcate într-un dosar app-info"
+msgstr ""
+"O listă de URL-uri care indică fișiere appstream care vor fi descărcate într-"
+"un dosar app-info"
 
 #: data/org.gnome.software.gschema.xml:143
 msgid "Install the AppStream files to a system-wide location for all users"
@@ -254,13 +293,16 @@ msgstr ""
 
 #: data/org.gnome.software.gschema.xml:147
 msgid "Sorts the apps shown in the overview in alphabetical order"
-msgstr "Sortează în ordine alfabetică aplicațiile afișate în prezentare generală"
+msgstr ""
+"Sortează în ordine alfabetică aplicațiile afișate în prezentare generală"
 
 #: data/org.gnome.software.gschema.xml:151
 msgid ""
 "Overrides the name of the \"Featured\" entry in the side-filter (category "
 "list)"
-msgstr "Înlocuiește numele intrării \"Recomandate\" din filtrul lateral (lista de categorii)"
+msgstr ""
+"Înlocuiește numele intrării \"Recomandate\" din filtrul lateral (lista de "
+"categorii)"
 
 #: src/gnome-software-local-file.desktop.in:3
 msgid "Software Install"
@@ -270,8 +312,7 @@ msgstr "Instalare aplicații"
 msgid "Install selected software on the system"
 msgstr "Instalează aplicațiile selectate pe calculator"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 #: src/gnome-software-local-file.desktop.in:10
 msgid "system-software-install"
 msgstr "sistem-soft-instalare"
@@ -298,14 +339,12 @@ msgstr "Înapoi"
 msgid "_All"
 msgstr "_Tot"
 
-#. Translators: A label for a button to show only software which is already
-#. installed.
+#. Translators: A label for a button to show only software which is already installed.
 #: src/gnome-software.ui:104
 msgid "_Installed"
 msgstr "_Instalat"
 
-#. Translators: A label for a button to show only updates which are available
-#. to install.
+#. Translators: A label for a button to show only updates which are available to install.
 #: src/gnome-software.ui:155
 msgid "_Updates"
 msgstr "Act_ualizări"
@@ -353,7 +392,7 @@ msgstr "Instalat"
 
 #. TRANSLATORS: this is a button next to the search results that
 #. * shows the status of an application being installed
-#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:443
+#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:439
 msgid "Installing"
 msgstr "Se instalează"
 
@@ -368,7 +407,7 @@ msgid "Folder Name"
 msgstr "Nume dosar"
 
 #: src/gs-app-folder-dialog.c:321 src/gs-app-folder-dialog.ui:16
-#: src/gs-details-page.c:383 src/gs-details-page.ui:342 src/gs-editor.c:623
+#: src/gs-details-page.c:379 src/gs-details-page.ui:342 src/gs-editor.c:623
 #: src/gs-editor.c:655 src/gs-installed-page.c:609 src/gs-removal-dialog.ui:33
 #: src/gs-review-dialog.ui:23 src/gs-upgrade-banner.ui:131
 msgid "_Cancel"
@@ -383,90 +422,96 @@ msgid "Add to Application Folder"
 msgstr "Adaugă la dosarul de aplicații"
 
 #. TRANSLATORS: this is a command line option
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "Start up mode: either ‘updates’, ‘updated’, ‘installed’ or ‘overview’"
-msgstr "Mod de pornire: fie „actualizări”, „actualizat”, „instalat” sau „prezentare generală”"
+msgstr ""
+"Mod de pornire: fie „actualizări”, „actualizat”, „instalat” sau „prezentare "
+"generală”"
 
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "MODE"
 msgstr "MOD"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "Search for applications"
 msgstr "Căutați aplicații"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "SEARCH"
 msgstr "CAUTĂ"
 
-#: src/gs-application.c:105
+#: src/gs-application.c:133
 msgid "Show application details (using application ID)"
 msgstr "Arata detaliile aplicatiei (folosind ID-ul aplicatiei)"
 
-#: src/gs-application.c:105 src/gs-application.c:109
+#: src/gs-application.c:133 src/gs-application.c:137
 msgid "ID"
 msgstr "ID"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "Show application details (using package name)"
 msgstr "Arata detaliile aplicatiei (folosind numele pachetului)"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "PKGNAME"
 msgstr "Numele Pachetului"
 
-#: src/gs-application.c:109
+#: src/gs-application.c:137
 msgid "Install the application (using application ID)"
 msgstr "Instaleaza aplicatia (folosind ID-ul aplicatiei)"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "Open a local package file"
 msgstr "Deschide un pachet local"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "FILENAME"
 msgstr "NUME FIȘIER"
 
-#: src/gs-application.c:113
+#: src/gs-application.c:141
 msgid ""
 "The kind of interaction expected for this action: either ‘none’, ‘notify’, "
 "or ‘full’"
-msgstr "Genul de interacțiune așteptata pentru această acțiune: fie \"nici unul\", \"notifică\", sau \"complet\""
+msgstr ""
+"Genul de interacțiune așteptata pentru această acțiune: fie \"nici unul\", "
+"\"notifică\", sau \"complet\""
 
-#: src/gs-application.c:116
+#: src/gs-application.c:144
 msgid "Show verbose debugging information"
 msgstr "Arată informații detaliate de depanare"
 
-#: src/gs-application.c:118
+#: src/gs-application.c:146
 msgid "Show profiling information for the service"
 msgstr "Arată informații de profil pentru acest serviciu"
 
-#: src/gs-application.c:120
+#: src/gs-application.c:148
 msgid "Quit the running instance"
 msgstr "Renunta la instanta care se executa"
 
-#: src/gs-application.c:122
+#: src/gs-application.c:150
 msgid "Prefer local file sources to AppStream"
 msgstr "Preferă surse de fișiere locale pentru AppStream"
 
-#: src/gs-application.c:124
+#: src/gs-application.c:152
 msgid "Show version number"
 msgstr "Arata numarul versiunii"
 
-#: src/gs-application.c:325
+#: src/gs-application.c:358
 msgid "translator-credits"
-msgstr "Bogdan Mințoi <mintoi [dot ] bogdan [at] gmail [dot] com> 2014\nAdrian Gabor <raziel_theripper [at] yahoo [dot] com> 2015"
+msgstr ""
+"Bogdan Mințoi <mintoi [dot ] bogdan [at] gmail [dot] com> 2014\n"
+"Adrian Gabor <raziel_theripper [at] yahoo [dot] com> 2015"
 
 #. TRANSLATORS: this is the title of the about window, e.g.
 #. * 'About Software' or 'About Application Installer' where the %s is
 #. * the application name chosen by the distro
-#: src/gs-application.c:332
+#: src/gs-application.c:365
 #, c-format
 msgid "About %s"
 msgstr "Despre %s"
 
 #. TRANSLATORS: well, we seem to think so, anyway
-#: src/gs-application.c:336
+#: src/gs-application.c:369
 msgid "A nice way to manage the software on your system."
 msgstr "Un mod plăcut de a administra aplicații pentru sistemul dumneavoastră."
 
@@ -558,7 +603,8 @@ msgstr "Autentificate automat data viitoare"
 
 #: src/gs-auth-dialog.ui:210
 msgid "Enter your one-time pin for two-factor authentication."
-msgstr "Introduceți codul PIN o singură dată pentru autentificarea cu doi factori."
+msgstr ""
+"Introduceți codul PIN o singură dată pentru autentificarea cu doi factori."
 
 #: src/gs-auth-dialog.ui:223
 msgid "PIN"
@@ -581,7 +627,7 @@ msgid "All"
 msgstr "Toate"
 
 #. TRANSLATORS: this is a subcategory of featured apps
-#: lib/gs-category.c:202 src/gs-shell.c:2180
+#: lib/gs-category.c:202 src/gs-shell.c:2181
 msgid "Featured"
 msgstr "Recomandate"
 
@@ -591,9 +637,11 @@ msgstr "Setari Extensii"
 
 #: src/gs-category-page.ui:110
 msgid ""
-"Extensions are used at your own risk. If you have any system problems, it is"
-" recommended to disable them."
-msgstr "Extensiile sunt folosite pe risc propriu.Daca aveti probleme cu sistemul,este recomandat sa le dezactivati."
+"Extensions are used at your own risk. If you have any system problems, it is "
+"recommended to disable them."
+msgstr ""
+"Extensiile sunt folosite pe risc propriu.Daca aveti probleme cu sistemul,"
+"este recomandat sa le dezactivati."
 
 #. TRANSLATORS: the user isn't reading the question
 #: lib/gs-cmd.c:205
@@ -649,13 +697,15 @@ msgstr "Activați sursa terță de aplicații?"
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
 #. * 2. Software source name, e.g. fedora-optional
+#.
 #: src/gs-common.c:232
 #, c-format
 msgid ""
 "%s is not <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
-"source_software\">free and open source software</a>, and is provided by "
-"“%s”."
-msgstr "%s nu este <a href=\"https://ro.wikipedia.org/wiki/Software_liber\">software gratuit și liber</a> și este furnizat de către  „%s”."
+"source_software\">free and open source software</a>, and is provided by “%s”."
+msgstr ""
+"%s nu este <a href=\"https://ro.wikipedia.org/wiki/Software_liber\">software "
+"gratuit și liber</a> și este furnizat de către  „%s”."
 
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
@@ -668,7 +718,9 @@ msgstr "%s este furnizat de către „%s”."
 #. TRANSLATORS: a software source is a repo
 #: src/gs-common.c:252
 msgid "This software source must be enabled to continue installation."
-msgstr "Această sursă de aplicații trebuie activată petru a putea continua instalarea."
+msgstr ""
+"Această sursă de aplicații trebuie activată petru a putea continua "
+"instalarea."
 
 #. TRANSLATORS: Laws are geographical, urgh...
 #: src/gs-common.c:262
@@ -679,7 +731,8 @@ msgstr "Ar putea fi ilegală instalarea sau folosirea lui %s în anumite țări.
 #. TRANSLATORS: Laws are geographical, urgh...
 #: src/gs-common.c:268
 msgid "It may be illegal to install or use this codec in some countries."
-msgstr "Ar putea fi ilegală instalarea sau folosirea acestui codec în anumite țări."
+msgstr ""
+"Ar putea fi ilegală instalarea sau folosirea acestui codec în anumite țări."
 
 #. TRANSLATORS: this is button text to not ask about non-free content again
 #: src/gs-common.c:275
@@ -945,7 +998,8 @@ msgstr "Trimiterile explicite la anumite mărci sau produse de mărci comerciale
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:219
 msgid "Players are encouraged to purchase specific real-world items"
-msgstr "Jucătorii sunt încurajați să achiziționeze obiecte specifice din lumea reală"
+msgstr ""
+"Jucătorii sunt încurajați să achiziționeze obiecte specifice din lumea reală"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:222
@@ -1010,7 +1064,8 @@ msgstr "Functionalitate necontrolata chat audio sau video între jucători"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:258
 msgid "No sharing of social network usernames or email addresses"
-msgstr "Fara partajarea numelor de pe retele de socializare sau a adreselor de e-mail"
+msgstr ""
+"Fara partajarea numelor de pe retele de socializare sau a adreselor de e-mail"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:261
@@ -1020,7 +1075,8 @@ msgstr "Partajare nume utilizator rețea socială și adresa de e-mail"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:264
 msgid "No sharing of user information with 3rd parties"
-msgstr "Fara partajarea cu privire la informatiile utilizatorilor cu partile terte"
+msgstr ""
+"Fara partajarea cu privire la informatiile utilizatorilor cu partile terte"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:267
@@ -1037,14 +1093,12 @@ msgstr "Fara partajarea locatiei fizice catre alti utilizatori"
 msgid "Sharing physical location to other users"
 msgstr "Partajarea locației fizice către alți utilizatori"
 
-#. TRANSLATORS: this is a what we use in notifications if the app's name is
-#. unknown
+#. TRANSLATORS: this is a what we use in notifications if the app's name is unknown
 #: src/gs-dbus-helper.c:294
 msgid "An application"
 msgstr "O aplicație"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. MIME types.
+#. TRANSLATORS: this is a notification displayed when an app needs additional MIME types.
 #: src/gs-dbus-helper.c:300
 #, c-format
 msgid "%s is requesting additional file format support."
@@ -1055,8 +1109,7 @@ msgstr "%s cere suport adițional pentru formatul de fișier"
 msgid "Additional MIME Types Required"
 msgstr "Sunt necesare tipuri MIME adiționale"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. fonts.
+#. TRANSLATORS: this is a notification displayed when an app needs additional fonts.
 #: src/gs-dbus-helper.c:306
 #, c-format
 msgid "%s is requesting additional fonts."
@@ -1067,8 +1120,7 @@ msgstr "%s necesită fonturi adiționale."
 msgid "Additional Fonts Required"
 msgstr "Sunt necesare fonturi adiționale"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. codecs.
+#. TRANSLATORS: this is a notification displayed when an app needs additional codecs.
 #: src/gs-dbus-helper.c:312
 #, c-format
 msgid "%s is requesting additional multimedia codecs."
@@ -1079,8 +1131,7 @@ msgstr "%s cere codecuri multimedia adiționale."
 msgid "Additional Multimedia Codecs Required"
 msgstr "Sunt necesare codecuri multimedia adiționale"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. printer drivers.
+#. TRANSLATORS: this is a notification displayed when an app needs additional printer drivers.
 #: src/gs-dbus-helper.c:318
 #, c-format
 msgid "%s is requesting additional printer drivers."
@@ -1091,8 +1142,7 @@ msgstr "%s cere drivere adiționale pentru imprimantă."
 msgid "Additional Printer Drivers Required"
 msgstr "Sunt necesare drivere adiționale pentru imprimantă"
 
-#. TRANSLATORS: this is a notification displayed when an app wants to install
-#. additional packages.
+#. TRANSLATORS: this is a notification displayed when an app wants to install additional packages.
 #: src/gs-dbus-helper.c:324
 #, c-format
 msgid "%s is requesting additional packages."
@@ -1112,14 +1162,14 @@ msgstr "Găsește în Aplicații"
 #. * can be installed
 #. TRANSLATORS: button text in the header when firmware
 #. * can be live-installed
-#: src/gs-details-page.c:281 src/gs-details-page.c:312
-#: src/gs-details-page.ui:206 src/gs-upgrade-banner.ui:146
+#: src/gs-details-page.c:280 src/gs-details-page.c:310
+#: src/gs-details-page.ui:237 src/gs-upgrade-banner.ui:146
 msgid "_Install"
 msgstr "_Instalează"
 
 #. TRANSLATORS: button text in the header when an application
 #. * can be live-updated
-#: src/gs-details-page.c:316
+#: src/gs-details-page.c:314
 msgid "_Update"
 msgstr "_Actualizeaza"
 
@@ -1127,68 +1177,70 @@ msgstr "_Actualizeaza"
 #. * be installed.
 #. * The ellipsis indicates that further steps are required,
 #. * e.g. enabling software sources or the like
-#: src/gs-details-page.c:330
+#: src/gs-details-page.c:326
 msgid "_Install…"
 msgstr "_Instalează…"
 
 #. TRANSLATORS: button text in the header when an application can be erased
-#: src/gs-details-page.c:377 src/gs-details-page.ui:547
+#: src/gs-details-page.c:373 src/gs-details-page.ui:547
 msgid "_Uninstall"
 msgstr "_Dezinstaleaza"
 
-#: src/gs-details-page.c:438 src/gs-sources-dialog.c:513
+#: src/gs-details-page.c:434 src/gs-sources-dialog.c:513
 msgid "Removing…"
 msgstr "Se elimină…"
 
 #. TRANSLATORS: this is the warning box
-#: src/gs-details-page.c:748
+#: src/gs-details-page.c:744
 msgid ""
 "This application can only be used when there is an active internet "
 "connection."
-msgstr "Această aplicație poate fi utilizată doar când este prezentă o conexiune activă de internet."
+msgstr ""
+"Această aplicație poate fi utilizată doar când este prezentă o conexiune "
+"activă de internet."
 
 #. TRANSLATORS: this is where the version is not known
-#: src/gs-details-page.c:892
+#: src/gs-details-page.c:888
 msgctxt "version"
 msgid "Unknown"
 msgstr "Necunoscută"
 
 #. TRANSLATORS: this is where we don't know the origin of the
 #. * application
-#: src/gs-details-page.c:971
+#: src/gs-details-page.c:967
 msgctxt "origin"
 msgid "Unknown"
 msgstr "Necunoscută"
 
 #. TRANSLATORS: we need a remote server to process
-#: src/gs-details-page.c:1378
+#: src/gs-details-page.c:1374
 msgid "You need internet access to write a review"
 msgstr "Este necesar accesul la internet pentru a scrie o recenzie"
 
-#: src/gs-details-page.c:1507
+#: src/gs-details-page.c:1503
 #, c-format
 msgid "Unable to find “%s”"
 msgstr "Nu sa gasit \"%s\""
 
 #. TRANSLATORS: see the wikipedia page
-#: src/gs-details-page.c:2087
+#: src/gs-details-page.c:2083
 msgid "Public domain"
 msgstr "Domeniu public"
 
 #. TRANSLATORS: see GNU page
-#: src/gs-details-page.c:2103 src/gs-details-page.ui:1397
+#: src/gs-details-page.c:2099 src/gs-details-page.ui:1397
 msgid "Free Software"
 msgstr "Software Gratuit"
 
 #. TRANSLATORS: for the free software popover
-#: src/gs-details-page.c:2160
+#: src/gs-details-page.c:2156
 msgid "Users are bound by the following license:"
 msgid_plural "Users are bound by the following licenses:"
 msgstr[0] "Utilizatorii sunt obligați prin următoarea licența:"
 msgstr[1] "Utilizatorii sunt obligați prin următoarele licențe:"
 msgstr[2] "Utilizatorii sunt obligați prin următoarele licențe:"
 
-#: src/gs-details-page.c:2176 src/gs-details-page.ui:1506
+#: src/gs-details-page.c:2172 src/gs-details-page.ui:1506
 msgid "More information"
 msgstr "Mai multe informatii"
 
@@ -1196,15 +1248,13 @@ msgstr "Mai multe informatii"
 msgid "Details page"
 msgstr "Pagina de detalii"
 
-#. Translators: A label for a button to add a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:228
+#. Translators: A label for a button to add a shortcut to the selected application.
+#: src/gs-details-page.ui:209
 msgid "_Add to Desktop"
 msgstr "_Adauga pe Desktop"
 
-#. Translators: A label for a button to remove a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:245
+#. Translators: A label for a button to remove a shortcut to the selected application.
+#: src/gs-details-page.ui:226
 msgid "_Remove from Desktop"
 msgstr "_Inlatura de pe Desktop"
 
@@ -1225,7 +1275,9 @@ msgstr "Sursă de aplicații inclusă"
 msgid ""
 "This application includes a software source which provides updates, as well "
 "as access to other software."
-msgstr "Aplicația include o sursă de aplicații care furnizează atât actualizări cât și acces la alte aplicații."
+msgstr ""
+"Aplicația include o sursă de aplicații care furnizează atât actualizări cât "
+"și acces la alte aplicații."
 
 #: src/gs-details-page.ui:500
 msgid "No Software Source Included"
@@ -1235,16 +1287,19 @@ msgstr "Nicio sursă de aplicații inclusă"
 msgid ""
 "This application does not include a software source. It will not be updated "
 "with new versions."
-msgstr "Acest program nu include o sursă de aplicații. Ca urmare, nu va fi actualizată la versiuni noi."
+msgstr ""
+"Acest program nu include o sursă de aplicații. Ca urmare, nu va fi "
+"actualizată la versiuni noi."
 
 #: src/gs-details-page.ui:515
 msgid ""
 "This software is already provided by your distribution and should not be "
 "replaced."
-msgstr "Această aplicație este deja furnizată de distribuția instalată și nu ar trebui înlocuită."
+msgstr ""
+"Această aplicație este deja furnizată de distribuția instalată și nu ar "
+"trebui înlocuită."
 
-#. Translators: a repository file used for installing software has been
-#. discovered.
+#. Translators: a repository file used for installing software has been discovered.
 #: src/gs-details-page.ui:528
 msgid "Software Source Identified"
 msgstr "Sursă de aplicații identificată"
@@ -1253,7 +1308,9 @@ msgstr "Sursă de aplicații identificată"
 msgid ""
 "Adding this software source will give you access to additional software and "
 "upgrades."
-msgstr "Adăugarea acestei surse de aplicații vă va oferi acces la actualizări și aplicații adiționale."
+msgstr ""
+"Adăugarea acestei surse de aplicații vă va oferi acces la actualizări și "
+"aplicații adiționale."
 
 #: src/gs-details-page.ui:530
 msgid "Only use software sources that you trust."
@@ -1345,14 +1402,12 @@ msgstr "Suplimente"
 msgid "Selected add-ons will be installed with the application."
 msgstr "Suplimentele alese vor fi instalate împreună cu aplicația."
 
-#. Translators: Header of the section with other users' opinions about the
-#. app.
+#. Translators: Header of the section with other users' opinions about the app.
 #: src/gs-details-page.ui:1233
 msgid "Reviews"
 msgstr "Comentarii"
 
-#. Translators: Button opening a dialog where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Button opening a dialog where the users can write and publish their opinions about the apps.
 #: src/gs-details-page.ui:1249
 msgid "_Write a Review"
 msgstr "_Lasa un comentariu"
@@ -1364,9 +1419,11 @@ msgstr "_Arata mai multe"
 
 #: src/gs-details-page.ui:1414
 msgid ""
-"This means that the software can be freely run, copied, distributed, studied"
-" and modified."
-msgstr "Asta inseamna ca software-ul poate fi rulat gratuit,copiat,distribuit,studiat si modificat."
+"This means that the software can be freely run, copied, distributed, studied "
+"and modified."
+msgstr ""
+"Asta inseamna ca software-ul poate fi rulat gratuit,copiat,distribuit,"
+"studiat si modificat."
 
 #: src/gs-details-page.ui:1473
 msgid "Proprietary Software"
@@ -1377,7 +1434,9 @@ msgid ""
 "This means that the software is owned by an individual or a company. There "
 "are often restrictions on its use and its source code cannot usually be "
 "accessed."
-msgstr "Asta inseamna ca Software-ul  este detinut de o companie sau un individ.Sunt unele restrictii la folosire si la codul sursa care nu pot fi accesate."
+msgstr ""
+"Asta inseamna ca Software-ul  este detinut de o companie sau un individ.Sunt "
+"unele restrictii la folosire si la codul sursa care nu pot fi accesate."
 
 #: src/gs-details-page.ui:1535
 msgid "Unknown Software License"
@@ -1461,8 +1520,7 @@ msgstr ""
 msgid "Use verbose logging"
 msgstr ""
 
-#. TRANSLATORS: program name, an application to add and remove software
-#. repositories
+#. TRANSLATORS: program name, an application to add and remove software repositories
 #: src/gs-editor.c:1119
 msgid "GNOME Software Banner Designer"
 msgstr ""
@@ -1491,8 +1549,7 @@ msgstr "Rezumat"
 msgid "Editor’s Pick"
 msgstr ""
 
-#. This check button controls whether the application’s banner appears in the
-#. “Featured” category
+#. This check button controls whether the application’s banner appears in the “Featured” category
 #: src/gs-editor.ui:397
 msgid "Category Featured"
 msgstr ""
@@ -1583,9 +1640,11 @@ msgstr "Nu sunt disponibile aplicații care să furnizeze fișierul %s."
 #: src/gs-extras-page.c:337 src/gs-extras-page.c:348 src/gs-extras-page.c:359
 #, c-format
 msgid ""
-"Information about %s, as well as options for how to get missing applications"
-" might be found %s."
-msgstr "Informații despre %s, precum și opțiuni despre cum să obțineți aplicațiile lipsă pot fi găsite pe %s."
+"Information about %s, as well as options for how to get missing applications "
+"might be found %s."
+msgstr ""
+"Informații despre %s, precum și opțiuni despre cum să obțineți aplicațiile "
+"lipsă pot fi găsite pe %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1608,7 +1667,9 @@ msgstr "%s nu este disponibilă."
 msgid ""
 "Information about %s, as well as options for how to get an application that "
 "can support this format might be found %s."
-msgstr "Informații despre %s, precum și opțiuni despre cum să obțineți o aplicație necesară redării acestui format pot fi găsite pe %s."
+msgstr ""
+"Informații despre %s, precum și opțiuni despre cum să obțineți o aplicație "
+"necesară redării acestui format pot fi găsite pe %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1624,11 +1685,13 @@ msgstr "Nu sunt disponibile fonturi pentru suportul scriptului %s."
 msgid ""
 "Information about %s, as well as options for how to get additional fonts "
 "might be found %s."
-msgstr "Informații despre %s, precum și opțiuni despre cum să obțineți fonturi adiționale pot fi găsite pe %s."
+msgstr ""
+"Informații despre %s, precum și opțiuni despre cum să obțineți fonturi "
+"adiționale pot fi găsite pe %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
-#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1426
+#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1430
 #, c-format
 msgid "No addon codecs are available for the %s format."
 msgstr "Niciun codec suplimentar disponibil pentru formatul %s."
@@ -1640,7 +1703,9 @@ msgstr "Niciun codec suplimentar disponibil pentru formatul %s."
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format might be found %s."
-msgstr "Informații despre %s, precum și opțiuni despre cum să obțineți un codec care să poată reda acest format pot fi găsite pe %s."
+msgstr ""
+"Informații despre %s, precum și opțiuni despre cum să obțineți un codec care "
+"să poată reda acest format pot fi găsite pe %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1656,7 +1721,9 @@ msgstr "Nu sunt disponibile resurse Plasma pentru suportul lui %s."
 msgid ""
 "Information about %s, as well as options for how to get additional Plasma "
 "resources might be found %s."
-msgstr "Informații despre %s, precum și opțiuni despre cum să obțineți resurse Plasma adiționale pot fi găsite pe %s."
+msgstr ""
+"Informații despre %s, precum și opțiuni despre cum să obțineți resurse "
+"Plasma adiționale pot fi găsite pe %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1672,15 +1739,16 @@ msgstr "Nu sunt disponibile drivere pentru %s."
 msgid ""
 "Information about %s, as well as options for how to get a driver that "
 "supports this printer might be found %s."
-msgstr "Informații despre %s, precum și opțiuni despre cum să obțineți un driver cu suport pentru această imprimantă pot fi găsite pe %s."
+msgstr ""
+"Informații despre %s, precum și opțiuni despre cum să obțineți un driver cu "
+"suport pentru această imprimantă pot fi găsite pe %s."
 
 #. TRANSLATORS: hyperlink title
 #: src/gs-extras-page.c:459
 msgid "this website"
 msgstr "acest portal web"
 
-#. TRANSLATORS: no codecs were found. First %s will be replaced by actual
-#. codec name(s), second %s is a link titled "this website"
+#. TRANSLATORS: no codecs were found. First %s will be replaced by actual codec name(s), second %s is a link titled "this website"
 #: src/gs-extras-page.c:463
 #, c-format
 msgid ""
@@ -1689,9 +1757,15 @@ msgid ""
 msgid_plural ""
 "Unfortunately, the %s you were searching for could not be found. Please see "
 "%s for more information."
-msgstr[0] "Din păcate, %s pe care îl căutați nu a putut fi găsit. Vedeți %s pentru mai multe informații."
-msgstr[1] "Din păcate, %s pe care le căutați nu au putut fi găsite. Vedeți %s pentru mai multe informații."
-msgstr[2] "Din păcate, %s pe care le căutați nu au putut fi găsite. Vedeți %s pentru mai multe informații."
+msgstr[0] ""
+"Din păcate, %s pe care îl căutați nu a putut fi găsit. Vedeți %s pentru mai "
+"multe informații."
+msgstr[1] ""
+"Din păcate, %s pe care le căutați nu au putut fi găsite. Vedeți %s pentru "
+"mai multe informații."
+msgstr[2] ""
+"Din păcate, %s pe care le căutați nu au putut fi găsite. Vedeți %s pentru "
+"mai multe informații."
 
 #: src/gs-extras-page.c:535 src/gs-extras-page.c:591 src/gs-extras-page.c:630
 msgid "Failed to find any search results"
@@ -1716,10 +1790,13 @@ msgstr "Bun venit la Aplicații"
 
 #: src/gs-first-run-dialog.ui:66
 msgid ""
-"Software lets you install all the software you need, all from one place. See"
-" our recommendations, browse the categories, or search for the applications "
+"Software lets you install all the software you need, all from one place. See "
+"our recommendations, browse the categories, or search for the applications "
 "you want."
-msgstr "Aplicații vă permite să instalați toate aplicațiile de care aveți nevoie, dintr-un singur loc. Vedeți recomandările noastre, aruncați o privire în categorii, sau pur și simplu căutați aplicația pe care o doriți."
+msgstr ""
+"Aplicații vă permite să instalați toate aplicațiile de care aveți nevoie, "
+"dintr-un singur loc. Vedeți recomandările noastre, aruncați o privire în "
+"categorii, sau pur și simplu căutați aplicația pe care o doriți."
 
 #: src/gs-first-run-dialog.ui:85
 msgid "_Let’s Go Shopping"
@@ -1873,9 +1950,9 @@ msgstr "Oferă acces la software suplimentar, inclusiv browsere web și jocuri."
 
 #. TRANSLATORS: this is the proprietary info bar
 #: src/gs-overview-page.c:978
-msgid ""
-"Proprietary software has restrictions on use and access to source code."
-msgstr "Software-ul proprietar are restricții de utilizare și acces la codul sursă."
+msgid "Proprietary software has restrictions on use and access to source code."
+msgstr ""
+"Software-ul proprietar are restricții de utilizare și acces la codul sursă."
 
 #. TRANSLATORS: this is the clickable
 #. * link on the proprietary info bar
@@ -1904,14 +1981,12 @@ msgstr "Aplicații recomandate"
 msgid "Categories"
 msgstr "Categorii"
 
-#. Translators: This is a heading for software which has been featured
-#. ('picked') by the distribution.
+#. Translators: This is a heading for software which has been featured ('picked') by the distribution.
 #: src/gs-overview-page.ui:315
 msgid "Editor’s Picks"
 msgstr "Sugerate"
 
-#. Translators: This is a heading for software which has been recently
-#. released upstream.
+#. Translators: This is a heading for software which has been recently released upstream.
 #: src/gs-overview-page.ui:359
 msgid "Recent Releases"
 msgstr ""
@@ -1958,7 +2033,9 @@ msgstr "Sigur doriți să eliminați sursa %s?"
 msgid ""
 "All applications from %s will be removed, and you will have to re-install "
 "the source to use them again."
-msgstr "Toate aplicatiile din %s vor fi inlaturate,si va trebui sa reinstalati sursa pentru a le folosi din nou."
+msgstr ""
+"Toate aplicatiile din %s vor fi inlaturate,si va trebui sa reinstalati sursa "
+"pentru a le folosi din nou."
 
 #. TRANSLATORS: this is a prompt message, and '%s' is an
 #. * application summary, e.g. 'GNOME Clocks'
@@ -1971,14 +2048,18 @@ msgstr "Sigur doriți să eliminați %s?"
 #: src/gs-page.c:684
 #, c-format
 msgid "%s will be removed, and you will have to install it to use it again."
-msgstr "Aplicația %s va fi eliminată și va fi necesar să o reinstalați pentru a o utiliza din nou."
+msgstr ""
+"Aplicația %s va fi eliminată și va fi necesar să o reinstalați pentru a o "
+"utiliza din nou."
 
-#: lib/gs-plugin-loader.c:1429
+#: lib/gs-plugin-loader.c:1433
 #, c-format
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format can be found on the website."
-msgstr "Informații despre %s, precum și opțiuni despre cum să obțineți codecul necesar redării acestui format pot fi găsite pe pagina web."
+msgstr ""
+"Informații despre %s, precum și opțiuni despre cum să obțineți codecul "
+"necesar redării acestui format pot fi găsite pe pagina web."
 
 #: lib/gs-price.c:111
 #, c-format
@@ -2037,7 +2118,10 @@ msgstr ""
 msgid ""
 "Some of the currently installed software is not compatible with %s. If you "
 "continue, the following will be automatically removed during the upgrade:"
-msgstr "Unul dintre software-ul instalat în prezent, nu este compatibil cu% s. Dacă veți continua, următoarele vor fi eliminate în mod automat în timpul actualizării:"
+msgstr ""
+"Unul dintre software-ul instalat în prezent, nu este compatibil cu% s. Dacă "
+"veți continua, următoarele vor fi eliminate în mod automat în timpul "
+"actualizării:"
 
 #: src/gs-removal-dialog.ui:27
 msgid "Incompatible Software"
@@ -2107,8 +2191,7 @@ msgstr "Descriere prea scurta"
 msgid "The description is too long"
 msgstr "Descriere prea lunga"
 
-#. Translators: Title of the dialog box where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Title of the dialog box where the users can write and publish their opinions about the apps.
 #: src/gs-review-dialog.ui:11
 msgid "Post Review"
 msgstr "Recenzie Postare"
@@ -2126,7 +2209,9 @@ msgstr "Evaluare"
 msgid ""
 "Give a short summary of your review, for example: “Great app, would "
 "recommend”."
-msgstr "Da un scurt rezumat al recenziei, de exemplu:\"Imi place aplicatia,o recomand\"."
+msgstr ""
+"Da un scurt rezumat al recenziei, de exemplu:\"Imi place aplicatia,o recomand"
+"\"."
 
 #. Translators: This is where the users enter their opinions about the apps.
 #: src/gs-review-dialog.ui:199
@@ -2136,7 +2221,8 @@ msgstr "Recenzie"
 
 #: src/gs-review-dialog.ui:215
 msgid "What do you think of the app? Try to give reasons for your views."
-msgstr "Ce crezi despre aplicatie?Incearca sa oferi motive pentru opiniile tale."
+msgstr ""
+"Ce crezi despre aplicatie?Incearca sa oferi motive pentru opiniile tale."
 
 #. Translators: A label for the total number of reviews.
 #: src/gs-review-histogram.ui:413
@@ -2146,14 +2232,18 @@ msgstr "Evaluări în total"
 #. TRANSLATORS: we explain what the action is going to do
 #: src/gs-review-row.c:234
 msgid "You can report reviews for abusive, rude, or discriminatory behavior."
-msgstr "Poti raporta recenzii pentru comportament abuziv, nepoliticos sau discriminatoriu."
+msgstr ""
+"Poti raporta recenzii pentru comportament abuziv, nepoliticos sau "
+"discriminatoriu."
 
 #. TRANSLATORS: we ask the user if they really want to do this
 #: src/gs-review-row.c:239
 msgid ""
 "Once reported, a review will be hidden until it has been checked by an "
 "administrator."
-msgstr "Odata raportata,o recenzie va fi ascunsa pana cand va fi vazuta de un administrator."
+msgstr ""
+"Odata raportata,o recenzie va fi ascunsa pana cand va fi vazuta de un "
+"administrator."
 
 #. TRANSLATORS: window title when
 #. * reporting a user-submitted review
@@ -2168,8 +2258,7 @@ msgstr "Raportezi Recenzie?"
 msgid "Report"
 msgstr "Raporteaza"
 
-#. Translators: Users can express their opinions about other users' opinions
-#. about the apps.
+#. Translators: Users can express their opinions about other users' opinions about the apps.
 #: src/gs-review-row.ui:112
 msgid "Was this review useful to you?"
 msgstr "A fost aceasta recenzie utila pentru tine?"
@@ -2259,81 +2348,81 @@ msgstr "Nu a fost găsită nicio aplicație"
 #. TRANSLATORS: this is part of the in-app notification,
 #. * where the %s is a multi-word localised app name
 #. * e.g. 'Getting things GNOME!"
-#: src/gs-shell.c:846 src/gs-shell.c:851 src/gs-shell.c:866 src/gs-shell.c:870
+#: src/gs-shell.c:847 src/gs-shell.c:852 src/gs-shell.c:867 src/gs-shell.c:871
 #, c-format
 msgid "“%s”"
 msgstr "“%s”"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:898
+#: src/gs-shell.c:899
 #, c-format
 msgid "Unable to download firmware updates from %s"
 msgstr "Nu se pot descărca actualizări de firmware de la %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:904
+#: src/gs-shell.c:905
 #, c-format
 msgid "Unable to download updates from %s"
 msgstr "Nu se pot descarca actualizari de la %s"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:911
+#: src/gs-shell.c:912
 msgid "Unable to download updates"
 msgstr "Nu se pot descarca actualizari"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:916
+#: src/gs-shell.c:917
 msgid ""
-"Unable to download updates: internet access was required but wasn’t "
-"available"
+"Unable to download updates: internet access was required but wasn’t available"
 msgstr "Nu se pot descarca actualizari: accesul la internet nu este disponibil"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:925
+#: src/gs-shell.c:926
 #, c-format
 msgid "Unable to download updates from %s: not enough disk space"
 msgstr "Nu se pot descarca actualizari de la %s: nu exista spatiu suficient"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:930
+#: src/gs-shell.c:931
 msgid "Unable to download updates: not enough disk space"
 msgstr "Nu se pot descarca actualizari: nu esista spatiu suficient"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:938
+#: src/gs-shell.c:939
 msgid "Unable to download updates: authentication was required"
 msgstr "Nu se pot descarca actualizari: este necesara autentificarea"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:943
+#: src/gs-shell.c:944
 msgid "Unable to download updates: authentication was invalid"
 msgstr "Nu se pot descarca actualizari: autentificarea nu este valabila"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:948
+#: src/gs-shell.c:949
 msgid ""
 "Unable to download updates: you do not have permission to install software"
-msgstr "Nu se pot descarca actualizari: nu aveti permisiunea de a instala softul"
+msgstr ""
+"Nu se pot descarca actualizari: nu aveti permisiunea de a instala softul"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:955
+#: src/gs-shell.c:956
 msgid "Unable to get list of updates"
 msgstr "Nu sa putut gasi lista de actualizari"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the application name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1001
+#: src/gs-shell.c:1002
 #, c-format
 msgid "Unable to install %s as download failed from %s"
 msgstr "Nu se poate instala %s descarcarea a esuat de la %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1007
+#: src/gs-shell.c:1008
 #, c-format
 msgid "Unable to install %s as download failed"
 msgstr "Nu sa putut instala %s descarcarea a esuat"
@@ -2342,51 +2431,51 @@ msgstr "Nu sa putut instala %s descarcarea a esuat"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1019
+#: src/gs-shell.c:1020
 #, c-format
 msgid "Unable to install %s as runtime %s not available"
 msgstr "Nu sa putut instala %s rularea %s nu este disponibila"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1025
+#: src/gs-shell.c:1026
 #, c-format
 msgid "Unable to install %s as not supported"
 msgstr "Nu se poate instala %s nu este suportat"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1032
+#: src/gs-shell.c:1033
 msgid "Unable to install: internet access was required but wasn’t available"
 msgstr "Nu sa putut instalat:Accesul la internet nu este disponibil"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1038
+#: src/gs-shell.c:1039
 msgid "Unable to install: the application has an invalid format"
 msgstr "Nu sa putut instala: aplicatia are un format invalid"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1043
+#: src/gs-shell.c:1044
 #, c-format
 msgid "Unable to install %s: not enough disk space"
 msgstr "Nu sa putut instala %s: nu exista spatiu suficient pe disk"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1051
+#: src/gs-shell.c:1052
 #, c-format
 msgid "Unable to install %s: authentication was required"
 msgstr "Nu sa putut instala %s: necesita autentificare"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1058
+#: src/gs-shell.c:1059
 #, c-format
 msgid "Unable to install %s: authentication was invalid"
 msgstr "Nu se poate instala %s: autentificarea este invalida"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1065
+#: src/gs-shell.c:1066
 #, c-format
 msgid "Unable to install %s: you do not have permission to install software"
 msgstr "Nu se poate instala %s: nu ai permisiunea de a instala softul"
@@ -2394,34 +2483,34 @@ msgstr "Nu se poate instala %s: nu ai permisiunea de a instala softul"
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the name of the authentication service,
 #. * e.g. "Ubuntu One"
-#: src/gs-shell.c:1078
+#: src/gs-shell.c:1079
 #, c-format
 msgid "Your %s account has been suspended."
 msgstr "Contul %s a fost suspendat"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1082
+#: src/gs-shell.c:1083
 msgid "It is not possible to install software until this has been resolved."
 msgstr "Nu se poate instala softul pana cand aceasta nu va fi rezolvata."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the clickable link (e.g.
 #. * "http://example.com/what-did-i-do-wrong/")
-#: src/gs-shell.c:1093
+#: src/gs-shell.c:1094
 #, c-format
 msgid "For more information, visit %s."
 msgstr "Pentru mai multe informatii, viziteaza %s."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1102
+#: src/gs-shell.c:1103
 #, c-format
 msgid "Unable to install %s: AC power is required"
 msgstr "Imposibil de instalat %s: este necesară alimentarea la sursa de curent"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1111
+#: src/gs-shell.c:1112
 #, c-format
 msgid "Unable to install %s"
 msgstr "Nu sa putut instala %s"
@@ -2430,61 +2519,62 @@ msgstr "Nu sa putut instala %s"
 #. * where the first %s is the app name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1157
+#: src/gs-shell.c:1158
 #, c-format
 msgid "Unable to update %s from %s"
 msgstr "Nu sa putut actualiza %s de la %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1163
+#: src/gs-shell.c:1164
 #, c-format
 msgid "Unable to update %s as download failed"
 msgstr "Nu sa putut actualiza %s deoarece descarcarea a esuat"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1169
+#: src/gs-shell.c:1170
 msgid "Unable to update: internet access was required but wasn’t available"
 msgstr "Nu sa putut actualiza: accesul la internet nu este disponibil"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1177
+#: src/gs-shell.c:1178
 #, c-format
 msgid "Unable to update %s: not enough disk space"
 msgstr "Nu sa putut actualiza %s: nu exista spatiu suficient pe disk"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1186
+#: src/gs-shell.c:1187
 #, c-format
 msgid "Unable to update %s: authentication was required"
 msgstr "Nu sa putut actualiza %s: necesita autentificare"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1193
+#: src/gs-shell.c:1194
 #, c-format
 msgid "Unable to update %s: authentication was invalid"
 msgstr "Nu sa putut actualiza %s: autentificarea este invalida"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1200
+#: src/gs-shell.c:1201
 #, c-format
 msgid "Unable to update %s: you do not have permission to update software"
 msgstr "Nu sa putut actualiza %s: nu ai permisiunea de a actualiza softul"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1208
+#: src/gs-shell.c:1209
 #, c-format
 msgid "Unable to update %s: AC power is required"
-msgstr "Imposibil de actualizat %s: este necesară alimentarea la sursa de curent"
+msgstr ""
+"Imposibil de actualizat %s: este necesară alimentarea la sursa de curent"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1217
+#: src/gs-shell.c:1218
 #, c-format
 msgid "Unable to update %s"
 msgstr "Nu sa putut actualiza %s"
@@ -2492,96 +2582,98 @@ msgstr "Nu sa putut actualiza %s"
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the distro name (e.g. "Fedora 25") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1262
+#: src/gs-shell.c:1263
 #, c-format
 msgid "Unable to upgrade to %s from %s"
 msgstr "Nu sa putut actualiza de la %s la %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the app name (e.g. "GIMP")
-#: src/gs-shell.c:1267
+#: src/gs-shell.c:1268
 #, c-format
 msgid "Unable to upgrade to %s as download failed"
 msgstr "Nu sa putut actualiza la %s deoarece descarcarea a esuat"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1274
+#: src/gs-shell.c:1275
 msgid "Unable to upgrade: internet access was required but wasn’t available"
 msgstr "Nu sa putut actualiza: accesul la internet nu este disponibil"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1282
+#: src/gs-shell.c:1283
 #, c-format
 msgid "Unable to upgrade to %s: not enough disk space"
 msgstr "Nu sa putut actualiza la %s: nu exista spatiu suficient pe disk"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1291
+#: src/gs-shell.c:1292
 #, c-format
 msgid "Unable to upgrade to %s: authentication was required"
 msgstr "Nu sa putut actualiza la %s: este necesara autentificarea"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1298
+#: src/gs-shell.c:1299
 #, c-format
 msgid "Unable to upgrade to %s: authentication was invalid"
 msgstr "Nu sa putut actualiza la %s: autentificarea este invalida"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1305
+#: src/gs-shell.c:1306
 #, c-format
 msgid "Unable to upgrade to %s: you do not have permission to upgrade"
 msgstr "Nu sa putut actualiza la %s: nu ai permisiunea de a actualiza"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1312
+#: src/gs-shell.c:1313
 #, c-format
 msgid "Unable to upgrade to %s: AC power is required"
-msgstr "Imposibil de actualizat la %s: este necesară alimentarea la sursa de curent"
+msgstr ""
+"Imposibil de actualizat la %s: este necesară alimentarea la sursa de curent"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1321
+#: src/gs-shell.c:1322
 #, c-format
 msgid "Unable to upgrade to %s"
 msgstr "Nu sa putut actualiza la %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1363
+#: src/gs-shell.c:1364
 #, c-format
 msgid "Unable to remove %s: authentication was required"
 msgstr "Nu sa putut inlatura %s: este necesara autentificarea"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1369
+#: src/gs-shell.c:1370
 #, c-format
 msgid "Unable to remove %s: authentication was invalid"
 msgstr "Nu sa putut inlatura %s: autentificarea este invalida"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1375
+#: src/gs-shell.c:1376
 #, c-format
 msgid "Unable to remove %s: you do not have permission to remove software"
 msgstr "Nu sa putut inlaturat %s: nu ai permisiunea de a inlatura softul"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1382
+#: src/gs-shell.c:1383
 #, c-format
 msgid "Unable to remove %s: AC power is required"
-msgstr "Imposibil de inlaturat %s: este necesară alimentarea la sursa de curent"
+msgstr ""
+"Imposibil de inlaturat %s: este necesară alimentarea la sursa de curent"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1391
+#: src/gs-shell.c:1392
 #, c-format
 msgid "Unable to remove %s"
 msgstr "Nu sa putut inlatura %s"
@@ -2590,48 +2682,48 @@ msgstr "Nu sa putut inlatura %s"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1437
+#: src/gs-shell.c:1438
 #, c-format
 msgid "Unable to launch %s: %s is not installed"
 msgstr "Nu sa putut lansa %s: %s nu este instalat"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1444 src/gs-shell.c:1492 src/gs-shell.c:1540
+#: src/gs-shell.c:1445 src/gs-shell.c:1493 src/gs-shell.c:1541
 msgid "Not enough disk space — free up some space and try again"
 msgstr "Nu exista spatiu suficient - eliberati din spatiu si incercati din nou"
 
 #. TRANSLATORS: we failed to get a proper error code
-#: src/gs-shell.c:1452 src/gs-shell.c:1500 src/gs-shell.c:1567
+#: src/gs-shell.c:1453 src/gs-shell.c:1501 src/gs-shell.c:1568
 msgid "Sorry, something went wrong"
 msgstr ""
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1487
+#: src/gs-shell.c:1488
 msgid "Failed to install file: authentication failed"
 msgstr "Nu sa putut instala fisierul: autentificare esuata"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1534
+#: src/gs-shell.c:1535
 #, c-format
 msgid "Unable to contact %s"
 msgstr "Nu se poate contacta %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1549
+#: src/gs-shell.c:1550
 #, c-format
 msgid "%s needs to be restarted to use new plugins."
 msgstr "%s necesita repornire pentru a folosi noile plugin-uri"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1554
+#: src/gs-shell.c:1555
 msgid "This application needs to be restarted to use new plugins."
 msgstr "Aceasta aplicatie trebuie repornita pentru a folosi noile plugin-uri"
 
 #. TRANSLATORS: need to be connected to the AC power
-#: src/gs-shell.c:1561
+#: src/gs-shell.c:1562
 msgid "AC power is required"
 msgstr "Este necesară alimentarea la sursa de curent"
 
@@ -2639,7 +2731,9 @@ msgstr "Este necesară alimentarea la sursa de curent"
 #. has no software installed from it.
 #: src/gs-sources-dialog.c:98
 msgid "No applications or addons installed; other software might still be"
-msgstr "Nicio aplicație sau supliment adițional instalate; alte aplicații ar putea fi totuși"
+msgstr ""
+"Nicio aplicație sau supliment adițional instalate; alte aplicații ar putea "
+"fi totuși"
 
 #. TRANSLATORS: This string is used to construct the 'X applications
 #. installed' sentence, describing a software source.
@@ -2698,7 +2792,8 @@ msgstr[2] "%s și %s instalate"
 #. TRANSLATORS: nonfree software
 #: src/gs-sources-dialog.c:257
 msgid "Typically has restrictions on use and access to source code."
-msgstr "Are în mod obișnuit restricții privind utilizarea și accesul la codul sursă."
+msgstr ""
+"Are în mod obișnuit restricții privind utilizarea și accesul la codul sursă."
 
 #. TRANSLATORS: list header
 #: src/gs-sources-dialog.c:278
@@ -2723,7 +2818,9 @@ msgstr "sistemul de operare"
 msgid ""
 "Software sources can be downloaded from the internet. They give you access "
 "to additional software that is not provided by %s."
-msgstr "Pot fi descărcate surse de aplicații de pe internet. Acestea vă oferă acces la aplicații adiționale ce nu sunt furnizate de %s."
+msgstr ""
+"Pot fi descărcate surse de aplicații de pe internet. Acestea vă oferă acces "
+"la aplicații adiționale ce nu sunt furnizate de %s."
 
 #: src/gs-sources-dialog.ui:155
 msgid "Additional Sources"
@@ -2732,7 +2829,9 @@ msgstr "Surse Aditionale"
 #: src/gs-sources-dialog.ui:175
 msgid ""
 "Removing a source will also remove any software you have installed from it."
-msgstr "Eliminarea unei surse conduce implicit la eliminarea aplicațiilor instalate prin intermediul acesteia."
+msgstr ""
+"Eliminarea unei surse conduce implicit la eliminarea aplicațiilor instalate "
+"prin intermediul acesteia."
 
 #: src/gs-sources-dialog.ui:260
 msgid "No software installed from this source"
@@ -2932,29 +3031,38 @@ msgstr "Actualizarea a fost anulată."
 #. * something with no network available
 #: src/gs-update-monitor.c:714
 msgid ""
-"Internet access was required but wasn’t available. Please make sure that you"
-" have internet access and try again."
-msgstr "Accesul la internet era necesar dar a fost indisponibil. Asigurați-vă că aveți acces la internet și încercați din nou."
+"Internet access was required but wasn’t available. Please make sure that you "
+"have internet access and try again."
+msgstr ""
+"Accesul la internet era necesar dar a fost indisponibil. Asigurați-vă că "
+"aveți acces la internet și încercați din nou."
 
 #. TRANSLATORS: if the package is not signed correctly
 #: src/gs-update-monitor.c:720
 msgid ""
 "There were security issues with the update. Please consult your software "
 "provider for more details."
-msgstr "Au apărut probleme de securitate la această actualizare. Consultați furnizorul dumneavoastră de aplicații pentru mai multe detalii."
+msgstr ""
+"Au apărut probleme de securitate la această actualizare. Consultați "
+"furnizorul dumneavoastră de aplicații pentru mai multe detalii."
 
 #. TRANSLATORS: we ran out of disk space
 #: src/gs-update-monitor.c:726
 msgid ""
 "There wasn’t enough disk space. Please free up some space and try again."
-msgstr "Insuficient spațiu disponibil pe disc. Eliberați puțin spațiu și încercați din nou."
+msgstr ""
+"Insuficient spațiu disponibil pe disc. Eliberați puțin spațiu și încercați "
+"din nou."
 
 #. TRANSLATORS: We didn't handle the error type
 #: src/gs-update-monitor.c:731
 msgid ""
 "We’re sorry: the update failed to install. Please wait for another update "
 "and try again. If the problem persists, contact your software provider."
-msgstr "Ne pare rău: instalarea actualizării a eșuat. Așteptați o altă actualizare și încercați din nou. Dacă problema persistă, contactați furnizorul dumneavoastră de aplicații."
+msgstr ""
+"Ne pare rău: instalarea actualizării a eșuat. Așteptați o altă actualizare "
+"și încercați din nou. Dacă problema persistă, contactați furnizorul "
+"dumneavoastră de aplicații."
 
 #. TRANSLATORS: Time in 24h format
 #: src/gs-updates-page.c:297
@@ -3134,7 +3242,9 @@ msgstr "Se pot aplica taxe"
 msgid ""
 "Checking for updates while using mobile broadband could cause you to incur "
 "charges."
-msgstr "Verificarea actualizărilor când folosiți o conexiune mobilă de bandă largă poate să conducă la suportarea unor taxe."
+msgstr ""
+"Verificarea actualizărilor când folosiți o conexiune mobilă de bandă largă "
+"poate să conducă la suportarea unor taxe."
 
 #. TRANSLATORS: this is a link to the
 #. * control-center network panel
@@ -3151,7 +3261,9 @@ msgstr "Nicio rețea"
 #. * to do the updates check
 #: src/gs-updates-page.c:1433
 msgid "Internet access is required to check for updates."
-msgstr "Este necesară o conexiune la internet pentru a putea verifica dacă există actualizări."
+msgstr ""
+"Este necesară o conexiune la internet pentru a putea verifica dacă există "
+"actualizări."
 
 #: src/gs-updates-page.c:1819
 msgid "Restart & _Install"
@@ -3173,7 +3285,9 @@ msgstr "Aplicațiile sunt actualizate"
 msgid ""
 "Checking for updates when using mobile broadband could cause you to incur "
 "charges"
-msgstr "Verificarea de actualizări când folosiți o conexiune mobilă de bandă largă poate să conducă la suportarea unor taxe"
+msgstr ""
+"Verificarea de actualizări când folosiți o conexiune mobilă de bandă largă "
+"poate să conducă la suportarea unor taxe"
 
 #: src/gs-updates-page.ui:257
 msgid "_Check Anyway"
@@ -3227,7 +3341,8 @@ msgstr "_Află mai multe"
 #: src/gs-upgrade-banner.ui:98
 msgid ""
 "It is recommended that you back up your data and files before upgrading."
-msgstr "Este recomandat sa va salvati datele si fisierele inaintea actualizarii"
+msgstr ""
+"Este recomandat sa va salvati datele si fisierele inaintea actualizarii"
 
 #: src/gs-upgrade-banner.ui:116
 msgid "_Download"
@@ -3238,22 +3353,27 @@ msgid "App Center"
 msgstr "Centru de aplicatii"
 
 #: src/org.gnome.Software.desktop.in:4
+msgid "More Apps"
+msgstr "Mai multe aplicatii"
+
+#: src/org.gnome.Software.desktop.in:5
 msgid "Add, remove or update software on this computer"
 msgstr "Adaugă, elimină sau actualizează aplicații pe acest calculator"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
-#: src/org.gnome.Software.desktop.in:6
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: src/org.gnome.Software.desktop.in:7
 #: src/org.gnome.Software.Editor.desktop.in:6
 msgid "org.gnome.Software"
 msgstr "org.gnome.Software"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
-#: src/org.gnome.Software.desktop.in:12
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: src/org.gnome.Software.desktop.in:13
 msgid ""
-"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;"
-msgstr "Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;Surse;Instalează;Aplicații;Preferințe;Actualizări;"
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;"
+msgstr ""
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;Surse;Instalează;Aplicații;Preferințe;Actualizări;"
 
 #: src/org.gnome.Software.Editor.desktop.in:3
 msgid "Banner Designer"
@@ -3263,8 +3383,7 @@ msgstr ""
 msgid "Design the featured banners for GNOME Software"
 msgstr ""
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: src/org.gnome.Software.Editor.desktop.in:13
 msgid "AppStream;Software;App;"
 msgstr ""
@@ -3534,100 +3653,111 @@ msgctxt "Menu of Communication & News"
 msgid "Web Browsers"
 msgstr "Browsere Web"
 
-#: plugins/core/gs-desktop-common.c:247
-msgctxt "Menu of Reference"
-msgid "All"
-msgstr "Toate"
-
-#: plugins/core/gs-desktop-common.c:250
-msgctxt "Menu of Reference"
-msgid "Featured"
-msgstr "Recomandate"
-
-#: plugins/core/gs-desktop-common.c:253
-msgctxt "Menu of Reference"
-msgid "Art"
-msgstr "Arta"
-
-#: plugins/core/gs-desktop-common.c:256
-msgctxt "Menu of Reference"
-msgid "Biography"
-msgstr "Biografie"
-
-#: plugins/core/gs-desktop-common.c:259
-msgctxt "Menu of Reference"
-msgid "Comics"
-msgstr "Comice"
-
-#: plugins/core/gs-desktop-common.c:262
-msgctxt "Menu of Reference"
-msgid "Fiction"
-msgstr "Fictiune"
-
-#: plugins/core/gs-desktop-common.c:265
-msgctxt "Menu of Reference"
-msgid "Health"
-msgstr "Sanatate"
-
-#: plugins/core/gs-desktop-common.c:268
-msgctxt "Menu of Reference"
-msgid "History"
-msgstr "Istoric"
-
-#: plugins/core/gs-desktop-common.c:271
-msgctxt "Menu of Reference"
-msgid "Lifestyle"
-msgstr "Stil de viata"
-
-#: plugins/core/gs-desktop-common.c:274
+#: plugins/core/gs-desktop-common.c:242
 msgctxt "Menu of Communication & News"
 msgid "News"
 msgstr "Stiri"
 
+#: plugins/core/gs-desktop-common.c:251
+msgctxt "Menu of Reference"
+msgid "All"
+msgstr "Toate"
+
+#: plugins/core/gs-desktop-common.c:254
+msgctxt "Menu of Reference"
+msgid "Featured"
+msgstr "Recomandate"
+
+#: plugins/core/gs-desktop-common.c:257
+msgctxt "Menu of Reference"
+msgid "Art"
+msgstr "Arta"
+
+#: plugins/core/gs-desktop-common.c:260
+msgctxt "Menu of Reference"
+msgid "Biography"
+msgstr "Biografie"
+
+#: plugins/core/gs-desktop-common.c:263
+msgctxt "Menu of Reference"
+msgid "Comics"
+msgstr "Comice"
+
+#: plugins/core/gs-desktop-common.c:266
+msgctxt "Menu of Reference"
+msgid "Feed"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:269
+msgctxt "Menu of Reference"
+msgid "Fiction"
+msgstr "Fictiune"
+
+#: plugins/core/gs-desktop-common.c:272
+msgctxt "Menu of Reference"
+msgid "Health"
+msgstr "Sanatate"
+
+#: plugins/core/gs-desktop-common.c:275
+msgctxt "Menu of Reference"
+msgid "History"
+msgstr "Istoric"
+
 #: plugins/core/gs-desktop-common.c:278
+msgctxt "Menu of Reference"
+msgid "Lifestyle"
+msgstr "Stil de viata"
+
+#: plugins/core/gs-desktop-common.c:281
+#, fuzzy
+msgctxt "Menu of Reference"
+msgid "News"
+msgstr "Stiri"
+
+#: plugins/core/gs-desktop-common.c:284
 msgctxt "Menu of Reference"
 msgid "Politics"
 msgstr "Politica"
 
-#: plugins/core/gs-desktop-common.c:281
+#: plugins/core/gs-desktop-common.c:287
 msgctxt "Menu of Reference"
 msgid "Sports"
 msgstr "Sport"
 
 #. TRANSLATORS: this is the menu spec main category for Learning
-#: plugins/core/gs-desktop-common.c:291
+#: plugins/core/gs-desktop-common.c:297
 msgid "Learning"
 msgstr "Invatare"
 
 #. TRANSLATORS: this is the menu spec main category for Game
-#: plugins/core/gs-desktop-common.c:294
+#: plugins/core/gs-desktop-common.c:300
 msgid "Games"
 msgstr "Jocuri"
 
 #. TRANSLATORS: this is the menu spec main category for Multimedia
-#: plugins/core/gs-desktop-common.c:297
+#: plugins/core/gs-desktop-common.c:303
 msgid "Multimedia"
 msgstr "Multimedia"
 
 #. TRANSLATORS: this is the menu spec main category for Work
-#: plugins/core/gs-desktop-common.c:300
+#: plugins/core/gs-desktop-common.c:306
 msgid "Work"
 msgstr "Munca"
 
 #. TRANSLATORS: this is the menu spec main category for Reference
-#: plugins/core/gs-desktop-common.c:303
+#: plugins/core/gs-desktop-common.c:309
 msgid "Reference & News"
 msgstr "Referinte & Noutati"
 
 #. TRANSLATORS: this is the menu spec main category for Utilities
-#: plugins/core/gs-desktop-common.c:306
+#: plugins/core/gs-desktop-common.c:312
 msgid "Utilities"
 msgstr "Utilități"
 
 #. TRANSLATORS: this is the menu spec main category for Dev Tools; it
 #. * should be a relatively short label; as an example, in Portuguese and
 #. * Spanish the direct translation of "Programming" (noun) is used
-#: plugins/core/gs-desktop-common.c:311
+#: plugins/core/gs-desktop-common.c:317
 msgid "Dev Tools"
 msgstr "Unelte Dev"
 
@@ -3653,16 +3783,16 @@ msgstr "Include îmbunătățiri de performanță, stabilitate și securitate."
 msgid "Downloading featured images…"
 msgstr ""
 
-#: plugins/eos/gs-plugin-eos.c:1249
+#: plugins/eos/gs-plugin-eos.c:1233
 #, c-format
 msgid "Could not launch this application."
 msgstr "Nu se poate lansa aceasta aplicatie"
 
-#: plugins/eos/gs-plugin-eos.c:1305
+#: plugins/eos/gs-plugin-eos.c:1289
 msgid "Endless Platform"
 msgstr "Platforma Endless"
 
-#: plugins/eos/gs-plugin-eos.c:1308
+#: plugins/eos/gs-plugin-eos.c:1292
 msgid "Framework for applications"
 msgstr "Cadru pentru aplicații"
 
@@ -3722,13 +3852,13 @@ msgid "Flatpak is a framework for desktop applications on Linux"
 msgstr "Flatpak este un cadru pentru aplicatiile desktop din Linux"
 
 #. TRANSLATORS: status text when downloading new metadata
-#: plugins/flatpak/gs-flatpak.c:821
+#: plugins/flatpak/gs-flatpak.c:815
 #, c-format
 msgid "Getting flatpak metadata for %s…"
 msgstr ""
 
 #. TRANSLATORS: status text when downloading the RuntimeRepo
-#: plugins/flatpak/gs-flatpak.c:2796
+#: plugins/flatpak/gs-flatpak.c:2803
 msgid "Getting runtime source…"
 msgstr ""
 
@@ -3761,7 +3891,8 @@ msgstr "Suport Limba"
 
 #: plugins/limba/org.gnome.Software.Plugin.Limba.metainfo.xml.in:7
 msgid "Limba provides developers a way to easily create software bundles"
-msgstr "Limba ofera dezvoltatorilor un mod mai usor de a creea pachete de software"
+msgstr ""
+"Limba ofera dezvoltatorilor un mod mai usor de a creea pachete de software"
 
 #. TRANSLATORS: status text when downloading
 #: plugins/odrs/gs-plugin-odrs.c:205
@@ -3774,7 +3905,8 @@ msgstr "Deschideți Support Evaluări Desktop"
 
 #: plugins/odrs/org.gnome.Software.Plugin.Odrs.metainfo.xml.in:7
 msgid "ODRS is a service providing user reviews of applications"
-msgstr "ODRS este un serviciu care ofera comentariile utilizatorilor despre aplicatii"
+msgstr ""
+"ODRS este un serviciu care ofera comentariile utilizatorilor despre aplicatii"
 
 #. TRANSLATORS: status text when downloading
 #: plugins/shell-extensions/gs-plugin-shell-extensions.c:669

--- a/po/th.po
+++ b/po/th.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the gnome-software package.
-# 
+#
 # Translators:
 # Nuritzi Sanchez <ns@endlessm.com>, 2017
 # Roddy Shuler <roddy@endlessm.com>, 2016-2017
@@ -9,14 +9,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-software\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-12 22:31-0700\n"
+"POT-Creation-Date: 2017-11-02 16:28+0100\n"
 "PO-Revision-Date: 2017-10-17 06:00+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
-"Language-Team: Thai (http://www.transifex.com/endless-mobile-inc/gnome-software/language/th/)\n"
+"Language-Team: Thai (http://www.transifex.com/endless-mobile-inc/gnome-"
+"software/language/th/)\n"
+"Language: th\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: th\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:7
@@ -31,7 +32,9 @@ msgstr "เครื่องมือจัดการโปรแกรมส
 msgid ""
 "Software allows you to find and install new applications and system "
 "extensions and remove existing installed applications."
-msgstr "\"ซอฟต์แวร์\" ช่วยคุณหาและติดตั้งโปรแกรมและส่วนขยายของระบบเพิ่มเติม และถอดถอนโปรแกรมที่ติดตั้งแล้ว"
+msgstr ""
+"\"ซอฟต์แวร์\" ช่วยคุณหาและติดตั้งโปรแกรมและส่วนขยายของระบบเพิ่มเติม "
+"และถอดถอนโปรแกรมที่ติดตั้งแล้ว"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:14
 msgid ""
@@ -39,7 +42,11 @@ msgid ""
 "descriptions and multiple screenshots per application. Applications can be "
 "found either through browsing the list of categories or by searching. It "
 "also allows you to update your system using an offline update."
-msgstr "โปรแกรม \"ซอฟต์แวร์\" ของ GNOME จัดแสดงโปรแกรมที่เด่นและยอดนิยม พร้อมคำบรรยายที่เป็นประโยชน์และภาพหน้าจอหลายภาพต่อโปรแกรม คุณสามารถหาโปรแกรมผ่านการท่องดูตามหมวดหมู่หรือด้วยการค้นหาก็ได้ นอกจากนี้ ยังให้คุณปรับรุ่นระบบของคุณโดยใช้การปรับรุ่นแบบออฟไลน์ได้"
+msgstr ""
+"โปรแกรม \"ซอฟต์แวร์\" ของ GNOME จัดแสดงโปรแกรมที่เด่นและยอดนิยม "
+"พร้อมคำบรรยายที่เป็นประโยชน์และภาพหน้าจอหลายภาพต่อโปรแกรม "
+"คุณสามารถหาโปรแกรมผ่านการท่องดูตามหมวดหมู่หรือด้วยการค้นหาก็ได้ นอกจากนี้ "
+"ยังให้คุณปรับรุ่นระบบของคุณโดยใช้การปรับรุ่นแบบออฟไลน์ได้"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:25
 msgid "Overview panel"
@@ -91,9 +98,11 @@ msgstr "จะดาวน์โหลดรายการปรับรุ่
 
 #: data/org.gnome.software.gschema.xml:16
 msgid ""
-"If enabled, GNOME Software automatically downloads updates in the background"
-" and prompts the user to install them when ready."
-msgstr "ถ้าเปิดใช้ \"ซอฟต์แวร์\" ของ GNOME จะดาวน์โหลดรายการปรับรุ่นโดยอัตโนมัติในเบื้องหลัง และถามผู้ใช้เพื่อติดตั้งเมื่อพร้อมแล้ว"
+"If enabled, GNOME Software automatically downloads updates in the background "
+"and prompts the user to install them when ready."
+msgstr ""
+"ถ้าเปิดใช้ \"ซอฟต์แวร์\" ของ GNOME จะดาวน์โหลดรายการปรับรุ่นโดยอัตโนมัติในเบื้องหลัง "
+"และถามผู้ใช้เพื่อติดตั้งเมื่อพร้อมแล้ว"
 
 #: data/org.gnome.software.gschema.xml:20
 msgid "Whether to automatically refresh when on a metered connection"
@@ -104,7 +113,10 @@ msgid ""
 "If enabled, GNOME Software automatically refreshes in the background even "
 "when using a metered connection (eventually downloading some metadata, "
 "checking for updates, etc., which may incur in costs for the user)."
-msgstr "หากเปิดใช้งาน ซอฟท์แวร์ GNOME จะรีเฟรชในการทำงานพื้นหลังโดยอัตโนมัติแม้เมื่อมีการเชื่อมต่อแบบคิดค่าบริการตามปริมาณข้อมูล (เช่น การดาวน์โหลดเมตาเดต้าส่วน ตรวจสอบการอัพเดท เป็นต้น ซึ่งอาจทำให้ผู้ใช้มีค่าใช้จ่าย)"
+msgstr ""
+"หากเปิดใช้งาน ซอฟท์แวร์ GNOME "
+"จะรีเฟรชในการทำงานพื้นหลังโดยอัตโนมัติแม้เมื่อมีการเชื่อมต่อแบบคิดค่าบริการตามปริมาณข้อมูล (เช่น "
+"การดาวน์โหลดเมตาเดต้าส่วน ตรวจสอบการอัพเดท เป็นต้น ซึ่งอาจทำให้ผู้ใช้มีค่าใช้จ่าย)"
 
 #: data/org.gnome.software.gschema.xml:25
 msgid "Whether it’s the very first run of GNOME Software"
@@ -124,9 +136,11 @@ msgstr "แสดงกล่องโต้ตอบคำเตือนก่
 
 #: data/org.gnome.software.gschema.xml:38
 msgid ""
-"When non-free applications are installed a warning dialog can be shown. This"
-" controls if that dialog is suppressed."
-msgstr "โปรแกรมสามารถแสดงกล่องโต้ตอบคำเตือนก่อนติดตั้งซอฟต์แวร์เสรีได้ ตัวเลือกนี้จะควบคุมว่าจะระงับกล่องโต้ตอบดังกล่าวหรือไม่"
+"When non-free applications are installed a warning dialog can be shown. This "
+"controls if that dialog is suppressed."
+msgstr ""
+"โปรแกรมสามารถแสดงกล่องโต้ตอบคำเตือนก่อนติดตั้งซอฟต์แวร์เสรีได้ "
+"ตัวเลือกนี้จะควบคุมว่าจะระงับกล่องโต้ตอบดังกล่าวหรือไม่"
 
 #: data/org.gnome.software.gschema.xml:42
 msgid "A list of popular applications"
@@ -169,9 +183,12 @@ msgstr "อายุเป็นวินาทีที่ใช้เพื่
 #: data/org.gnome.software.gschema.xml:69
 msgid ""
 "Choosing a larger value will mean less round-trips to the remote server but "
-"updates to the screenshots may take longer to show to the user. A value of 0"
-" means to never check the server if the image already exists in the cache."
-msgstr "การเลือกค่าสูงขึ้นหมายความว่าจะมีการติดต่อไปกลับระหว่างเซิร์ฟเวอร์ทางไกลน้อยครั้งลง แต่การอัปเดตขึ้นบนภาพหน้าจอเพื่อแสดงแก่ผู้ใช้อาจใช้เวลานานมากขึ้น  ค่า 0 หมายความว่าไม่ต้องตรวจสอบกับเซิร์ฟเวอร์หากมีภาพดังกล่าวในแคช"
+"updates to the screenshots may take longer to show to the user. A value of 0 "
+"means to never check the server if the image already exists in the cache."
+msgstr ""
+"การเลือกค่าสูงขึ้นหมายความว่าจะมีการติดต่อไปกลับระหว่างเซิร์ฟเวอร์ทางไกลน้อยครั้งลง "
+"แต่การอัปเดตขึ้นบนภาพหน้าจอเพื่อแสดงแก่ผู้ใช้อาจใช้เวลานานมากขึ้น  ค่า 0 "
+"หมายความว่าไม่ต้องตรวจสอบกับเซิร์ฟเวอร์หากมีภาพดังกล่าวในแคช"
 
 #: data/org.gnome.software.gschema.xml:78
 msgid "The server to use for application reviews"
@@ -195,13 +212,11 @@ msgstr "รายการแหล่งข้อมูลอย่างเป
 
 #: data/org.gnome.software.gschema.xml:95
 msgid ""
-"The licence URL to use when an application should be considered free "
-"software"
+"The licence URL to use when an application should be considered free software"
 msgstr "URL ลิขสิทธิ์สำหรับใช้งานเมื่อแอพพลิเคชั่นอาจจัดเป็นซอฟต์แวร์ฟรี"
 
 #: data/org.gnome.software.gschema.xml:99
-msgid ""
-"Install bundled applications for all users on the system where possible"
+msgid "Install bundled applications for all users on the system where possible"
 msgstr "ติดตั้งชุดรวมแอปพลิเคชั่นสำหรับผู้ใช้ทั้งหมดบนระบบเมื่อสามารถทำได้"
 
 #: data/org.gnome.software.gschema.xml:103
@@ -248,7 +263,8 @@ msgstr "รายการ  URL ไปยังไฟล์อัปสตรี
 
 #: data/org.gnome.software.gschema.xml:143
 msgid "Install the AppStream files to a system-wide location for all users"
-msgstr "ติดตั้งไฟล์ AppStream files ลงในตำแหน่งที่เข้าถึงได้ทั้งระบบเพื่อให้ผู้ใช้งานทุกคนใช้งานได้ "
+msgstr ""
+"ติดตั้งไฟล์ AppStream files ลงในตำแหน่งที่เข้าถึงได้ทั้งระบบเพื่อให้ผู้ใช้งานทุกคนใช้งานได้ "
 
 #: data/org.gnome.software.gschema.xml:147
 msgid "Sorts the apps shown in the overview in alphabetical order"
@@ -268,8 +284,7 @@ msgstr "ติดตั้งซอฟต์แวร์"
 msgid "Install selected software on the system"
 msgstr "ติดตั้งซอฟต์แวร์ที่เลือกลงในระบบ"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 #: src/gnome-software-local-file.desktop.in:10
 msgid "system-software-install"
 msgstr "system-software-install"
@@ -296,14 +311,12 @@ msgstr "กลับไป"
 msgid "_All"
 msgstr "_ทั้งหมด"
 
-#. Translators: A label for a button to show only software which is already
-#. installed.
+#. Translators: A label for a button to show only software which is already installed.
 #: src/gnome-software.ui:104
 msgid "_Installed"
 msgstr "_ติดตั้งอยู่"
 
-#. Translators: A label for a button to show only updates which are available
-#. to install.
+#. Translators: A label for a button to show only updates which are available to install.
 #: src/gnome-software.ui:155
 msgid "_Updates"
 msgstr "_มีรุ่นใหม่"
@@ -351,7 +364,7 @@ msgstr "ติดตั้งอยู่"
 
 #. TRANSLATORS: this is a button next to the search results that
 #. * shows the status of an application being installed
-#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:443
+#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:439
 msgid "Installing"
 msgstr "กำลังติดตั้ง"
 
@@ -366,7 +379,7 @@ msgid "Folder Name"
 msgstr "ชื่อโฟลเดอร์"
 
 #: src/gs-app-folder-dialog.c:321 src/gs-app-folder-dialog.ui:16
-#: src/gs-details-page.c:383 src/gs-details-page.ui:342 src/gs-editor.c:623
+#: src/gs-details-page.c:379 src/gs-details-page.ui:342 src/gs-editor.c:623
 #: src/gs-editor.c:655 src/gs-installed-page.c:609 src/gs-removal-dialog.ui:33
 #: src/gs-review-dialog.ui:23 src/gs-upgrade-banner.ui:131
 msgid "_Cancel"
@@ -381,90 +394,92 @@ msgid "Add to Application Folder"
 msgstr "เพิ่มเข้าโฟลเดอร์โปรแกรม"
 
 #. TRANSLATORS: this is a command line option
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "Start up mode: either ‘updates’, ‘updated’, ‘installed’ or ‘overview’"
-msgstr "โหมดเริ่มทำงาน: เป็นค่า ‘updates’ (รายการปรับรุ่น), ‘updated’ (รายการปรับรุ่นแล้ว), ‘installed’ (รายการติดตั้งแล้ว) หรือ ‘overview’ (ภาพรวม) อย่างใดอย่างหนึ่ง"
+msgstr ""
+"โหมดเริ่มทำงาน: เป็นค่า ‘updates’ (รายการปรับรุ่น), ‘updated’ (รายการปรับรุ่นแล้ว), "
+"‘installed’ (รายการติดตั้งแล้ว) หรือ ‘overview’ (ภาพรวม) อย่างใดอย่างหนึ่ง"
 
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "MODE"
 msgstr "โหมด"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "Search for applications"
 msgstr "ค้นหาโปรแกรม"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "SEARCH"
 msgstr "คำค้น"
 
-#: src/gs-application.c:105
+#: src/gs-application.c:133
 msgid "Show application details (using application ID)"
 msgstr "แสดงรายละเอียดแอพพลิเคชั่น (ใช้งาน ID ของแอพพลิเคชั่น)"
 
-#: src/gs-application.c:105 src/gs-application.c:109
+#: src/gs-application.c:133 src/gs-application.c:137
 msgid "ID"
 msgstr "ID"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "Show application details (using package name)"
 msgstr "แสดงรายละเอียดแอพพลิเคชั่น (ใช้ชื่อแพคเกจ)"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "PKGNAME"
 msgstr "PKGNAME"
 
-#: src/gs-application.c:109
+#: src/gs-application.c:137
 msgid "Install the application (using application ID)"
 msgstr "ติดตั้งแอปพลิเคชั่น (ใช้ ID ของแอปพลิเคชั่น)"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "Open a local package file"
 msgstr "เปิดแฟ้มแพกเกจในเครื่อง"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "FILENAME"
 msgstr "ชื่อแฟ้ม"
 
-#: src/gs-application.c:113
+#: src/gs-application.c:141
 msgid ""
 "The kind of interaction expected for this action: either ‘none’, ‘notify’, "
 "or ‘full’"
 msgstr "ประเภทปฏิสัมพันธ์ที่คาดหวังจากแอคชั่นนี้: ทั้ง \"ไม่เลย\", \"แจ้ง\" หรือ \"เต็ม\""
 
-#: src/gs-application.c:116
+#: src/gs-application.c:144
 msgid "Show verbose debugging information"
 msgstr "แสดงข้อมูลดีบั๊กโดยละเอียด"
 
-#: src/gs-application.c:118
+#: src/gs-application.c:146
 msgid "Show profiling information for the service"
 msgstr "แสดงข้อมูลการวัดประสิทธิภาพของบริการ"
 
-#: src/gs-application.c:120
+#: src/gs-application.c:148
 msgid "Quit the running instance"
 msgstr "ยุติการดำเนินงานทันที"
 
-#: src/gs-application.c:122
+#: src/gs-application.c:150
 msgid "Prefer local file sources to AppStream"
 msgstr "พยายามใช้แหล่งแฟ้มในเครื่องก่อนใช้ AppStream"
 
-#: src/gs-application.c:124
+#: src/gs-application.c:152
 msgid "Show version number"
 msgstr "แสดงเลขรุ่น"
 
-#: src/gs-application.c:325
+#: src/gs-application.c:358
 msgid "translator-credits"
 msgstr "Akom Chotiphantawanon"
 
 #. TRANSLATORS: this is the title of the about window, e.g.
 #. * 'About Software' or 'About Application Installer' where the %s is
 #. * the application name chosen by the distro
-#: src/gs-application.c:332
+#: src/gs-application.c:365
 #, c-format
 msgid "About %s"
 msgstr "เกี่ยวกับ %s"
 
 #. TRANSLATORS: well, we seem to think so, anyway
-#: src/gs-application.c:336
+#: src/gs-application.c:369
 msgid "A nice way to manage the software on your system."
 msgstr "วิธีที่ดีในการจัดการซอฟต์แวร์ในระบบของคุณ"
 
@@ -579,7 +594,7 @@ msgid "All"
 msgstr "ทั้งหมด"
 
 #. TRANSLATORS: this is a subcategory of featured apps
-#: lib/gs-category.c:202 src/gs-shell.c:2180
+#: lib/gs-category.c:202 src/gs-shell.c:2181
 msgid "Featured"
 msgstr "เด่น"
 
@@ -589,9 +604,10 @@ msgstr "ตั้งค่าส่วนขยาย"
 
 #: src/gs-category-page.ui:110
 msgid ""
-"Extensions are used at your own risk. If you have any system problems, it is"
-" recommended to disable them."
-msgstr "คุณต้องรับความเสียงเองเมื่อใช้ส่วนขยายต่างๆ ถ้าคุณมีปัญหาใดๆ กับระบบ ขอแนะนำให้ปิดส่วนขยายต่างๆ"
+"Extensions are used at your own risk. If you have any system problems, it is "
+"recommended to disable them."
+msgstr ""
+"คุณต้องรับความเสียงเองเมื่อใช้ส่วนขยายต่างๆ ถ้าคุณมีปัญหาใดๆ กับระบบ ขอแนะนำให้ปิดส่วนขยายต่างๆ"
 
 #. TRANSLATORS: the user isn't reading the question
 #: lib/gs-cmd.c:205
@@ -647,13 +663,15 @@ msgstr "เปิดใช้แหล่งซอฟต์แวร์ของ
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
 #. * 2. Software source name, e.g. fedora-optional
+#.
 #: src/gs-common.c:232
 #, c-format
 msgid ""
 "%s is not <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
-"source_software\">free and open source software</a>, and is provided by "
-"“%s”."
-msgstr "%s ไม่ใช่ <a href=\"https://en.wikipedia.org/wiki/Free_and_open-source_software\">ซอฟต์แวร์เสรีและโอเพนซอร์ส</a> และจัดเตรียมโดย “%s”"
+"source_software\">free and open source software</a>, and is provided by “%s”."
+msgstr ""
+"%s ไม่ใช่ <a href=\"https://en.wikipedia.org/wiki/Free_and_open-source_software"
+"\">ซอฟต์แวร์เสรีและโอเพนซอร์ส</a> และจัดเตรียมโดย “%s”"
 
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
@@ -1035,14 +1053,12 @@ msgstr "ไม่แบ่งปันตำแหน่งที่อยู่
 msgid "Sharing physical location to other users"
 msgstr "แบ่งปันตำแหน่งที่อยู่กับผู้ใช้อื่นๆ"
 
-#. TRANSLATORS: this is a what we use in notifications if the app's name is
-#. unknown
+#. TRANSLATORS: this is a what we use in notifications if the app's name is unknown
 #: src/gs-dbus-helper.c:294
 msgid "An application"
 msgstr "มีโปรแกรมหนึ่ง"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. MIME types.
+#. TRANSLATORS: this is a notification displayed when an app needs additional MIME types.
 #: src/gs-dbus-helper.c:300
 #, c-format
 msgid "%s is requesting additional file format support."
@@ -1053,8 +1069,7 @@ msgstr "%s ร้องขอการรองรับฟอร์แมตแ
 msgid "Additional MIME Types Required"
 msgstr "ต้องการชนิด MIME เพิ่มเติม"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. fonts.
+#. TRANSLATORS: this is a notification displayed when an app needs additional fonts.
 #: src/gs-dbus-helper.c:306
 #, c-format
 msgid "%s is requesting additional fonts."
@@ -1065,8 +1080,7 @@ msgstr "%s ร้องขอแบบอักษรเพิ่มเติม
 msgid "Additional Fonts Required"
 msgstr "ต้องการแบบอักษรเพิ่มเติม"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. codecs.
+#. TRANSLATORS: this is a notification displayed when an app needs additional codecs.
 #: src/gs-dbus-helper.c:312
 #, c-format
 msgid "%s is requesting additional multimedia codecs."
@@ -1077,8 +1091,7 @@ msgstr "%s ร้องขอตัวอ่าน-ลงรหัสสื่�
 msgid "Additional Multimedia Codecs Required"
 msgstr "ต้องการตัวอ่าน-ลงรหัสสื่อผสมเพิ่มเติม"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. printer drivers.
+#. TRANSLATORS: this is a notification displayed when an app needs additional printer drivers.
 #: src/gs-dbus-helper.c:318
 #, c-format
 msgid "%s is requesting additional printer drivers."
@@ -1089,8 +1102,7 @@ msgstr "%s ร้องขอไดรเวอร์เครื่องพิ
 msgid "Additional Printer Drivers Required"
 msgstr "ต้องการไดรเวอร์เครื่องพิมพ์เพิ่มเติม"
 
-#. TRANSLATORS: this is a notification displayed when an app wants to install
-#. additional packages.
+#. TRANSLATORS: this is a notification displayed when an app wants to install additional packages.
 #: src/gs-dbus-helper.c:324
 #, c-format
 msgid "%s is requesting additional packages."
@@ -1110,14 +1122,14 @@ msgstr "หาใน \"ซอฟต์แวร์\""
 #. * can be installed
 #. TRANSLATORS: button text in the header when firmware
 #. * can be live-installed
-#: src/gs-details-page.c:281 src/gs-details-page.c:312
-#: src/gs-details-page.ui:206 src/gs-upgrade-banner.ui:146
+#: src/gs-details-page.c:280 src/gs-details-page.c:310
+#: src/gs-details-page.ui:237 src/gs-upgrade-banner.ui:146
 msgid "_Install"
 msgstr "_ติดตั้ง"
 
 #. TRANSLATORS: button text in the header when an application
 #. * can be live-updated
-#: src/gs-details-page.c:316
+#: src/gs-details-page.c:314
 msgid "_Update"
 msgstr "_อัพเดต"
 
@@ -1125,66 +1137,66 @@ msgstr "_อัพเดต"
 #. * be installed.
 #. * The ellipsis indicates that further steps are required,
 #. * e.g. enabling software sources or the like
-#: src/gs-details-page.c:330
+#: src/gs-details-page.c:326
 msgid "_Install…"
 msgstr "_ติดตั้ง…"
 
 #. TRANSLATORS: button text in the header when an application can be erased
-#: src/gs-details-page.c:377 src/gs-details-page.ui:547
+#: src/gs-details-page.c:373 src/gs-details-page.ui:547
 msgid "_Uninstall"
 msgstr "_ถอนการติดตั้ง"
 
-#: src/gs-details-page.c:438 src/gs-sources-dialog.c:513
+#: src/gs-details-page.c:434 src/gs-sources-dialog.c:513
 msgid "Removing…"
 msgstr "กำลังถอดถอน…"
 
 #. TRANSLATORS: this is the warning box
-#: src/gs-details-page.c:748
+#: src/gs-details-page.c:744
 msgid ""
 "This application can only be used when there is an active internet "
 "connection."
 msgstr "โปรแกรมนี้สามารถใช้งานได้เมื่อมีการเชื่อมต่ออินเทอร์เน็ตเท่านั้น"
 
 #. TRANSLATORS: this is where the version is not known
-#: src/gs-details-page.c:892
+#: src/gs-details-page.c:888
 msgctxt "version"
 msgid "Unknown"
 msgstr "ไม่ทราบ"
 
 #. TRANSLATORS: this is where we don't know the origin of the
 #. * application
-#: src/gs-details-page.c:971
+#: src/gs-details-page.c:967
 msgctxt "origin"
 msgid "Unknown"
 msgstr "ไม่ทราบ"
 
 #. TRANSLATORS: we need a remote server to process
-#: src/gs-details-page.c:1378
+#: src/gs-details-page.c:1374
 msgid "You need internet access to write a review"
 msgstr "คุณจำเป็นต้องเข้าถึงอินเทอร์เน็ตเพื่อเขียนรีวิว"
 
-#: src/gs-details-page.c:1507
+#: src/gs-details-page.c:1503
 #, c-format
 msgid "Unable to find “%s”"
 msgstr "ไม่พบ \"%s\""
 
 #. TRANSLATORS: see the wikipedia page
-#: src/gs-details-page.c:2087
+#: src/gs-details-page.c:2083
 msgid "Public domain"
 msgstr "สาธารณสมบัติ"
 
 #. TRANSLATORS: see GNU page
-#: src/gs-details-page.c:2103 src/gs-details-page.ui:1397
+#: src/gs-details-page.c:2099 src/gs-details-page.ui:1397
 msgid "Free Software"
 msgstr "ซอฟต์แวร์ฟรี"
 
 #. TRANSLATORS: for the free software popover
-#: src/gs-details-page.c:2160
+#: src/gs-details-page.c:2156
 msgid "Users are bound by the following license:"
 msgid_plural "Users are bound by the following licenses:"
 msgstr[0] "ผู้ใช้จะต้องปฏิบัติตามการอนุญาตต่อไปนี้"
 
-#: src/gs-details-page.c:2176 src/gs-details-page.ui:1506
+#: src/gs-details-page.c:2172 src/gs-details-page.ui:1506
 msgid "More information"
 msgstr "ข้อมูลเพิ่มเติม"
 
@@ -1192,15 +1204,13 @@ msgstr "ข้อมูลเพิ่มเติม"
 msgid "Details page"
 msgstr "หน้ารายละเอียด"
 
-#. Translators: A label for a button to add a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:228
+#. Translators: A label for a button to add a shortcut to the selected application.
+#: src/gs-details-page.ui:209
 msgid "_Add to Desktop"
 msgstr "_เพิ่มไปยังเดสก์ท็อป"
 
-#. Translators: A label for a button to remove a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:245
+#. Translators: A label for a button to remove a shortcut to the selected application.
+#: src/gs-details-page.ui:226
 msgid "_Remove from Desktop"
 msgstr "_ลบออกจากเดสก์ท็อป"
 
@@ -1221,7 +1231,8 @@ msgstr "มีแหล่งซอฟต์แวร์"
 msgid ""
 "This application includes a software source which provides updates, as well "
 "as access to other software."
-msgstr "โปรแกรมนี้มีแหล่งซอฟต์แวร์ ซึ่งมีการจัดเตรียมรายการปรับรุ่น และสามารถเข้าถึงซอฟต์แวร์อื่นๆ ได้"
+msgstr ""
+"โปรแกรมนี้มีแหล่งซอฟต์แวร์ ซึ่งมีการจัดเตรียมรายการปรับรุ่น และสามารถเข้าถึงซอฟต์แวร์อื่นๆ ได้"
 
 #: src/gs-details-page.ui:500
 msgid "No Software Source Included"
@@ -1239,8 +1250,7 @@ msgid ""
 "replaced."
 msgstr "ซอฟต์แวร์นี้จัดเตรียมโดยชุดจัดแจกของคุณอยู่แล้ว และไม่ควรแทนที่"
 
-#. Translators: a repository file used for installing software has been
-#. discovered.
+#. Translators: a repository file used for installing software has been discovered.
 #: src/gs-details-page.ui:528
 msgid "Software Source Identified"
 msgstr "แหล่งซอฟต์แวร์ที่ระบุที่มา"
@@ -1341,14 +1351,12 @@ msgstr "ส่วนเสริม"
 msgid "Selected add-ons will be installed with the application."
 msgstr "ส่วนเสริมที่เลือกจะถูกติดตั้งพร้อมกับโปรแกรม"
 
-#. Translators: Header of the section with other users' opinions about the
-#. app.
+#. Translators: Header of the section with other users' opinions about the app.
 #: src/gs-details-page.ui:1233
 msgid "Reviews"
 msgstr "บทวิจารณ์"
 
-#. Translators: Button opening a dialog where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Button opening a dialog where the users can write and publish their opinions about the apps.
 #: src/gs-details-page.ui:1249
 msgid "_Write a Review"
 msgstr "เ_ขียนบทวิจารณ์"
@@ -1360,8 +1368,8 @@ msgstr "แ_สดงเพิ่มเติม"
 
 #: src/gs-details-page.ui:1414
 msgid ""
-"This means that the software can be freely run, copied, distributed, studied"
-" and modified."
+"This means that the software can be freely run, copied, distributed, studied "
+"and modified."
 msgstr "นี่หมายความว่าคุณสามารถดำเนินการ, ตัดลอก, แจกจ่าย, ศึกษา และแก้ไขโปรแกรมได้"
 
 #: src/gs-details-page.ui:1473
@@ -1373,7 +1381,9 @@ msgid ""
 "This means that the software is owned by an individual or a company. There "
 "are often restrictions on its use and its source code cannot usually be "
 "accessed."
-msgstr "นี่หมายความว่าซอฟต์แวร์เป็นของบุคคลหรือบริษัท ซึ่งมักทีข้อกำหนดในการใช้งานและไม่สามารถเข้าถึงรหัสคำสั่งได้"
+msgstr ""
+"นี่หมายความว่าซอฟต์แวร์เป็นของบุคคลหรือบริษัท "
+"ซึ่งมักทีข้อกำหนดในการใช้งานและไม่สามารถเข้าถึงรหัสคำสั่งได้"
 
 #: src/gs-details-page.ui:1535
 msgid "Unknown Software License"
@@ -1457,8 +1467,7 @@ msgstr "รายการแอปพลิเคชั่นมีการเ
 msgid "Use verbose logging"
 msgstr "ใช้ verbose logging"
 
-#. TRANSLATORS: program name, an application to add and remove software
-#. repositories
+#. TRANSLATORS: program name, an application to add and remove software repositories
 #: src/gs-editor.c:1119
 msgid "GNOME Software Banner Designer"
 msgstr "ผู้ออกแบบแบนเนอร์ GNOME Software "
@@ -1487,8 +1496,7 @@ msgstr "สรุป"
 msgid "Editor’s Pick"
 msgstr "การคัดสรรจากบรรณาธิการ"
 
-#. This check button controls whether the application’s banner appears in the
-#. “Featured” category
+#. This check button controls whether the application’s banner appears in the “Featured” category
 #: src/gs-editor.ui:397
 msgid "Category Featured"
 msgstr "หมวดหมู่แนะนำ"
@@ -1575,8 +1583,8 @@ msgstr "ไม่มีโปรแกรมที่จัดเตรียม
 #: src/gs-extras-page.c:337 src/gs-extras-page.c:348 src/gs-extras-page.c:359
 #, c-format
 msgid ""
-"Information about %s, as well as options for how to get missing applications"
-" might be found %s."
+"Information about %s, as well as options for how to get missing applications "
+"might be found %s."
 msgstr "อ่านข้อมูลเกี่ยวกับ %s รวมทั้งตัวเลือกต่างๆ สำหรับการรับโปรแกรมที่ขาดได้ %s"
 
 #. TRANSLATORS: this is when we know about an application or
@@ -1600,7 +1608,8 @@ msgstr "ไม่มี %s"
 msgid ""
 "Information about %s, as well as options for how to get an application that "
 "can support this format might be found %s."
-msgstr "อ่านข้อมูลเกี่ยวกับ %s รวมทั้งตัวเลือกต่างๆ สำหรับการรับโปรแกรมที่สามารถรองรับฟอร์แมตนี้ได้ %s"
+msgstr ""
+"อ่านข้อมูลเกี่ยวกับ %s รวมทั้งตัวเลือกต่างๆ สำหรับการรับโปรแกรมที่สามารถรองรับฟอร์แมตนี้ได้ %s"
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1620,7 +1629,7 @@ msgstr "อ่านข้อมูลเกี่ยวกับ %s รวม�
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
-#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1426
+#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1430
 #, c-format
 msgid "No addon codecs are available for the %s format."
 msgstr "ไม่มีส่วนเสริมของตัวอ่าน-ลงรหัสสำหรับรูปแบบ %s"
@@ -1632,7 +1641,8 @@ msgstr "ไม่มีส่วนเสริมของตัวอ่าน
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format might be found %s."
-msgstr "อ่านข้อมูลเกี่ยวกับ %s รวมทั้งตัวเลือกต่างๆ สำหรับการรับตัวอ่าน-ลงรหัสที่สามารถเล่นฟอร์แมตนี้ได้ %s"
+msgstr ""
+"อ่านข้อมูลเกี่ยวกับ %s รวมทั้งตัวเลือกต่างๆ สำหรับการรับตัวอ่าน-ลงรหัสที่สามารถเล่นฟอร์แมตนี้ได้ %s"
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1671,8 +1681,7 @@ msgstr "อ่านข้อมูลเกี่ยวกับ %s รวม�
 msgid "this website"
 msgstr "เว็บไซต์นี้"
 
-#. TRANSLATORS: no codecs were found. First %s will be replaced by actual
-#. codec name(s), second %s is a link titled "this website"
+#. TRANSLATORS: no codecs were found. First %s will be replaced by actual codec name(s), second %s is a link titled "this website"
 #: src/gs-extras-page.c:463
 #, c-format
 msgid ""
@@ -1706,10 +1715,12 @@ msgstr "ยินดีต้อนรับสู่ \"ซอฟต์แวร
 
 #: src/gs-first-run-dialog.ui:66
 msgid ""
-"Software lets you install all the software you need, all from one place. See"
-" our recommendations, browse the categories, or search for the applications "
+"Software lets you install all the software you need, all from one place. See "
+"our recommendations, browse the categories, or search for the applications "
 "you want."
-msgstr "\"ซอฟต์แวร์\" ช่วยคุณติดตั้งซอฟต์แวร์ใดๆ ที่คุณต้องการได้โดยสั่งจากที่นี่ที่เดียว คุณสามารถดูซอฟต์แวร์แนะนำ ท่องดูหมวดต่างๆ หรือค้นหาโปรแกรมที่คุณต้องการได้"
+msgstr ""
+"\"ซอฟต์แวร์\" ช่วยคุณติดตั้งซอฟต์แวร์ใดๆ ที่คุณต้องการได้โดยสั่งจากที่นี่ที่เดียว "
+"คุณสามารถดูซอฟต์แวร์แนะนำ ท่องดูหมวดต่างๆ หรือค้นหาโปรแกรมที่คุณต้องการได้"
 
 #: src/gs-first-run-dialog.ui:85
 msgid "_Let’s Go Shopping"
@@ -1863,8 +1874,7 @@ msgstr " ให้การเข้าถึงซอฟท์แวร์เ�
 
 #. TRANSLATORS: this is the proprietary info bar
 #: src/gs-overview-page.c:978
-msgid ""
-"Proprietary software has restrictions on use and access to source code."
+msgid "Proprietary software has restrictions on use and access to source code."
 msgstr "ซอฟต์แวร์กรรมสิทธิ์มีข้อจำกัดการใช้งานและเข้าถึงรหัสคำสั่ง"
 
 #. TRANSLATORS: this is the clickable
@@ -1894,14 +1904,12 @@ msgstr "โปรแกรมเด่น"
 msgid "Categories"
 msgstr "หมวด"
 
-#. Translators: This is a heading for software which has been featured
-#. ('picked') by the distribution.
+#. Translators: This is a heading for software which has been featured ('picked') by the distribution.
 #: src/gs-overview-page.ui:315
 msgid "Editor’s Picks"
 msgstr "ตัวเลือกของบรรณาธิการ"
 
-#. Translators: This is a heading for software which has been recently
-#. released upstream.
+#. Translators: This is a heading for software which has been recently released upstream.
 #: src/gs-overview-page.ui:359
 msgid "Recent Releases"
 msgstr "เปิดตัวล่าสุด"
@@ -1963,12 +1971,13 @@ msgstr "คุณแน่ใจหรือไม่ว่าต้องกา
 msgid "%s will be removed, and you will have to install it to use it again."
 msgstr "%s จะถูกถอดถอน และคุณจะต้องติดตั้งโปรแกรมดังกล่าวใหม่หากต้องการใช้งานอีกครั้ง"
 
-#: lib/gs-plugin-loader.c:1429
+#: lib/gs-plugin-loader.c:1433
 #, c-format
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format can be found on the website."
-msgstr "ข้อมูลเกี่ยวกับ %s และตัวเลือกสำหรับวิธีการรับตัวอ่าน-ลงรหัสที่สามารถเล่นรูปแบบนี้ มีอยู่ในในเว็บไซต์"
+msgstr ""
+"ข้อมูลเกี่ยวกับ %s และตัวเลือกสำหรับวิธีการรับตัวอ่าน-ลงรหัสที่สามารถเล่นรูปแบบนี้ มีอยู่ในในเว็บไซต์"
 
 #: lib/gs-price.c:111
 #, c-format
@@ -2027,7 +2036,9 @@ msgstr "%s %f"
 msgid ""
 "Some of the currently installed software is not compatible with %s. If you "
 "continue, the following will be automatically removed during the upgrade:"
-msgstr "ขณะนี้ซอฟต์แวร์ที่ติดตั้งแล้วบางส่วนไม่สามารถทำงานร่วมกับ %s ได้  หากคุณทำต่อ ซอฟต์แวร์ต่อไปนี้จะถูกลบโดยอัตโนมัติระหว่างการอัปเกรด:"
+msgstr ""
+"ขณะนี้ซอฟต์แวร์ที่ติดตั้งแล้วบางส่วนไม่สามารถทำงานร่วมกับ %s ได้  หากคุณทำต่อ "
+"ซอฟต์แวร์ต่อไปนี้จะถูกลบโดยอัตโนมัติระหว่างการอัปเกรด:"
 
 #: src/gs-removal-dialog.ui:27
 msgid "Incompatible Software"
@@ -2097,8 +2108,7 @@ msgstr "คำบรรยายสั้นเกินไป"
 msgid "The description is too long"
 msgstr "คำบรรยายยาวเกินไป"
 
-#. Translators: Title of the dialog box where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Title of the dialog box where the users can write and publish their opinions about the apps.
 #: src/gs-review-dialog.ui:11
 msgid "Post Review"
 msgstr "แปะประกาศบทวิจารณ์"
@@ -2158,8 +2168,7 @@ msgstr "รายงานบทวิจารณ์หรือไม่?"
 msgid "Report"
 msgstr "รายงาน"
 
-#. Translators: Users can express their opinions about other users' opinions
-#. about the apps.
+#. Translators: Users can express their opinions about other users' opinions about the apps.
 #: src/gs-review-row.ui:112
 msgid "Was this review useful to you?"
 msgstr "บทวิจารณ์นี้เป็นประโยชน์กับคุณหรือไม่?"
@@ -2247,81 +2256,81 @@ msgstr "ไม่พบโปรแกรม"
 #. TRANSLATORS: this is part of the in-app notification,
 #. * where the %s is a multi-word localised app name
 #. * e.g. 'Getting things GNOME!"
-#: src/gs-shell.c:846 src/gs-shell.c:851 src/gs-shell.c:866 src/gs-shell.c:870
+#: src/gs-shell.c:847 src/gs-shell.c:852 src/gs-shell.c:867 src/gs-shell.c:871
 #, c-format
 msgid "“%s”"
 msgstr "“%s”"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:898
+#: src/gs-shell.c:899
 #, c-format
 msgid "Unable to download firmware updates from %s"
 msgstr "ไม่สามารถดาวน์โหลดอัพเดทเฟิร์มแวร์จาก %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:904
+#: src/gs-shell.c:905
 #, c-format
 msgid "Unable to download updates from %s"
 msgstr "ไม่สามารถดาวน์โหลดอัพเดทจาก %s "
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:911
+#: src/gs-shell.c:912
 msgid "Unable to download updates"
 msgstr "ไม่สามารถดาวน์โหลดอัปเดตได้"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:916
+#: src/gs-shell.c:917
 msgid ""
-"Unable to download updates: internet access was required but wasn’t "
-"available"
-msgstr "ไม่สามารถดาวน์โหลดอัปเดตได้: จำเป็นต้องเข้าถึงอินเทอร์เน็ต แต่อินเทอร์เน็ตไม่สามารถใช้งานได้"
+"Unable to download updates: internet access was required but wasn’t available"
+msgstr ""
+"ไม่สามารถดาวน์โหลดอัปเดตได้: จำเป็นต้องเข้าถึงอินเทอร์เน็ต แต่อินเทอร์เน็ตไม่สามารถใช้งานได้"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:925
+#: src/gs-shell.c:926
 #, c-format
 msgid "Unable to download updates from %s: not enough disk space"
 msgstr "ไม่สามารถดาวน์โหลดอัปเดตจาก %s ได้: มีพื้นที่ดิสก์ไม่เพียงพอ"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:930
+#: src/gs-shell.c:931
 msgid "Unable to download updates: not enough disk space"
 msgstr "ไม่สามารถดาวน์โหลดอัปเดตได้: พื้นที่ดิสก์ไม่เพียงพอ"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:938
+#: src/gs-shell.c:939
 msgid "Unable to download updates: authentication was required"
 msgstr "ไม่สามารถดาวน์โหลดอัพเดท: ต้องได้รับอนุญาต"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:943
+#: src/gs-shell.c:944
 msgid "Unable to download updates: authentication was invalid"
 msgstr "ไม่สามารถดาวน์โหลดอัปเดตได้: การพิสูจน์ตัวจริงไม่ถูกต้อง"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:948
+#: src/gs-shell.c:949
 msgid ""
 "Unable to download updates: you do not have permission to install software"
 msgstr "ไม่สามารถดาวน์โหลดอัปเดตได้: คุณไม่ได้รับอนุญาตให้ติดตั้งซอฟต์แวร์"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:955
+#: src/gs-shell.c:956
 msgid "Unable to get list of updates"
 msgstr "ไม่สามารถรับรายการอัพเดทได้"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the application name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1001
+#: src/gs-shell.c:1002
 #, c-format
 msgid "Unable to install %s as download failed from %s"
 msgstr "ไม่สามารถติดตั้ง %s เนื่องจากการดาวน์โหลดล้มเหลวจาก %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1007
+#: src/gs-shell.c:1008
 #, c-format
 msgid "Unable to install %s as download failed"
 msgstr "ไม่สามารถติดตั้ง %s ได้เนื่องจากการดาวน์โหลดล้มเหลว"
@@ -2330,51 +2339,51 @@ msgstr "ไม่สามารถติดตั้ง %s ได้เนื�
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1019
+#: src/gs-shell.c:1020
 #, c-format
 msgid "Unable to install %s as runtime %s not available"
 msgstr "ไม่สามารถติดตั้ง %s ได้เนื่องจากระยะเวลาดำเนินการ %s ไม่พร้อมใช้งาน"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1025
+#: src/gs-shell.c:1026
 #, c-format
 msgid "Unable to install %s as not supported"
 msgstr "ไม่สามารถติดตั้ง %s ได้เนื่องจากไม่รองรับ"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1032
+#: src/gs-shell.c:1033
 msgid "Unable to install: internet access was required but wasn’t available"
 msgstr "ไม่สามารถติดตั้ง: จำเป็นต้องมีการเข้าอินเตอร์เน็ตแต่ไม่มี"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1038
+#: src/gs-shell.c:1039
 msgid "Unable to install: the application has an invalid format"
 msgstr "ไม่สามารถติดตั้งได้: แอปพลิเคชั่นมีรูปแบบไม่ถูกต้อง"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1043
+#: src/gs-shell.c:1044
 #, c-format
 msgid "Unable to install %s: not enough disk space"
 msgstr "ไม่สามารถติดตั้ง %s ได้: มีพื้นที่ดิสก์ไม่เพียงพอ"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1051
+#: src/gs-shell.c:1052
 #, c-format
 msgid "Unable to install %s: authentication was required"
 msgstr "ไม่สามารถติดตั้ง %s ได้: จำเป็นต้องได้รับการพิสูจน์ตัวจริง"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1058
+#: src/gs-shell.c:1059
 #, c-format
 msgid "Unable to install %s: authentication was invalid"
 msgstr "ไม่สามารถติดตั้ง %s ได้: การยืนยันตัวจริงไม่ถูกต้อง"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1065
+#: src/gs-shell.c:1066
 #, c-format
 msgid "Unable to install %s: you do not have permission to install software"
 msgstr "ไม่สามารถติดตั้ง %s: คุณไม่ได้รับอนุญาตให้ติดตั้งซอฟท์แวร์นี้"
@@ -2382,34 +2391,34 @@ msgstr "ไม่สามารถติดตั้ง %s: คุณไม่�
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the name of the authentication service,
 #. * e.g. "Ubuntu One"
-#: src/gs-shell.c:1078
+#: src/gs-shell.c:1079
 #, c-format
 msgid "Your %s account has been suspended."
 msgstr "บัญชี %s ของคุณถูกระงับ"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1082
+#: src/gs-shell.c:1083
 msgid "It is not possible to install software until this has been resolved."
 msgstr "เป็นไปไม่ได้ที่จะติดตั้งซอฟต์แวร์จนกว่าปัญหานี้จะแก้ไขได้"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the clickable link (e.g.
 #. * "http://example.com/what-did-i-do-wrong/")
-#: src/gs-shell.c:1093
+#: src/gs-shell.c:1094
 #, c-format
 msgid "For more information, visit %s."
 msgstr "สำหรับข้อมูลเพิ่มเติม ดูที่ %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1102
+#: src/gs-shell.c:1103
 #, c-format
 msgid "Unable to install %s: AC power is required"
 msgstr "ไม่สามารถติดตั้ง %s ได้: จำเป็นต้องใช้ไฟกระแสสลับ"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1111
+#: src/gs-shell.c:1112
 #, c-format
 msgid "Unable to install %s"
 msgstr "ไม่สามารถติดตั้ง %s ได้"
@@ -2418,61 +2427,61 @@ msgstr "ไม่สามารถติดตั้ง %s ได้"
 #. * where the first %s is the app name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1157
+#: src/gs-shell.c:1158
 #, c-format
 msgid "Unable to update %s from %s"
 msgstr "ไม่สามารถอัพเดท  %s จาก  %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1163
+#: src/gs-shell.c:1164
 #, c-format
 msgid "Unable to update %s as download failed"
 msgstr "ไม่สามารถอัปเดต %s ได้เนื่องจากการดาวน์โหลดล้มเหลว"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1169
+#: src/gs-shell.c:1170
 msgid "Unable to update: internet access was required but wasn’t available"
 msgstr "ไม่สามารถอัปเดตได้: จำเป็นต้องเข้าถึงอินเทอร์เน็ต แต่อินเทอร์เน็ตไม่พร้อมใช้งาน"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1177
+#: src/gs-shell.c:1178
 #, c-format
 msgid "Unable to update %s: not enough disk space"
 msgstr "ไม่สามารถอัพเดท  %s: ไม่มีพื้นที่ว่างในดิสก์เพียงพอ"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1186
+#: src/gs-shell.c:1187
 #, c-format
 msgid "Unable to update %s: authentication was required"
 msgstr "ไม่สามารถอัปเดต %s ได้: จำเป็นต้องได้รับการพิสูจน์ตัวจริง"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1193
+#: src/gs-shell.c:1194
 #, c-format
 msgid "Unable to update %s: authentication was invalid"
 msgstr "ไม่สามารถอัปเดต %s ได้: การยืนยันตัวจริงไม่ถูกต้อง"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1200
+#: src/gs-shell.c:1201
 #, c-format
 msgid "Unable to update %s: you do not have permission to update software"
 msgstr "ไม่สามารถอัปเดต %sได้: คุณไม่ได้รับอนุญาตให้อัปเดตซอฟต์แวร์ "
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1208
+#: src/gs-shell.c:1209
 #, c-format
 msgid "Unable to update %s: AC power is required"
 msgstr "ไม่สามารถอัปเดต %s: ต้องการไฟกระแสสลับ"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1217
+#: src/gs-shell.c:1218
 #, c-format
 msgid "Unable to update %s"
 msgstr "ไม่สามารถอัปเดต %s"
@@ -2480,96 +2489,97 @@ msgstr "ไม่สามารถอัปเดต %s"
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the distro name (e.g. "Fedora 25") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1262
+#: src/gs-shell.c:1263
 #, c-format
 msgid "Unable to upgrade to %s from %s"
 msgstr "ไม่สามารถอัปเกรดเป็น %s จาก %s "
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the app name (e.g. "GIMP")
-#: src/gs-shell.c:1267
+#: src/gs-shell.c:1268
 #, c-format
 msgid "Unable to upgrade to %s as download failed"
 msgstr "ไม่สามารถอัปเกรดเป็น %s ได้เนื่องจากการดาวน์โหลดล้มเหลว"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1274
+#: src/gs-shell.c:1275
 msgid "Unable to upgrade: internet access was required but wasn’t available"
-msgstr "ไม่สามารถอัปเกรดได้: จำเป็นต้องมีการเข้าถึงอินเทอร์เน็ต แต่อินเทอร์เน็ตไม่สามารถใช้งานได้"
+msgstr ""
+"ไม่สามารถอัปเกรดได้: จำเป็นต้องมีการเข้าถึงอินเทอร์เน็ต แต่อินเทอร์เน็ตไม่สามารถใช้งานได้"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1282
+#: src/gs-shell.c:1283
 #, c-format
 msgid "Unable to upgrade to %s: not enough disk space"
 msgstr "ไม่สามารถอัปเกรดเป็น %s ได้: พื้นที่ดิสก์ไม่เพียงพอ"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1291
+#: src/gs-shell.c:1292
 #, c-format
 msgid "Unable to upgrade to %s: authentication was required"
 msgstr "ไม่สามารถอัพเกรดเป็น  %s: ต้องมีการอนุญาต"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1298
+#: src/gs-shell.c:1299
 #, c-format
 msgid "Unable to upgrade to %s: authentication was invalid"
 msgstr "ไม่สามารถอัพเกรดเป็น  %s: การอนุญาตไม่ถูกต้อง"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1305
+#: src/gs-shell.c:1306
 #, c-format
 msgid "Unable to upgrade to %s: you do not have permission to upgrade"
 msgstr "ไม่สามารถอัปเกรดเป็น %s ได้: คุณไม่ได้รับอนุญาตให้อัปเกรด"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1312
+#: src/gs-shell.c:1313
 #, c-format
 msgid "Unable to upgrade to %s: AC power is required"
 msgstr "ไม่สามารถอัพเกรดเป็น %s ได้: จำเป็นต้องใช้ไฟกระแสสลับ"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1321
+#: src/gs-shell.c:1322
 #, c-format
 msgid "Unable to upgrade to %s"
 msgstr "ไม่สามารถอัพเกรดเป็น %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1363
+#: src/gs-shell.c:1364
 #, c-format
 msgid "Unable to remove %s: authentication was required"
 msgstr "ไม่สามารถลบ %s ได้: จำเป็นต้องได้รับการพิสูจน์ตัวจริง"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1369
+#: src/gs-shell.c:1370
 #, c-format
 msgid "Unable to remove %s: authentication was invalid"
 msgstr "ไม่สามารถลบ %s ได้: การยืนยันตัวจริงไม่ถูกต้อง"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1375
+#: src/gs-shell.c:1376
 #, c-format
 msgid "Unable to remove %s: you do not have permission to remove software"
 msgstr "ไม่สามารถลบ %s ได้: คุณไม่ได้รับอนุญาตให้ลบซอฟต์แวร์"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1382
+#: src/gs-shell.c:1383
 #, c-format
 msgid "Unable to remove %s: AC power is required"
 msgstr "ไม่สามารถลบ %s ออกได้: จำเป็นต้องใช้ไฟกระแสสลับ"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1391
+#: src/gs-shell.c:1392
 #, c-format
 msgid "Unable to remove %s"
 msgstr "ไม่สามารถลบ %s ได้"
@@ -2578,48 +2588,48 @@ msgstr "ไม่สามารถลบ %s ได้"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1437
+#: src/gs-shell.c:1438
 #, c-format
 msgid "Unable to launch %s: %s is not installed"
 msgstr "ไม่สามารถเปิด %s: %s ไม่ได้ถูกติดตั้ง"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1444 src/gs-shell.c:1492 src/gs-shell.c:1540
+#: src/gs-shell.c:1445 src/gs-shell.c:1493 src/gs-shell.c:1541
 msgid "Not enough disk space — free up some space and try again"
 msgstr "มีพื้นที่ดิสก์ไม่เพียงพอ  เพิ่มพื้นที่ดิสก์ก่อนทดลองอีกครั้ง"
 
 #. TRANSLATORS: we failed to get a proper error code
-#: src/gs-shell.c:1452 src/gs-shell.c:1500 src/gs-shell.c:1567
+#: src/gs-shell.c:1453 src/gs-shell.c:1501 src/gs-shell.c:1568
 msgid "Sorry, something went wrong"
 msgstr "ขออภัย บางส่ิงทำงานผิดปกติ"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1487
+#: src/gs-shell.c:1488
 msgid "Failed to install file: authentication failed"
 msgstr "ติดตั้งไฟล์ล้มเหลว: การพิสูจน์ตัวจริงล้มเหลว"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1534
+#: src/gs-shell.c:1535
 #, c-format
 msgid "Unable to contact %s"
 msgstr "ไม่สามารถติดต่อ %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1549
+#: src/gs-shell.c:1550
 #, c-format
 msgid "%s needs to be restarted to use new plugins."
 msgstr "จำเป็นต้องรีสตาร์ต %s เพื่อใช้งานปลั๊กอินใหม่"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1554
+#: src/gs-shell.c:1555
 msgid "This application needs to be restarted to use new plugins."
 msgstr "จำเป็นต้องรีสตาร์ตแอปพลิเคชั่นนี้เพื่อช้งานปลั๊กอินใหม่"
 
 #. TRANSLATORS: need to be connected to the AC power
-#: src/gs-shell.c:1561
+#: src/gs-shell.c:1562
 msgid "AC power is required"
 msgstr "จำเป็นต้องใช้ไฟกระแสสลับ"
 
@@ -2701,7 +2711,9 @@ msgstr "ระบบปฏิบัติการ"
 msgid ""
 "Software sources can be downloaded from the internet. They give you access "
 "to additional software that is not provided by %s."
-msgstr "แหล่งซอฟต์แวร์สามารถดาวน์โหลดได้จากอินเทอร์เน็ต ซึ่งช่วยให้คุณเข้าถึงซอฟต์แวร์เพิ่มเติมที่ไม่ได้จัดเตรียมไว้โดย %s"
+msgstr ""
+"แหล่งซอฟต์แวร์สามารถดาวน์โหลดได้จากอินเทอร์เน็ต "
+"ซึ่งช่วยให้คุณเข้าถึงซอฟต์แวร์เพิ่มเติมที่ไม่ได้จัดเตรียมไว้โดย %s"
 
 #: src/gs-sources-dialog.ui:155
 msgid "Additional Sources"
@@ -2906,16 +2918,20 @@ msgstr "การปรับรุ่นถูกยกเลิก"
 #. * something with no network available
 #: src/gs-update-monitor.c:714
 msgid ""
-"Internet access was required but wasn’t available. Please make sure that you"
-" have internet access and try again."
-msgstr "ต้องใช้การเชื่อมต่ออินเทอร์เน็ต แต่ไม่สามารถใช้ได้ กรุณาตรวจสอบให้แน่ใจว่าคุณมีการเข้าถึงอินเทอร์เน็ตแล้วลองใหม่"
+"Internet access was required but wasn’t available. Please make sure that you "
+"have internet access and try again."
+msgstr ""
+"ต้องใช้การเชื่อมต่ออินเทอร์เน็ต แต่ไม่สามารถใช้ได้ "
+"กรุณาตรวจสอบให้แน่ใจว่าคุณมีการเข้าถึงอินเทอร์เน็ตแล้วลองใหม่"
 
 #. TRANSLATORS: if the package is not signed correctly
 #: src/gs-update-monitor.c:720
 msgid ""
 "There were security issues with the update. Please consult your software "
 "provider for more details."
-msgstr "มีปัญหาด้านความปลอดภัยในแพกเกจปรับรุ่น กรุณาสอบถามรายละเอียดเพิ่มเติมจากผู้ให้บริการซอฟต์แวร์ของคุณ"
+msgstr ""
+"มีปัญหาด้านความปลอดภัยในแพกเกจปรับรุ่น "
+"กรุณาสอบถามรายละเอียดเพิ่มเติมจากผู้ให้บริการซอฟต์แวร์ของคุณ"
 
 #. TRANSLATORS: we ran out of disk space
 #: src/gs-update-monitor.c:726
@@ -2928,7 +2944,9 @@ msgstr "เนื้อที่ว่างในดิสก์ไม่เพ
 msgid ""
 "We’re sorry: the update failed to install. Please wait for another update "
 "and try again. If the problem persists, contact your software provider."
-msgstr "ขออภัย: ติดตั้งแพกเกจปรับรุ่นไม่สำเร็จ กรุณารอการปรับรุ่นครั้งถัดไปแล้วลองใหม่ ถ้าปัญหายังคงอยู่ กรุณาติดต่อผู้ให้บริการซอฟต์แวร์ของคุณ"
+msgstr ""
+"ขออภัย: ติดตั้งแพกเกจปรับรุ่นไม่สำเร็จ กรุณารอการปรับรุ่นครั้งถัดไปแล้วลองใหม่ ถ้าปัญหายังคงอยู่ "
+"กรุณาติดต่อผู้ให้บริการซอฟต์แวร์ของคุณ"
 
 #. TRANSLATORS: Time in 24h format
 #: src/gs-updates-page.c:297
@@ -3212,22 +3230,26 @@ msgid "App Center"
 msgstr "แอพเซ็นเตอร์"
 
 #: src/org.gnome.Software.desktop.in:4
+msgid "More Apps"
+msgstr "แอพเพิ่มเติม"
+
+#: src/org.gnome.Software.desktop.in:5
 msgid "Add, remove or update software on this computer"
 msgstr "เพิ่ม ลบ หรือปรับรุ่นซอฟต์แวร์ในคอมพิวเตอร์นี้"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
-#: src/org.gnome.Software.desktop.in:6
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: src/org.gnome.Software.desktop.in:7
 #: src/org.gnome.Software.Editor.desktop.in:6
 msgid "org.gnome.Software"
 msgstr "org.gnome.Software"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
-#: src/org.gnome.Software.desktop.in:12
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: src/org.gnome.Software.desktop.in:13
 msgid ""
-"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;"
-msgstr "ปรับรุ่น;แหล่งซอฟต์แวร์;คลังแพกเกจ;ปรับแต่ง;ติดตั้ง;ถอดถอน;โปรแกรม;ซอฟต์แวร์;แอ็ป;ร้าน;"
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;"
+msgstr ""
+"ปรับรุ่น;แหล่งซอฟต์แวร์;คลังแพกเกจ;ปรับแต่ง;ติดตั้ง;ถอดถอน;โปรแกรม;ซอฟต์แวร์;แอ็ป;ร้าน;"
 
 #: src/org.gnome.Software.Editor.desktop.in:3
 msgid "Banner Designer"
@@ -3237,8 +3259,7 @@ msgstr "ผู้ออกแบบแบนเนอร์"
 msgid "Design the featured banners for GNOME Software"
 msgstr "ดีไซน์แบนเนอร์แนะนำจาก GNOME Software"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: src/org.gnome.Software.Editor.desktop.in:13
 msgid "AppStream;Software;App;"
 msgstr "แอปสตรีม;ซอฟต์แวร์;แอป;"
@@ -3508,100 +3529,111 @@ msgctxt "Menu of Communication & News"
 msgid "Web Browsers"
 msgstr "เว็บเบราว์เซอร์"
 
-#: plugins/core/gs-desktop-common.c:247
-msgctxt "Menu of Reference"
-msgid "All"
-msgstr "ทั้งหมด"
-
-#: plugins/core/gs-desktop-common.c:250
-msgctxt "Menu of Reference"
-msgid "Featured"
-msgstr "ที่แนะนำ"
-
-#: plugins/core/gs-desktop-common.c:253
-msgctxt "Menu of Reference"
-msgid "Art"
-msgstr "ศิลปะ"
-
-#: plugins/core/gs-desktop-common.c:256
-msgctxt "Menu of Reference"
-msgid "Biography"
-msgstr "ชีวประวัติ"
-
-#: plugins/core/gs-desktop-common.c:259
-msgctxt "Menu of Reference"
-msgid "Comics"
-msgstr "การ์ตูน"
-
-#: plugins/core/gs-desktop-common.c:262
-msgctxt "Menu of Reference"
-msgid "Fiction"
-msgstr "นิยาย"
-
-#: plugins/core/gs-desktop-common.c:265
-msgctxt "Menu of Reference"
-msgid "Health"
-msgstr "สุขภาพ"
-
-#: plugins/core/gs-desktop-common.c:268
-msgctxt "Menu of Reference"
-msgid "History"
-msgstr "ประวัติ"
-
-#: plugins/core/gs-desktop-common.c:271
-msgctxt "Menu of Reference"
-msgid "Lifestyle"
-msgstr "ไลฟ์สไตล์"
-
-#: plugins/core/gs-desktop-common.c:274
+#: plugins/core/gs-desktop-common.c:242
 msgctxt "Menu of Communication & News"
 msgid "News"
 msgstr "ข่าว"
 
+#: plugins/core/gs-desktop-common.c:251
+msgctxt "Menu of Reference"
+msgid "All"
+msgstr "ทั้งหมด"
+
+#: plugins/core/gs-desktop-common.c:254
+msgctxt "Menu of Reference"
+msgid "Featured"
+msgstr "ที่แนะนำ"
+
+#: plugins/core/gs-desktop-common.c:257
+msgctxt "Menu of Reference"
+msgid "Art"
+msgstr "ศิลปะ"
+
+#: plugins/core/gs-desktop-common.c:260
+msgctxt "Menu of Reference"
+msgid "Biography"
+msgstr "ชีวประวัติ"
+
+#: plugins/core/gs-desktop-common.c:263
+msgctxt "Menu of Reference"
+msgid "Comics"
+msgstr "การ์ตูน"
+
+#: plugins/core/gs-desktop-common.c:266
+msgctxt "Menu of Reference"
+msgid "Feed"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:269
+msgctxt "Menu of Reference"
+msgid "Fiction"
+msgstr "นิยาย"
+
+#: plugins/core/gs-desktop-common.c:272
+msgctxt "Menu of Reference"
+msgid "Health"
+msgstr "สุขภาพ"
+
+#: plugins/core/gs-desktop-common.c:275
+msgctxt "Menu of Reference"
+msgid "History"
+msgstr "ประวัติ"
+
 #: plugins/core/gs-desktop-common.c:278
+msgctxt "Menu of Reference"
+msgid "Lifestyle"
+msgstr "ไลฟ์สไตล์"
+
+#: plugins/core/gs-desktop-common.c:281
+#, fuzzy
+msgctxt "Menu of Reference"
+msgid "News"
+msgstr "ข่าว"
+
+#: plugins/core/gs-desktop-common.c:284
 msgctxt "Menu of Reference"
 msgid "Politics"
 msgstr "การเมือง"
 
-#: plugins/core/gs-desktop-common.c:281
+#: plugins/core/gs-desktop-common.c:287
 msgctxt "Menu of Reference"
 msgid "Sports"
 msgstr "กีฬา"
 
 #. TRANSLATORS: this is the menu spec main category for Learning
-#: plugins/core/gs-desktop-common.c:291
+#: plugins/core/gs-desktop-common.c:297
 msgid "Learning"
 msgstr "การเรียนรู้"
 
 #. TRANSLATORS: this is the menu spec main category for Game
-#: plugins/core/gs-desktop-common.c:294
+#: plugins/core/gs-desktop-common.c:300
 msgid "Games"
 msgstr "เกม"
 
 #. TRANSLATORS: this is the menu spec main category for Multimedia
-#: plugins/core/gs-desktop-common.c:297
+#: plugins/core/gs-desktop-common.c:303
 msgid "Multimedia"
 msgstr "มัลติมีเดีย"
 
 #. TRANSLATORS: this is the menu spec main category for Work
-#: plugins/core/gs-desktop-common.c:300
+#: plugins/core/gs-desktop-common.c:306
 msgid "Work"
 msgstr "งาน"
 
 #. TRANSLATORS: this is the menu spec main category for Reference
-#: plugins/core/gs-desktop-common.c:303
+#: plugins/core/gs-desktop-common.c:309
 msgid "Reference & News"
 msgstr "ข้อมูลอ้างอิง & ข่าว"
 
 #. TRANSLATORS: this is the menu spec main category for Utilities
-#: plugins/core/gs-desktop-common.c:306
+#: plugins/core/gs-desktop-common.c:312
 msgid "Utilities"
 msgstr "อรรถประโยชน์"
 
 #. TRANSLATORS: this is the menu spec main category for Dev Tools; it
 #. * should be a relatively short label; as an example, in Portuguese and
 #. * Spanish the direct translation of "Programming" (noun) is used
-#: plugins/core/gs-desktop-common.c:311
+#: plugins/core/gs-desktop-common.c:317
 msgid "Dev Tools"
 msgstr "เครื่องมือพัฒนา"
 
@@ -3627,16 +3659,16 @@ msgstr "มีการปรับปรุงประสิทธิภาพ
 msgid "Downloading featured images…"
 msgstr "กำลังดาวน์โหลดภาพแนะนำ..."
 
-#: plugins/eos/gs-plugin-eos.c:1249
+#: plugins/eos/gs-plugin-eos.c:1233
 #, c-format
 msgid "Could not launch this application."
 msgstr "ไม่สามารถเริ่มแอพพลิเคชันนี้ได้"
 
-#: plugins/eos/gs-plugin-eos.c:1305
+#: plugins/eos/gs-plugin-eos.c:1289
 msgid "Endless Platform"
 msgstr "แพลตฟอร์ม Endless"
 
-#: plugins/eos/gs-plugin-eos.c:1308
+#: plugins/eos/gs-plugin-eos.c:1292
 msgid "Framework for applications"
 msgstr "เฟรมเวิร์กสำหรับแอปพลิเคชั่น"
 
@@ -3696,13 +3728,13 @@ msgid "Flatpak is a framework for desktop applications on Linux"
 msgstr "Flatpak คือเฟรมเวิร์กสำหรับแอปพลิเคชั่นบนเดสก์ท็อปบน Linux"
 
 #. TRANSLATORS: status text when downloading new metadata
-#: plugins/flatpak/gs-flatpak.c:821
+#: plugins/flatpak/gs-flatpak.c:815
 #, c-format
 msgid "Getting flatpak metadata for %s…"
 msgstr "กำลังดึงเมตาดาตา flatpak สำหรับ %s…"
 
 #. TRANSLATORS: status text when downloading the RuntimeRepo
-#: plugins/flatpak/gs-flatpak.c:2796
+#: plugins/flatpak/gs-flatpak.c:2803
 msgid "Getting runtime source…"
 msgstr "รับแหล่งข้อมูลเวลาทำงาน..."
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the gnome-software package.
-# 
+#
 # Translators:
 # Emin Tufan <etcetin@gmail.com>, 2017
 # Gökhan Gurbetoğlu <ggurbet@gmail.com>, 2014
@@ -13,14 +13,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-software\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-12 22:31-0700\n"
+"POT-Creation-Date: 2017-11-02 16:28+0100\n"
 "PO-Revision-Date: 2017-10-13 05:52+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
-"Language-Team: Turkish (http://www.transifex.com/endless-mobile-inc/gnome-software/language/tr/)\n"
+"Language-Team: Turkish (http://www.transifex.com/endless-mobile-inc/gnome-"
+"software/language/tr/)\n"
+"Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: tr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:7
@@ -35,7 +36,9 @@ msgstr "GNOME için uygulama yöneticisi"
 msgid ""
 "Software allows you to find and install new applications and system "
 "extensions and remove existing installed applications."
-msgstr "Yazılımlar uygulaması, yeni uygulamalar ve sistem uzantılarını bulup kurmanıza ve halihazırda kurulu olan uygulamaları kaldırmanıza olanak tanır."
+msgstr ""
+"Yazılımlar uygulaması, yeni uygulamalar ve sistem uzantılarını bulup "
+"kurmanıza ve halihazırda kurulu olan uygulamaları kaldırmanıza olanak tanır."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:14
 msgid ""
@@ -43,7 +46,12 @@ msgid ""
 "descriptions and multiple screenshots per application. Applications can be "
 "found either through browsing the list of categories or by searching. It "
 "also allows you to update your system using an offline update."
-msgstr "GNOME Yazılımlar; seçkin ve popüler uygulamaları, her uygulama için kullanışlı bir açıklama ve çoklu ekran görüntüleri ile birlikte beğeninize sunar. Uygulamalar, kategori listesinde gezinerek ya da arama yoluyla bulunabilir. Ayrıca çevrim dışı bir güncellemeyi kullanarak sisteminizi güncellemenize olanak tanır."
+msgstr ""
+"GNOME Yazılımlar; seçkin ve popüler uygulamaları, her uygulama için "
+"kullanışlı bir açıklama ve çoklu ekran görüntüleri ile birlikte beğeninize "
+"sunar. Uygulamalar, kategori listesinde gezinerek ya da arama yoluyla "
+"bulunabilir. Ayrıca çevrim dışı bir güncellemeyi kullanarak sisteminizi "
+"güncellemenize olanak tanır."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:25
 msgid "Overview panel"
@@ -77,7 +85,9 @@ msgstr "Uyumlu projeler listesi"
 msgid ""
 "This is a list of compatible projects we should show such as GNOME, KDE and "
 "XFCE."
-msgstr "Bu; GNOME, KDE ve XFCE gibi, göstermemiz gereken uyumlu projelerin listesidir."
+msgstr ""
+"Bu; GNOME, KDE ve XFCE gibi, göstermemiz gereken uyumlu projelerin "
+"listesidir."
 
 #: data/org.gnome.software.gschema.xml:10
 msgid "Whether to manage updates in GNOME Software"
@@ -87,7 +97,9 @@ msgstr "GNOME Yazılımlar’da güncellemelerin yönetilmesi"
 msgid ""
 "If disabled, GNOME Software will hide the updates panel and not perform any "
 "automatic updates actions."
-msgstr "Eğer devre dışıysa, GNOME Yazılımlar güncellemeler bölmesini gizleyecek ve herhangi bir kendiliğinden güncelleme eylemi gerçekleştirmeyecek."
+msgstr ""
+"Eğer devre dışıysa, GNOME Yazılımlar güncellemeler bölmesini gizleyecek ve "
+"herhangi bir kendiliğinden güncelleme eylemi gerçekleştirmeyecek."
 
 #: data/org.gnome.software.gschema.xml:15
 msgid "Whether to automatically download updates"
@@ -95,9 +107,11 @@ msgstr "Güncellemelerin kendiliğinden indirilmesi"
 
 #: data/org.gnome.software.gschema.xml:16
 msgid ""
-"If enabled, GNOME Software automatically downloads updates in the background"
-" and prompts the user to install them when ready."
-msgstr "Eğer etkinleştirilirse, GNOME Yazılımlar güncellemeleri kendiliğinden arka planda indirir ve hazır olduğunda kurulması için kullanıcıya haber verir."
+"If enabled, GNOME Software automatically downloads updates in the background "
+"and prompts the user to install them when ready."
+msgstr ""
+"Eğer etkinleştirilirse, GNOME Yazılımlar güncellemeleri kendiliğinden arka "
+"planda indirir ve hazır olduğunda kurulması için kullanıcıya haber verir."
 
 #: data/org.gnome.software.gschema.xml:20
 msgid "Whether to automatically refresh when on a metered connection"
@@ -108,7 +122,10 @@ msgid ""
 "If enabled, GNOME Software automatically refreshes in the background even "
 "when using a metered connection (eventually downloading some metadata, "
 "checking for updates, etc., which may incur in costs for the user)."
-msgstr "Eğer etkinse, GNOME Yazılımlar ölçülü bağlantı kullanımı da dahil olmak üzere arkaplanda kendini yenileyecek (kullanıcı için ücrete neden olsa da sonunda bazı üstverileri indirecek, güncellemeleri denetleyecek vb.)"
+msgstr ""
+"Eğer etkinse, GNOME Yazılımlar ölçülü bağlantı kullanımı da dahil olmak "
+"üzere arkaplanda kendini yenileyecek (kullanıcı için ücrete neden olsa da "
+"sonunda bazı üstverileri indirecek, güncellemeleri denetleyecek vb.)"
 
 #: data/org.gnome.software.gschema.xml:25
 msgid "Whether it’s the very first run of GNOME Software"
@@ -128,9 +145,11 @@ msgstr "Özgür olmayan uygulamalar kurulmadan önce bir uyarı penceresi göste
 
 #: data/org.gnome.software.gschema.xml:38
 msgid ""
-"When non-free applications are installed a warning dialog can be shown. This"
-" controls if that dialog is suppressed."
-msgstr "Özgür olmayan uygulamalar kurulduğunda, bir uyarı penceresi gösterilebilir. Bu, o iletişim penceresinin baskılanıp baskılanmayacağını denetler."
+"When non-free applications are installed a warning dialog can be shown. This "
+"controls if that dialog is suppressed."
+msgstr ""
+"Özgür olmayan uygulamalar kurulduğunda, bir uyarı penceresi gösterilebilir. "
+"Bu, o iletişim penceresinin baskılanıp baskılanmayacağını denetler."
 
 #: data/org.gnome.software.gschema.xml:42
 msgid "A list of popular applications"
@@ -138,7 +157,9 @@ msgstr "Popüler uygulamalar listesi"
 
 #: data/org.gnome.software.gschema.xml:43
 msgid "A list of applications to use, overriding the system defined ones."
-msgstr "Sistem tarafından tanımlananları geçersiz kılan, kullanılacak uygulamalar listesi."
+msgstr ""
+"Sistem tarafından tanımlananları geçersiz kılan, kullanılacak uygulamalar "
+"listesi."
 
 #: data/org.gnome.software.gschema.xml:47
 msgid "The list of extra sources that have been previously enabled"
@@ -148,7 +169,9 @@ msgstr "Önceden etkinleştirilmiş olan ek kaynakların listesi"
 msgid ""
 "The list of sources that have been previously enabled when installing third-"
 "party applications."
-msgstr "Üçüncü taraf uygulamalar kurulurken önceden etkinleştirilmiş olan kaynakların listesi."
+msgstr ""
+"Üçüncü taraf uygulamalar kurulurken önceden etkinleştirilmiş olan "
+"kaynakların listesi."
 
 #: data/org.gnome.software.gschema.xml:52
 msgid "The last update check timestamp"
@@ -160,7 +183,8 @@ msgstr "Son yükseltme bildirimi zaman damgası"
 
 #: data/org.gnome.software.gschema.xml:60
 msgid "The timestamp of the first security update, cleared after update"
-msgstr "Güncellemeden sonra temizlenmiş ilk güvenlik güncellemesinin zaman damgası"
+msgstr ""
+"Güncellemeden sonra temizlenmiş ilk güvenlik güncellemesinin zaman damgası"
 
 #: data/org.gnome.software.gschema.xml:64
 msgid "The last update timestamp"
@@ -168,14 +192,19 @@ msgstr "Son güncelleme zaman damgası"
 
 #: data/org.gnome.software.gschema.xml:68
 msgid "The age in seconds to verify the upstream screenshot is still valid"
-msgstr "Kaynak ekran görüntüsünü doğrulamak için saniye türünden yaş hala geçerlidir"
+msgstr ""
+"Kaynak ekran görüntüsünü doğrulamak için saniye türünden yaş hala geçerlidir"
 
 #: data/org.gnome.software.gschema.xml:69
 msgid ""
 "Choosing a larger value will mean less round-trips to the remote server but "
-"updates to the screenshots may take longer to show to the user. A value of 0"
-" means to never check the server if the image already exists in the cache."
-msgstr "Daha büyük sayılar seçmek uzak sunucuya giden tur sayısını azaltır ama ekran görüntülerindeki güncellemeleri kullanıcının görmesi daha uzun sürebilir. Değeri 0 seçmek eğer görüntü zaten önbellekteyse sunucunun hiçbir zaman denetlenmeyeceği anlamına gelir."
+"updates to the screenshots may take longer to show to the user. A value of 0 "
+"means to never check the server if the image already exists in the cache."
+msgstr ""
+"Daha büyük sayılar seçmek uzak sunucuya giden tur sayısını azaltır ama ekran "
+"görüntülerindeki güncellemeleri kullanıcının görmesi daha uzun sürebilir. "
+"Değeri 0 seçmek eğer görüntü zaten önbellekteyse sunucunun hiçbir zaman "
+"denetlenmeyeceği anlamına gelir."
 
 #: data/org.gnome.software.gschema.xml:78
 msgid "The server to use for application reviews"
@@ -199,14 +228,14 @@ msgstr "Özgür yazılımı dikkate alan resmi kaynakların listesi"
 
 #: data/org.gnome.software.gschema.xml:95
 msgid ""
-"The licence URL to use when an application should be considered free "
-"software"
-msgstr "Bir uygulama özgür yazılım olarak anıldığında kullanılacak lisans adresi"
+"The licence URL to use when an application should be considered free software"
+msgstr ""
+"Bir uygulama özgür yazılım olarak anıldığında kullanılacak lisans adresi"
 
 #: data/org.gnome.software.gschema.xml:99
-msgid ""
-"Install bundled applications for all users on the system where possible"
-msgstr "Mümkün olduğunda yığın uygulamaları sistemdeki tüm kullanıcılar için yükle"
+msgid "Install bundled applications for all users on the system where possible"
+msgstr ""
+"Mümkün olduğunda yığın uygulamaları sistemdeki tüm kullanıcılar için yükle"
 
 #: data/org.gnome.software.gschema.xml:103
 msgid "Show the folder management UI"
@@ -242,17 +271,21 @@ msgstr "Özgür olmayan ve sahipli yazılımı açıklayan URI"
 
 #: data/org.gnome.software.gschema.xml:135
 msgid "A list of non-free sources that can be optionally enabled"
-msgstr "İsteğe bağlı olarak etkinleştirilebilecek özgür olmayan kaynakların listesi"
+msgstr ""
+"İsteğe bağlı olarak etkinleştirilebilecek özgür olmayan kaynakların listesi"
 
 #: data/org.gnome.software.gschema.xml:139
 msgid ""
 "A list of URLs pointing to appstream files that will be downloaded into an "
 "app-info folder"
-msgstr "Uygulama-bilgisi klasörüne indirilecek appstream dosyalarına işaret eden URL’lerin listesi"
+msgstr ""
+"Uygulama-bilgisi klasörüne indirilecek appstream dosyalarına işaret eden "
+"URL’lerin listesi"
 
 #: data/org.gnome.software.gschema.xml:143
 msgid "Install the AppStream files to a system-wide location for all users"
-msgstr "AppStream dosyalarını tüm kullanıcılar için sistem geneli bir konuma kur"
+msgstr ""
+"AppStream dosyalarını tüm kullanıcılar için sistem geneli bir konuma kur"
 
 #: data/org.gnome.software.gschema.xml:147
 msgid "Sorts the apps shown in the overview in alphabetical order"
@@ -272,8 +305,7 @@ msgstr "Yazılım Kur"
 msgid "Install selected software on the system"
 msgstr "Seçili yazılımı sisteme kur"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 #: src/gnome-software-local-file.desktop.in:10
 msgid "system-software-install"
 msgstr "system-software-install"
@@ -300,14 +332,12 @@ msgstr "Geri git"
 msgid "_All"
 msgstr "_Tümü"
 
-#. Translators: A label for a button to show only software which is already
-#. installed.
+#. Translators: A label for a button to show only software which is already installed.
 #: src/gnome-software.ui:104
 msgid "_Installed"
 msgstr "_Kuruldu"
 
-#. Translators: A label for a button to show only updates which are available
-#. to install.
+#. Translators: A label for a button to show only updates which are available to install.
 #: src/gnome-software.ui:155
 msgid "_Updates"
 msgstr "_Güncellemeler"
@@ -355,7 +385,7 @@ msgstr "Kuruldu"
 
 #. TRANSLATORS: this is a button next to the search results that
 #. * shows the status of an application being installed
-#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:443
+#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:439
 msgid "Installing"
 msgstr "Kuruluyor"
 
@@ -370,7 +400,7 @@ msgid "Folder Name"
 msgstr "Klasör Adı"
 
 #: src/gs-app-folder-dialog.c:321 src/gs-app-folder-dialog.ui:16
-#: src/gs-details-page.c:383 src/gs-details-page.ui:342 src/gs-editor.c:623
+#: src/gs-details-page.c:379 src/gs-details-page.ui:342 src/gs-editor.c:623
 #: src/gs-editor.c:655 src/gs-installed-page.c:609 src/gs-removal-dialog.ui:33
 #: src/gs-review-dialog.ui:23 src/gs-upgrade-banner.ui:131
 msgid "_Cancel"
@@ -385,90 +415,95 @@ msgid "Add to Application Folder"
 msgstr "Uygulama Klasörüne Ekle"
 
 #. TRANSLATORS: this is a command line option
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "Start up mode: either ‘updates’, ‘updated’, ‘installed’ or ‘overview’"
-msgstr "Başlangıç kipi: ‘updates’ (güncellemeler), ‘updated’ (güncellendi), ‘installed’ (kuruldu) ya da ‘overview’ (genel görünüm)"
+msgstr ""
+"Başlangıç kipi: ‘updates’ (güncellemeler), ‘updated’ (güncellendi), "
+"‘installed’ (kuruldu) ya da ‘overview’ (genel görünüm)"
 
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "MODE"
 msgstr "KİP"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "Search for applications"
 msgstr "Uygulamalarda ara"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "SEARCH"
 msgstr "ARA"
 
-#: src/gs-application.c:105
+#: src/gs-application.c:133
 msgid "Show application details (using application ID)"
 msgstr "Uygulama ayrıntılarını göster (uygulama kimliğini kullanarak)"
 
-#: src/gs-application.c:105 src/gs-application.c:109
+#: src/gs-application.c:133 src/gs-application.c:137
 msgid "ID"
 msgstr "Kimlik"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "Show application details (using package name)"
 msgstr "Uygulama ayrıntılarını göster (paket adını kullanarak)"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "PKGNAME"
 msgstr "PKTADI"
 
-#: src/gs-application.c:109
+#: src/gs-application.c:137
 msgid "Install the application (using application ID)"
 msgstr "Uygulama yükle (uygulama kimliğini kullanarak)"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "Open a local package file"
 msgstr "Yerel paket dosyası aç"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "FILENAME"
 msgstr "DOSYAADI"
 
-#: src/gs-application.c:113
+#: src/gs-application.c:141
 msgid ""
 "The kind of interaction expected for this action: either ‘none’, ‘notify’, "
 "or ‘full’"
-msgstr "Bu eylem için beklenen etkileşim türü: ‘hiçbiri’, ‘bildir’, veya ‘dolu’"
+msgstr ""
+"Bu eylem için beklenen etkileşim türü: ‘hiçbiri’, ‘bildir’, veya ‘dolu’"
 
-#: src/gs-application.c:116
+#: src/gs-application.c:144
 msgid "Show verbose debugging information"
 msgstr "Ayrıntılı hata ayıklama bilgilerini göster"
 
-#: src/gs-application.c:118
+#: src/gs-application.c:146
 msgid "Show profiling information for the service"
 msgstr "Hizmetin profil oluşturma bilgilerini göster"
 
-#: src/gs-application.c:120
+#: src/gs-application.c:148
 msgid "Quit the running instance"
 msgstr "Çalışan oluşumdan çık"
 
-#: src/gs-application.c:122
+#: src/gs-application.c:150
 msgid "Prefer local file sources to AppStream"
 msgstr "AppStream yerine yerel dosya kaynaklarını tercih et."
 
-#: src/gs-application.c:124
+#: src/gs-application.c:152
 msgid "Show version number"
 msgstr "Sürüm numarasını göster"
 
-#: src/gs-application.c:325
+#: src/gs-application.c:358
 msgid "translator-credits"
-msgstr "Muhammet Kara <muhammetk@gmail.com>\nEmin Tufan Çetin <etcetin@gmail.com>"
+msgstr ""
+"Muhammet Kara <muhammetk@gmail.com>\n"
+"Emin Tufan Çetin <etcetin@gmail.com>"
 
 #. TRANSLATORS: this is the title of the about window, e.g.
 #. * 'About Software' or 'About Application Installer' where the %s is
 #. * the application name chosen by the distro
-#: src/gs-application.c:332
+#: src/gs-application.c:365
 #, c-format
 msgid "About %s"
 msgstr "%s Hakkında"
 
 #. TRANSLATORS: well, we seem to think so, anyway
-#: src/gs-application.c:336
+#: src/gs-application.c:369
 msgid "A nice way to manage the software on your system."
 msgstr "Sisteminizdeki yazılımları yönetmenin güzel bir yolu."
 
@@ -583,7 +618,7 @@ msgid "All"
 msgstr "Tümü"
 
 #. TRANSLATORS: this is a subcategory of featured apps
-#: lib/gs-category.c:202 src/gs-shell.c:2180
+#: lib/gs-category.c:202 src/gs-shell.c:2181
 msgid "Featured"
 msgstr "Vitrin"
 
@@ -593,9 +628,11 @@ msgstr "Uzantı Ayarları"
 
 #: src/gs-category-page.ui:110
 msgid ""
-"Extensions are used at your own risk. If you have any system problems, it is"
-" recommended to disable them."
-msgstr "Uzantıları kullanırken tüm sorumluluk size aittir. Eğer herhangi bir sistem sorunu yaşarsanız, bunları devre dışı bırakmanız önerilir."
+"Extensions are used at your own risk. If you have any system problems, it is "
+"recommended to disable them."
+msgstr ""
+"Uzantıları kullanırken tüm sorumluluk size aittir. Eğer herhangi bir sistem "
+"sorunu yaşarsanız, bunları devre dışı bırakmanız önerilir."
 
 #. TRANSLATORS: the user isn't reading the question
 #: lib/gs-cmd.c:205
@@ -651,13 +688,16 @@ msgstr "Üçüncü Taraf Yazılım Kaynakları Etkinleştirilsin mi?"
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
 #. * 2. Software source name, e.g. fedora-optional
+#.
 #: src/gs-common.c:232
 #, c-format
 msgid ""
 "%s is not <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
-"source_software\">free and open source software</a>, and is provided by "
-"“%s”."
-msgstr "%s, <a href=\"https://tr.wikipedia.org/wiki/Özgür_ve_açık_kaynak_kodlu_yazılım\">özgür ve açık kaynak kodlu yazılım</a> değildir; ve “%s” tarafından sunulur."
+"source_software\">free and open source software</a>, and is provided by “%s”."
+msgstr ""
+"%s, <a href=\"https://tr.wikipedia.org/wiki/"
+"Özgür_ve_açık_kaynak_kodlu_yazılım\">özgür ve açık kaynak kodlu yazılım</a> "
+"değildir; ve “%s” tarafından sunulur."
 
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
@@ -676,12 +716,14 @@ msgstr "Kuruluma devam etmek için bu yazılım kaynağı etkinleştirilmelidir.
 #: src/gs-common.c:262
 #, c-format
 msgid "It may be illegal to install or use %s in some countries."
-msgstr "%s yazılımını kurmak ya da kullanmak, bazı ülkelerde yasa dışı olabilir."
+msgstr ""
+"%s yazılımını kurmak ya da kullanmak, bazı ülkelerde yasa dışı olabilir."
 
 #. TRANSLATORS: Laws are geographical, urgh...
 #: src/gs-common.c:268
 msgid "It may be illegal to install or use this codec in some countries."
-msgstr "Bu kod çözücüyü kurmak ya da kullanmak, bazı ülkelerde yasa dışı olabilir."
+msgstr ""
+"Bu kod çözücüyü kurmak ya da kullanmak, bazı ülkelerde yasa dışı olabilir."
 
 #. TRANSLATORS: this is button text to not ask about non-free content again
 #: src/gs-common.c:275
@@ -732,12 +774,14 @@ msgstr "Fantezi şiddeti yok"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:90
 msgid "Characters in unsafe situations easily distinguishable from reality"
-msgstr "Güvensiz durumlardaki karakterler gerçeklikten kolayca ayırt edilebilir"
+msgstr ""
+"Güvensiz durumlardaki karakterler gerçeklikten kolayca ayırt edilebilir"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:93
 msgid "Characters in aggressive conflict easily distinguishable from reality"
-msgstr "Agresif çatışma içindeki karakterler gerçeklikten kolayca ayırt edilebilir"
+msgstr ""
+"Agresif çatışma içindeki karakterler gerçeklikten kolayca ayırt edilebilir"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:96
@@ -957,7 +1001,8 @@ msgstr "Herhangi biçimde kumar yok"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:225
 msgid "Gambling on random events using tokens or credits"
-msgstr "Belirteç veya kontör kullanarak rastlantısal etkinlikler üzerinde kumar"
+msgstr ""
+"Belirteç veya kontör kullanarak rastlantısal etkinlikler üzerinde kumar"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:228
@@ -992,7 +1037,8 @@ msgstr "Oyuncudan oyuncuya konuşma işlevi olmadan oyun etkileşimleri"
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:246
 msgid "Player-to-player preset interactions without chat functionality"
-msgstr "Oyuncudan oyuncuya konuşma işlevi olmadan önceden ayarlanmış etkileşimler"
+msgstr ""
+"Oyuncudan oyuncuya konuşma işlevi olmadan önceden ayarlanmış etkileşimler"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:249
@@ -1039,14 +1085,12 @@ msgstr "Fiziksel konumun diğer kullanıcılara paylaşımı yok"
 msgid "Sharing physical location to other users"
 msgstr "Diğer kullanıcılara fiziksel konumu paylaşır"
 
-#. TRANSLATORS: this is a what we use in notifications if the app's name is
-#. unknown
+#. TRANSLATORS: this is a what we use in notifications if the app's name is unknown
 #: src/gs-dbus-helper.c:294
 msgid "An application"
 msgstr "Bir uygulama"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. MIME types.
+#. TRANSLATORS: this is a notification displayed when an app needs additional MIME types.
 #: src/gs-dbus-helper.c:300
 #, c-format
 msgid "%s is requesting additional file format support."
@@ -1057,8 +1101,7 @@ msgstr "%s, ek dosya biçimi desteği talep ediyor."
 msgid "Additional MIME Types Required"
 msgstr "Ek MIME (Dosya) Türleri Gerekli"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. fonts.
+#. TRANSLATORS: this is a notification displayed when an app needs additional fonts.
 #: src/gs-dbus-helper.c:306
 #, c-format
 msgid "%s is requesting additional fonts."
@@ -1069,8 +1112,7 @@ msgstr "%s, ek yazı tipleri talep ediyor."
 msgid "Additional Fonts Required"
 msgstr "Ek Yazı Tipleri Gerekli"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. codecs.
+#. TRANSLATORS: this is a notification displayed when an app needs additional codecs.
 #: src/gs-dbus-helper.c:312
 #, c-format
 msgid "%s is requesting additional multimedia codecs."
@@ -1081,8 +1123,7 @@ msgstr "%s, ek çokluortam kod çözücüleri (kodek) talep ediyor."
 msgid "Additional Multimedia Codecs Required"
 msgstr "Ek Çokluortam Kod Çözücüleri Gerekli"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. printer drivers.
+#. TRANSLATORS: this is a notification displayed when an app needs additional printer drivers.
 #: src/gs-dbus-helper.c:318
 #, c-format
 msgid "%s is requesting additional printer drivers."
@@ -1093,8 +1134,7 @@ msgstr "%s, ek yazıcı sürücüleri talep ediyor."
 msgid "Additional Printer Drivers Required"
 msgstr "Ek Yazıcı Sürücüleri Gerekli"
 
-#. TRANSLATORS: this is a notification displayed when an app wants to install
-#. additional packages.
+#. TRANSLATORS: this is a notification displayed when an app wants to install additional packages.
 #: src/gs-dbus-helper.c:324
 #, c-format
 msgid "%s is requesting additional packages."
@@ -1114,14 +1154,14 @@ msgstr "Yazılımlar’da Bul"
 #. * can be installed
 #. TRANSLATORS: button text in the header when firmware
 #. * can be live-installed
-#: src/gs-details-page.c:281 src/gs-details-page.c:312
-#: src/gs-details-page.ui:206 src/gs-upgrade-banner.ui:146
+#: src/gs-details-page.c:280 src/gs-details-page.c:310
+#: src/gs-details-page.ui:237 src/gs-upgrade-banner.ui:146
 msgid "_Install"
 msgstr "_Kur"
 
 #. TRANSLATORS: button text in the header when an application
 #. * can be live-updated
-#: src/gs-details-page.c:316
+#: src/gs-details-page.c:314
 msgid "_Update"
 msgstr "_Güncelle"
 
@@ -1129,67 +1169,69 @@ msgstr "_Güncelle"
 #. * be installed.
 #. * The ellipsis indicates that further steps are required,
 #. * e.g. enabling software sources or the like
-#: src/gs-details-page.c:330
+#: src/gs-details-page.c:326
 msgid "_Install…"
 msgstr "_Kur…"
 
 #. TRANSLATORS: button text in the header when an application can be erased
-#: src/gs-details-page.c:377 src/gs-details-page.ui:547
+#: src/gs-details-page.c:373 src/gs-details-page.ui:547
 msgid "_Uninstall"
 msgstr ""
 
-#: src/gs-details-page.c:438 src/gs-sources-dialog.c:513
+#: src/gs-details-page.c:434 src/gs-sources-dialog.c:513
 msgid "Removing…"
 msgstr "Kaldırılıyor…"
 
 #. TRANSLATORS: this is the warning box
-#: src/gs-details-page.c:748
+#: src/gs-details-page.c:744
 msgid ""
 "This application can only be used when there is an active internet "
 "connection."
-msgstr "Bu uygulama, yalnızca etkin bir İnternet bağlantınız olduğunda kullanılabilir."
+msgstr ""
+"Bu uygulama, yalnızca etkin bir İnternet bağlantınız olduğunda "
+"kullanılabilir."
 
 #. TRANSLATORS: this is where the version is not known
-#: src/gs-details-page.c:892
+#: src/gs-details-page.c:888
 msgctxt "version"
 msgid "Unknown"
 msgstr "Bilinmiyor"
 
 #. TRANSLATORS: this is where we don't know the origin of the
 #. * application
-#: src/gs-details-page.c:971
+#: src/gs-details-page.c:967
 msgctxt "origin"
 msgid "Unknown"
 msgstr "Bilinmiyor"
 
 #. TRANSLATORS: we need a remote server to process
-#: src/gs-details-page.c:1378
+#: src/gs-details-page.c:1374
 msgid "You need internet access to write a review"
 msgstr "Değerlendirme yazmanız için İnternet erişimi gerekiyor"
 
-#: src/gs-details-page.c:1507
+#: src/gs-details-page.c:1503
 #, c-format
 msgid "Unable to find “%s”"
 msgstr "“%s” bulunamıyor"
 
 #. TRANSLATORS: see the wikipedia page
-#: src/gs-details-page.c:2087
+#: src/gs-details-page.c:2083
 msgid "Public domain"
 msgstr "Kamu malı"
 
 #. TRANSLATORS: see GNU page
-#: src/gs-details-page.c:2103 src/gs-details-page.ui:1397
+#: src/gs-details-page.c:2099 src/gs-details-page.ui:1397
 msgid "Free Software"
 msgstr "Özgür Yazılım"
 
 #. TRANSLATORS: for the free software popover
-#: src/gs-details-page.c:2160
+#: src/gs-details-page.c:2156
 msgid "Users are bound by the following license:"
 msgid_plural "Users are bound by the following licenses:"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/gs-details-page.c:2176 src/gs-details-page.ui:1506
+#: src/gs-details-page.c:2172 src/gs-details-page.ui:1506
 msgid "More information"
 msgstr "Daha çok bilgi"
 
@@ -1197,15 +1239,13 @@ msgstr "Daha çok bilgi"
 msgid "Details page"
 msgstr "Ayrıntılar sayfası"
 
-#. Translators: A label for a button to add a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:228
+#. Translators: A label for a button to add a shortcut to the selected application.
+#: src/gs-details-page.ui:209
 msgid "_Add to Desktop"
 msgstr ""
 
-#. Translators: A label for a button to remove a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:245
+#. Translators: A label for a button to remove a shortcut to the selected application.
+#: src/gs-details-page.ui:226
 msgid "_Remove from Desktop"
 msgstr ""
 
@@ -1226,7 +1266,9 @@ msgstr "Yazılımı Kaynağı Dahildir"
 msgid ""
 "This application includes a software source which provides updates, as well "
 "as access to other software."
-msgstr "Bu uygulama; güncellemelerin yanı sıra, başka yazılımlara erişim sağlayan bir yazılım kaynağı içerir."
+msgstr ""
+"Bu uygulama; güncellemelerin yanı sıra, başka yazılımlara erişim sağlayan "
+"bir yazılım kaynağı içerir."
 
 #: src/gs-details-page.ui:500
 msgid "No Software Source Included"
@@ -1236,16 +1278,19 @@ msgstr "Yazılım Kaynağı Dahil Değildir"
 msgid ""
 "This application does not include a software source. It will not be updated "
 "with new versions."
-msgstr "Bu uygulamada yazılım kaynağı bulunmuyor. Yeni sürümleri çıktığında güncellenmeyecek."
+msgstr ""
+"Bu uygulamada yazılım kaynağı bulunmuyor. Yeni sürümleri çıktığında "
+"güncellenmeyecek."
 
 #: src/gs-details-page.ui:515
 msgid ""
 "This software is already provided by your distribution and should not be "
 "replaced."
-msgstr "Bu yazılım zaten dağıtımınız tarafından sağlanmaktadır ve değiştirilmemelidir."
+msgstr ""
+"Bu yazılım zaten dağıtımınız tarafından sağlanmaktadır ve "
+"değiştirilmemelidir."
 
-#. Translators: a repository file used for installing software has been
-#. discovered.
+#. Translators: a repository file used for installing software has been discovered.
 #: src/gs-details-page.ui:528
 msgid "Software Source Identified"
 msgstr "Yazılım Kaynağı Belirlendi"
@@ -1254,7 +1299,9 @@ msgstr "Yazılım Kaynağı Belirlendi"
 msgid ""
 "Adding this software source will give you access to additional software and "
 "upgrades."
-msgstr "Bu yazılım kaynağını eklemek, ek yazılımlara ve yükseltmelere erişmenizi sağlar."
+msgstr ""
+"Bu yazılım kaynağını eklemek, ek yazılımlara ve yükseltmelere erişmenizi "
+"sağlar."
 
 #: src/gs-details-page.ui:530
 msgid "Only use software sources that you trust."
@@ -1346,14 +1393,12 @@ msgstr "Eklentiler"
 msgid "Selected add-ons will be installed with the application."
 msgstr "Seçilen eklentiler, uygulama ile birlikte yüklenecek."
 
-#. Translators: Header of the section with other users' opinions about the
-#. app.
+#. Translators: Header of the section with other users' opinions about the app.
 #: src/gs-details-page.ui:1233
 msgid "Reviews"
 msgstr "İncelemeler"
 
-#. Translators: Button opening a dialog where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Button opening a dialog where the users can write and publish their opinions about the apps.
 #: src/gs-details-page.ui:1249
 msgid "_Write a Review"
 msgstr "_İnceleme Yaz"
@@ -1365,9 +1410,11 @@ msgstr "Daha Çoğunu Gö_ster"
 
 #: src/gs-details-page.ui:1414
 msgid ""
-"This means that the software can be freely run, copied, distributed, studied"
-" and modified."
-msgstr "Bu; yazılımı özgürce çalıştırma, kopyalama, dağıtma, öğrenme ve düzenleme anlamına gelir."
+"This means that the software can be freely run, copied, distributed, studied "
+"and modified."
+msgstr ""
+"Bu; yazılımı özgürce çalıştırma, kopyalama, dağıtma, öğrenme ve düzenleme "
+"anlamına gelir."
 
 #: src/gs-details-page.ui:1473
 msgid "Proprietary Software"
@@ -1378,7 +1425,10 @@ msgid ""
 "This means that the software is owned by an individual or a company. There "
 "are often restrictions on its use and its source code cannot usually be "
 "accessed."
-msgstr "Bu, yazılımın bir kişi ya da bir şirket tarafından sahiplenildiği anlamına gelir. Yazılımın kullanımında genellikle kısıtlamalar vardır ve kaynak koda çoğunlukla erişilemez."
+msgstr ""
+"Bu, yazılımın bir kişi ya da bir şirket tarafından sahiplenildiği anlamına "
+"gelir. Yazılımın kullanımında genellikle kısıtlamalar vardır ve kaynak koda "
+"çoğunlukla erişilemez."
 
 #: src/gs-details-page.ui:1535
 msgid "Unknown Software License"
@@ -1462,8 +1512,7 @@ msgstr "Uygulama listesinde kaydedilmemiş değişiklikler var."
 msgid "Use verbose logging"
 msgstr "Ayrıntılı günlükleme kullan"
 
-#. TRANSLATORS: program name, an application to add and remove software
-#. repositories
+#. TRANSLATORS: program name, an application to add and remove software repositories
 #: src/gs-editor.c:1119
 msgid "GNOME Software Banner Designer"
 msgstr "GNOME Yazılımlar Afiş Tasarlayıcı"
@@ -1492,8 +1541,7 @@ msgstr "Özet"
 msgid "Editor’s Pick"
 msgstr "Editörün Seçimi"
 
-#. This check button controls whether the application’s banner appears in the
-#. “Featured” category
+#. This check button controls whether the application’s banner appears in the “Featured” category
 #: src/gs-editor.ui:397
 msgid "Category Featured"
 msgstr "Kategori Vitrini"
@@ -1582,9 +1630,11 @@ msgstr "%s dosyasını sağlayan, kullanılabilir uygulama yok."
 #: src/gs-extras-page.c:337 src/gs-extras-page.c:348 src/gs-extras-page.c:359
 #, c-format
 msgid ""
-"Information about %s, as well as options for how to get missing applications"
-" might be found %s."
-msgstr "Eksik uygulamaları nasıl edinebileceğinizle ilgili seçeneklerin yanında, %s hakkındaki bilgileri şurada bulabilirsiniz: %s."
+"Information about %s, as well as options for how to get missing applications "
+"might be found %s."
+msgstr ""
+"Eksik uygulamaları nasıl edinebileceğinizle ilgili seçeneklerin yanında, %s "
+"hakkındaki bilgileri şurada bulabilirsiniz: %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1607,7 +1657,9 @@ msgstr "%s kullanılabilir değil"
 msgid ""
 "Information about %s, as well as options for how to get an application that "
 "can support this format might be found %s."
-msgstr "Hem %s hakkındaki bilgiler hem de bu biçimi oynatabilen uygulamayı nasıl edinebileceğinizle ilgili seçenekleri %s adresinde bulabilirsiniz."
+msgstr ""
+"Hem %s hakkındaki bilgiler hem de bu biçimi oynatabilen uygulamayı nasıl "
+"edinebileceğinizle ilgili seçenekleri %s adresinde bulabilirsiniz."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1623,11 +1675,13 @@ msgstr "%s betik desteği için kullanılabilir yazı tipi yok."
 msgid ""
 "Information about %s, as well as options for how to get additional fonts "
 "might be found %s."
-msgstr "Hem %s hakkındaki bilgiler hem de ek yazı tiplerini nasıl edinebileceğinizi %s adresinde bulabilirsiniz."
+msgstr ""
+"Hem %s hakkındaki bilgiler hem de ek yazı tiplerini nasıl edinebileceğinizi "
+"%s adresinde bulabilirsiniz."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
-#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1426
+#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1430
 #, c-format
 msgid "No addon codecs are available for the %s format."
 msgstr "%s biçimi için kullanılabilir ek kodek yok."
@@ -1639,7 +1693,9 @@ msgstr "%s biçimi için kullanılabilir ek kodek yok."
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format might be found %s."
-msgstr "Hem %s hakkındaki bilgiler hem de bu biçimi oynatabilen bir kod çözücüyü nasıl edinebileceğinizle ilgili bilgiyi %s adresinde bulabilirsiniz."
+msgstr ""
+"Hem %s hakkındaki bilgiler hem de bu biçimi oynatabilen bir kod çözücüyü "
+"nasıl edinebileceğinizle ilgili bilgiyi %s adresinde bulabilirsiniz."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1655,7 +1711,9 @@ msgstr "%s desteği için kullanılabilir Plazma kaynağı yok."
 msgid ""
 "Information about %s, as well as options for how to get additional Plasma "
 "resources might be found %s."
-msgstr "Hem %s hakkındaki bilgiler hem de ek Plazma kaynaklarını nasıl edinebileceğinizle ilgili bilgiyi %s adresinde bulabilirsiniz."
+msgstr ""
+"Hem %s hakkındaki bilgiler hem de ek Plazma kaynaklarını nasıl "
+"edinebileceğinizle ilgili bilgiyi %s adresinde bulabilirsiniz."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1671,15 +1729,16 @@ msgstr "%s için kullanılabilir yazıcı sürücüsü yok."
 msgid ""
 "Information about %s, as well as options for how to get a driver that "
 "supports this printer might be found %s."
-msgstr "Hem %s hakkındaki bilgiler hem de bu sürücüyü nasıl edinebileceğinizi %s adresinde bulabilirsiniz."
+msgstr ""
+"Hem %s hakkındaki bilgiler hem de bu sürücüyü nasıl edinebileceğinizi %s "
+"adresinde bulabilirsiniz."
 
 #. TRANSLATORS: hyperlink title
 #: src/gs-extras-page.c:459
 msgid "this website"
 msgstr "bu web sitesi"
 
-#. TRANSLATORS: no codecs were found. First %s will be replaced by actual
-#. codec name(s), second %s is a link titled "this website"
+#. TRANSLATORS: no codecs were found. First %s will be replaced by actual codec name(s), second %s is a link titled "this website"
 #: src/gs-extras-page.c:463
 #, c-format
 msgid ""
@@ -1714,10 +1773,13 @@ msgstr "Yazılımlar’a Hoş Geldiniz"
 
 #: src/gs-first-run-dialog.ui:66
 msgid ""
-"Software lets you install all the software you need, all from one place. See"
-" our recommendations, browse the categories, or search for the applications "
+"Software lets you install all the software you need, all from one place. See "
+"our recommendations, browse the categories, or search for the applications "
 "you want."
-msgstr "Yazılımlar uygulaması, gereksindiğiniz tüm yazılımları tek bir yerden kurmanıza olanak tanır. Bizim önerdiklerimize bakın, kategorilere gözatın ya da istediğiniz uygulamaları bulmak için arama yapın."
+msgstr ""
+"Yazılımlar uygulaması, gereksindiğiniz tüm yazılımları tek bir yerden "
+"kurmanıza olanak tanır. Bizim önerdiklerimize bakın, kategorilere gözatın ya "
+"da istediğiniz uygulamaları bulmak için arama yapın."
 
 #: src/gs-first-run-dialog.ui:85
 msgid "_Let’s Go Shopping"
@@ -1871,9 +1933,10 @@ msgstr "Web tarayıcılarını ve oyunları içeren ek yazılımlara erişmeyi s
 
 #. TRANSLATORS: this is the proprietary info bar
 #: src/gs-overview-page.c:978
-msgid ""
-"Proprietary software has restrictions on use and access to source code."
-msgstr "Sahipli yazılımların kaynak kod erişimi ve kullanımı üzerinde kısıtlamaları vardır."
+msgid "Proprietary software has restrictions on use and access to source code."
+msgstr ""
+"Sahipli yazılımların kaynak kod erişimi ve kullanımı üzerinde kısıtlamaları "
+"vardır."
 
 #. TRANSLATORS: this is the clickable
 #. * link on the proprietary info bar
@@ -1902,14 +1965,12 @@ msgstr "Öne Çıkan Uygulama"
 msgid "Categories"
 msgstr "Kategoriler"
 
-#. Translators: This is a heading for software which has been featured
-#. ('picked') by the distribution.
+#. Translators: This is a heading for software which has been featured ('picked') by the distribution.
 #: src/gs-overview-page.ui:315
 msgid "Editor’s Picks"
 msgstr "Editörün Seçtikleri"
 
-#. Translators: This is a heading for software which has been recently
-#. released upstream.
+#. Translators: This is a heading for software which has been recently released upstream.
 #: src/gs-overview-page.ui:359
 msgid "Recent Releases"
 msgstr "Son Çıkanlar"
@@ -1956,7 +2017,9 @@ msgstr "%s kaynağını kaldırmak istediğinizden emin misiniz?"
 msgid ""
 "All applications from %s will be removed, and you will have to re-install "
 "the source to use them again."
-msgstr "%s kaynağından olan tüm uygulamalar kaldırılacak ve tekrar kullanmak için yeniden kurmanız gerekecek."
+msgstr ""
+"%s kaynağından olan tüm uygulamalar kaldırılacak ve tekrar kullanmak için "
+"yeniden kurmanız gerekecek."
 
 #. TRANSLATORS: this is a prompt message, and '%s' is an
 #. * application summary, e.g. 'GNOME Clocks'
@@ -1971,12 +2034,14 @@ msgstr "%s uygulamasını kaldırmak istediğinizden emin misiniz?"
 msgid "%s will be removed, and you will have to install it to use it again."
 msgstr "%s kaldırılacak ve tekrar kullanmak için yeniden kurmanız gerekecek."
 
-#: lib/gs-plugin-loader.c:1429
+#: lib/gs-plugin-loader.c:1433
 #, c-format
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format can be found on the website."
-msgstr "Hem %s hakkındaki bilgiler hem de bu biçimi oynatabilen bir kod çözücüyü nasıl edinebileceğinizle ilgili seçenekleri, web sitesinde bulabilirsiniz."
+msgstr ""
+"Hem %s hakkındaki bilgiler hem de bu biçimi oynatabilen bir kod çözücüyü "
+"nasıl edinebileceğinizle ilgili seçenekleri, web sitesinde bulabilirsiniz."
 
 #: lib/gs-price.c:111
 #, c-format
@@ -2035,7 +2100,9 @@ msgstr "%s %f"
 msgid ""
 "Some of the currently installed software is not compatible with %s. If you "
 "continue, the following will be automatically removed during the upgrade:"
-msgstr "Yüklenmiş bazı yazılımlar %s ile uyumlu değil. Eğer devam ederseniz, takip edenler yükseltme sırasında kendiliğinden kaldırılacak:"
+msgstr ""
+"Yüklenmiş bazı yazılımlar %s ile uyumlu değil. Eğer devam ederseniz, takip "
+"edenler yükseltme sırasında kendiliğinden kaldırılacak:"
 
 #: src/gs-removal-dialog.ui:27
 msgid "Incompatible Software"
@@ -2105,8 +2172,7 @@ msgstr "Açıklama çok kısa"
 msgid "The description is too long"
 msgstr "Açıklama çok uzun"
 
-#. Translators: Title of the dialog box where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Title of the dialog box where the users can write and publish their opinions about the apps.
 #: src/gs-review-dialog.ui:11
 msgid "Post Review"
 msgstr "İnceleme Gönder"
@@ -2124,7 +2190,9 @@ msgstr "Puanlama"
 msgid ""
 "Give a short summary of your review, for example: “Great app, would "
 "recommend”."
-msgstr "İncelemenizin kısa bir özetini girin, öreğin: “Harika bir uygulama, tavsiye ediyorum”."
+msgstr ""
+"İncelemenizin kısa bir özetini girin, öreğin: “Harika bir uygulama, tavsiye "
+"ediyorum”."
 
 #. Translators: This is where the users enter their opinions about the apps.
 #: src/gs-review-dialog.ui:199
@@ -2134,7 +2202,9 @@ msgstr "İnceleme"
 
 #: src/gs-review-dialog.ui:215
 msgid "What do you think of the app? Try to give reasons for your views."
-msgstr "Uygulama hakkında ne düşünüyorsunuz? Görüşleriniz için neden belirtmeye çalışın."
+msgstr ""
+"Uygulama hakkında ne düşünüyorsunuz? Görüşleriniz için neden belirtmeye "
+"çalışın."
 
 #. Translators: A label for the total number of reviews.
 #: src/gs-review-histogram.ui:413
@@ -2144,14 +2214,17 @@ msgstr "toplam oylama"
 #. TRANSLATORS: we explain what the action is going to do
 #: src/gs-review-row.c:234
 msgid "You can report reviews for abusive, rude, or discriminatory behavior."
-msgstr "Küfürlü, kaba veya ayrımcı tutum içeren incelemeleri rapor edebilirsiniz."
+msgstr ""
+"Küfürlü, kaba veya ayrımcı tutum içeren incelemeleri rapor edebilirsiniz."
 
 #. TRANSLATORS: we ask the user if they really want to do this
 #: src/gs-review-row.c:239
 msgid ""
 "Once reported, a review will be hidden until it has been checked by an "
 "administrator."
-msgstr "Bir kere rapor edildikten sonra; inceleme, bir yönetici tarafından denetlenene dek gizlenecektir."
+msgstr ""
+"Bir kere rapor edildikten sonra; inceleme, bir yönetici tarafından "
+"denetlenene dek gizlenecektir."
 
 #. TRANSLATORS: window title when
 #. * reporting a user-submitted review
@@ -2166,8 +2239,7 @@ msgstr "İnceleme Rapor Edilsin Mi?"
 msgid "Report"
 msgstr "Rapor Et"
 
-#. Translators: Users can express their opinions about other users' opinions
-#. about the apps.
+#. Translators: Users can express their opinions about other users' opinions about the apps.
 #: src/gs-review-row.ui:112
 msgid "Was this review useful to you?"
 msgstr "Bu inceleme işinize yaradı mı?"
@@ -2256,81 +2328,82 @@ msgstr "Uygulama Bulunamadı"
 #. TRANSLATORS: this is part of the in-app notification,
 #. * where the %s is a multi-word localised app name
 #. * e.g. 'Getting things GNOME!"
-#: src/gs-shell.c:846 src/gs-shell.c:851 src/gs-shell.c:866 src/gs-shell.c:870
+#: src/gs-shell.c:847 src/gs-shell.c:852 src/gs-shell.c:867 src/gs-shell.c:871
 #, c-format
 msgid "“%s”"
 msgstr "“%s”"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:898
+#: src/gs-shell.c:899
 #, c-format
 msgid "Unable to download firmware updates from %s"
 msgstr "%s’den donanım yazılımı güncellemeleri indirilemiyor"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:904
+#: src/gs-shell.c:905
 #, c-format
 msgid "Unable to download updates from %s"
 msgstr "%s’den güncellemeler indirilemiyor"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:911
+#: src/gs-shell.c:912
 msgid "Unable to download updates"
 msgstr "Güncellemeler indirilemiyor"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:916
+#: src/gs-shell.c:917
 msgid ""
-"Unable to download updates: internet access was required but wasn’t "
-"available"
-msgstr "Güncellemeler indirilemiyor: İnternet bağlantısı gerekiyordu fakat kullanılabilir değildi."
+"Unable to download updates: internet access was required but wasn’t available"
+msgstr ""
+"Güncellemeler indirilemiyor: İnternet bağlantısı gerekiyordu fakat "
+"kullanılabilir değildi."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:925
+#: src/gs-shell.c:926
 #, c-format
 msgid "Unable to download updates from %s: not enough disk space"
 msgstr "%s’den güncellemeler indirilemiyor: yetersiz disk alanı"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:930
+#: src/gs-shell.c:931
 msgid "Unable to download updates: not enough disk space"
 msgstr "Güncellemeler indirilemiyor: yetersiz disk alanı"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:938
+#: src/gs-shell.c:939
 msgid "Unable to download updates: authentication was required"
 msgstr "Güncellemeler indirilemiyor: yetkilendirme gerekiyor"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:943
+#: src/gs-shell.c:944
 msgid "Unable to download updates: authentication was invalid"
 msgstr "Güncellemeler indirilemiyor: yetkilendirme geçersiz"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:948
+#: src/gs-shell.c:949
 msgid ""
 "Unable to download updates: you do not have permission to install software"
 msgstr "Güncellemeler indirilemiyor: yazılım yükleme izniniz yok"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:955
+#: src/gs-shell.c:956
 msgid "Unable to get list of updates"
 msgstr "Güncellemelerin listesi alınamıyor"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the application name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1001
+#: src/gs-shell.c:1002
 #, c-format
 msgid "Unable to install %s as download failed from %s"
 msgstr "%2$s’den indirme başarısız olduğundan %1$s yüklenemiyor"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1007
+#: src/gs-shell.c:1008
 #, c-format
 msgid "Unable to install %s as download failed"
 msgstr "İndirme başarısız olduğundan %s yüklenemiyor"
@@ -2339,51 +2412,52 @@ msgstr "İndirme başarısız olduğundan %s yüklenemiyor"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1019
+#: src/gs-shell.c:1020
 #, c-format
 msgid "Unable to install %s as runtime %s not available"
 msgstr "%2$s çalışma zamanı olmadığından %1$s yüklenemiyor"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1025
+#: src/gs-shell.c:1026
 #, c-format
 msgid "Unable to install %s as not supported"
 msgstr "Desteklenmediğinden %s yüklenemiyor"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1032
+#: src/gs-shell.c:1033
 msgid "Unable to install: internet access was required but wasn’t available"
-msgstr "Yüklenemiyor: İnternet bağlantısı gerekiyordu fakat kullanılabilir değildi."
+msgstr ""
+"Yüklenemiyor: İnternet bağlantısı gerekiyordu fakat kullanılabilir değildi."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1038
+#: src/gs-shell.c:1039
 msgid "Unable to install: the application has an invalid format"
 msgstr "Kurulamıyor: uygulama geçersiz biçime sahip"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1043
+#: src/gs-shell.c:1044
 #, c-format
 msgid "Unable to install %s: not enough disk space"
 msgstr "%s yüklenemiyor: yetersiz disk alanı"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1051
+#: src/gs-shell.c:1052
 #, c-format
 msgid "Unable to install %s: authentication was required"
 msgstr "%s yüklenemiyor: yetkilendirme gerekiyor"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1058
+#: src/gs-shell.c:1059
 #, c-format
 msgid "Unable to install %s: authentication was invalid"
 msgstr "%s yüklenemiyor: yetkilendirme geçersiz"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1065
+#: src/gs-shell.c:1066
 #, c-format
 msgid "Unable to install %s: you do not have permission to install software"
 msgstr "%s yüklenemiyor: yazılım yükleme izniniz yok"
@@ -2391,34 +2465,34 @@ msgstr "%s yüklenemiyor: yazılım yükleme izniniz yok"
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the name of the authentication service,
 #. * e.g. "Ubuntu One"
-#: src/gs-shell.c:1078
+#: src/gs-shell.c:1079
 #, c-format
 msgid "Your %s account has been suspended."
 msgstr "%s hesabınız askıya alındı."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1082
+#: src/gs-shell.c:1083
 msgid "It is not possible to install software until this has been resolved."
 msgstr "Bu çözülene dek yazılım yüklenmesi mümkün değildir."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the clickable link (e.g.
 #. * "http://example.com/what-did-i-do-wrong/")
-#: src/gs-shell.c:1093
+#: src/gs-shell.c:1094
 #, c-format
 msgid "For more information, visit %s."
 msgstr "Daha çok bilgi için %s adresini ziyaret et."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1102
+#: src/gs-shell.c:1103
 #, c-format
 msgid "Unable to install %s: AC power is required"
 msgstr "%s kurulamıyor: AC güç gerekiyor"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1111
+#: src/gs-shell.c:1112
 #, c-format
 msgid "Unable to install %s"
 msgstr "%s yüklenemiyor"
@@ -2427,61 +2501,63 @@ msgstr "%s yüklenemiyor"
 #. * where the first %s is the app name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1157
+#: src/gs-shell.c:1158
 #, c-format
 msgid "Unable to update %s from %s"
 msgstr "%2$s’den %1$s’e güncellenemiyor"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1163
+#: src/gs-shell.c:1164
 #, c-format
 msgid "Unable to update %s as download failed"
 msgstr "İndirme başarısız olduğundan %s güncellenemiyor"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1169
+#: src/gs-shell.c:1170
 msgid "Unable to update: internet access was required but wasn’t available"
-msgstr "Güncellenemiyor: İnternet bağlantısı gerekiyordu fakat kullanılabilir değildi."
+msgstr ""
+"Güncellenemiyor: İnternet bağlantısı gerekiyordu fakat kullanılabilir "
+"değildi."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1177
+#: src/gs-shell.c:1178
 #, c-format
 msgid "Unable to update %s: not enough disk space"
 msgstr "%s güncellenemiyor: yetersiz disk alanı"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1186
+#: src/gs-shell.c:1187
 #, c-format
 msgid "Unable to update %s: authentication was required"
 msgstr "%s güncellenemiyor: yetkilendirme gerekiyor"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1193
+#: src/gs-shell.c:1194
 #, c-format
 msgid "Unable to update %s: authentication was invalid"
 msgstr "%s güncellenemiyor: yetkilendirme geçersiz"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1200
+#: src/gs-shell.c:1201
 #, c-format
 msgid "Unable to update %s: you do not have permission to update software"
 msgstr "%s güncellenemiyor: yazılım güncellemeye yetkiniz yok"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1208
+#: src/gs-shell.c:1209
 #, c-format
 msgid "Unable to update %s: AC power is required"
 msgstr "%s güncellenemiyor: AC güç gerekiyor"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1217
+#: src/gs-shell.c:1218
 #, c-format
 msgid "Unable to update %s"
 msgstr "%s yükseltilemiyor"
@@ -2489,96 +2565,98 @@ msgstr "%s yükseltilemiyor"
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the distro name (e.g. "Fedora 25") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1262
+#: src/gs-shell.c:1263
 #, c-format
 msgid "Unable to upgrade to %s from %s"
 msgstr "%2$s’den %1$s’e yükseltilemiyor"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the app name (e.g. "GIMP")
-#: src/gs-shell.c:1267
+#: src/gs-shell.c:1268
 #, c-format
 msgid "Unable to upgrade to %s as download failed"
 msgstr "İndirme başarısız olduğundan %s yükseltilemiyor"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1274
+#: src/gs-shell.c:1275
 msgid "Unable to upgrade: internet access was required but wasn’t available"
-msgstr "Yükseltilemiyor: İnternet bağlantısı gerekiyordu fakat kullanılabilir değildi."
+msgstr ""
+"Yükseltilemiyor: İnternet bağlantısı gerekiyordu fakat kullanılabilir "
+"değildi."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1282
+#: src/gs-shell.c:1283
 #, c-format
 msgid "Unable to upgrade to %s: not enough disk space"
 msgstr "%s’e yükseltilemiyor: yetersiz disk alanı"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1291
+#: src/gs-shell.c:1292
 #, c-format
 msgid "Unable to upgrade to %s: authentication was required"
 msgstr "%s’e yükseltilemiyor: yetkilendirme gerekiyor"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1298
+#: src/gs-shell.c:1299
 #, c-format
 msgid "Unable to upgrade to %s: authentication was invalid"
 msgstr "%s’e yükseltilemiyor: yetkilendirme geçersiz"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1305
+#: src/gs-shell.c:1306
 #, c-format
 msgid "Unable to upgrade to %s: you do not have permission to upgrade"
 msgstr "Unable to upgrade to %s: yükseltme için izniniz yok"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1312
+#: src/gs-shell.c:1313
 #, c-format
 msgid "Unable to upgrade to %s: AC power is required"
 msgstr "%s’e yükseltilemiyor: AC güç gerekiyor"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1321
+#: src/gs-shell.c:1322
 #, c-format
 msgid "Unable to upgrade to %s"
 msgstr "%s’e yükseltilemiyor"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1363
+#: src/gs-shell.c:1364
 #, c-format
 msgid "Unable to remove %s: authentication was required"
 msgstr "%s kaldırılamıyor: yetkilendirme gerekiyor"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1369
+#: src/gs-shell.c:1370
 #, c-format
 msgid "Unable to remove %s: authentication was invalid"
 msgstr "%s kaldırılamıyor: yetkilendirme geçersiz"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1375
+#: src/gs-shell.c:1376
 #, c-format
 msgid "Unable to remove %s: you do not have permission to remove software"
 msgstr "%s kaldırılamıyor: yazılım kaldırma izniniz yok "
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1382
+#: src/gs-shell.c:1383
 #, c-format
 msgid "Unable to remove %s: AC power is required"
 msgstr "%s kaldırılamıyor: AC güç gerekiyor"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1391
+#: src/gs-shell.c:1392
 #, c-format
 msgid "Unable to remove %s"
 msgstr "%s kaldırılamıyor"
@@ -2587,48 +2665,49 @@ msgstr "%s kaldırılamıyor"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1437
+#: src/gs-shell.c:1438
 #, c-format
 msgid "Unable to launch %s: %s is not installed"
 msgstr "%s başlatılamıyor: %s yüklü değil"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1444 src/gs-shell.c:1492 src/gs-shell.c:1540
+#: src/gs-shell.c:1445 src/gs-shell.c:1493 src/gs-shell.c:1541
 msgid "Not enough disk space — free up some space and try again"
 msgstr "Yetersiz disk alanı — biraz yer aç ve yeniden dene."
 
 #. TRANSLATORS: we failed to get a proper error code
-#: src/gs-shell.c:1452 src/gs-shell.c:1500 src/gs-shell.c:1567
+#: src/gs-shell.c:1453 src/gs-shell.c:1501 src/gs-shell.c:1568
 msgid "Sorry, something went wrong"
 msgstr "Üzgünüz, bir şeyler yanlış gitti"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1487
+#: src/gs-shell.c:1488
 msgid "Failed to install file: authentication failed"
 msgstr "Dosya kurulamıyor: yetkilendirme başarısız"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1534
+#: src/gs-shell.c:1535
 #, c-format
 msgid "Unable to contact %s"
 msgstr "%s ile iletişim kurulamıyor"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1549
+#: src/gs-shell.c:1550
 #, c-format
 msgid "%s needs to be restarted to use new plugins."
 msgstr "Yeni eklentileri kullanmak için %s yeniden başlatılmalıdır."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1554
+#: src/gs-shell.c:1555
 msgid "This application needs to be restarted to use new plugins."
-msgstr "Yeni eklentileri kullanmak için bu uygulamanın yeniden başlatılması gerekiyor"
+msgstr ""
+"Yeni eklentileri kullanmak için bu uygulamanın yeniden başlatılması gerekiyor"
 
 #. TRANSLATORS: need to be connected to the AC power
-#: src/gs-shell.c:1561
+#: src/gs-shell.c:1562
 msgid "AC power is required"
 msgstr "AC güç gerekiyor"
 
@@ -2636,7 +2715,9 @@ msgstr "AC güç gerekiyor"
 #. has no software installed from it.
 #: src/gs-sources-dialog.c:98
 msgid "No applications or addons installed; other software might still be"
-msgstr "Hiçbir uygulama ya da eklenti kurulmadı; başka yazılımlar halen kurulu olabilir"
+msgstr ""
+"Hiçbir uygulama ya da eklenti kurulmadı; başka yazılımlar halen kurulu "
+"olabilir"
 
 #. TRANSLATORS: This string is used to construct the 'X applications
 #. installed' sentence, describing a software source.
@@ -2690,7 +2771,8 @@ msgstr[1] ""
 #. TRANSLATORS: nonfree software
 #: src/gs-sources-dialog.c:257
 msgid "Typically has restrictions on use and access to source code."
-msgstr "Tipik olarak kaynak kod kullanımı ve erişimi üzerinde kısıtlamalar vardır."
+msgstr ""
+"Tipik olarak kaynak kod kullanımı ve erişimi üzerinde kısıtlamalar vardır."
 
 #. TRANSLATORS: list header
 #: src/gs-sources-dialog.c:278
@@ -2715,7 +2797,9 @@ msgstr "işletim sistemi"
 msgid ""
 "Software sources can be downloaded from the internet. They give you access "
 "to additional software that is not provided by %s."
-msgstr "Yazılım kaynakları internetten indirilebilir. Bunlar size %s tarafından sağlanan ek yazılımlara erişmenize imkan verirler."
+msgstr ""
+"Yazılım kaynakları internetten indirilebilir. Bunlar size %s tarafından "
+"sağlanan ek yazılımlara erişmenize imkan verirler."
 
 #: src/gs-sources-dialog.ui:155
 msgid "Additional Sources"
@@ -2724,7 +2808,9 @@ msgstr "Ek Kaynaklar"
 #: src/gs-sources-dialog.ui:175
 msgid ""
 "Removing a source will also remove any software you have installed from it."
-msgstr "Bir kaynağı kaldırmak, bu kaynaktan kurmuş olduğunuz tüm yazılımları da kaldıracaktır."
+msgstr ""
+"Bir kaynağı kaldırmak, bu kaynaktan kurmuş olduğunuz tüm yazılımları da "
+"kaldıracaktır."
 
 #: src/gs-sources-dialog.ui:260
 msgid "No software installed from this source"
@@ -2922,29 +3008,37 @@ msgstr "Güncelleme iptal edildi."
 #. * something with no network available
 #: src/gs-update-monitor.c:714
 msgid ""
-"Internet access was required but wasn’t available. Please make sure that you"
-" have internet access and try again."
-msgstr "İnternet erişimine gereksinim duyuldu fakat bulunamadı. Lütfen internet erişiminiz olduğuna emin olun ve yeniden deneyin."
+"Internet access was required but wasn’t available. Please make sure that you "
+"have internet access and try again."
+msgstr ""
+"İnternet erişimine gereksinim duyuldu fakat bulunamadı. Lütfen internet "
+"erişiminiz olduğuna emin olun ve yeniden deneyin."
 
 #. TRANSLATORS: if the package is not signed correctly
 #: src/gs-update-monitor.c:720
 msgid ""
 "There were security issues with the update. Please consult your software "
 "provider for more details."
-msgstr "Güncellemede güvenlik sorunları var. Lütfen daha çok ayrıntı için yazılım sağlayıcınızla iletişime geçin."
+msgstr ""
+"Güncellemede güvenlik sorunları var. Lütfen daha çok ayrıntı için yazılım "
+"sağlayıcınızla iletişime geçin."
 
 #. TRANSLATORS: we ran out of disk space
 #: src/gs-update-monitor.c:726
 msgid ""
 "There wasn’t enough disk space. Please free up some space and try again."
-msgstr "Yeterince boş disk alanı yok. Lütfen biraz yer açın ve yeniden deneyin."
+msgstr ""
+"Yeterince boş disk alanı yok. Lütfen biraz yer açın ve yeniden deneyin."
 
 #. TRANSLATORS: We didn't handle the error type
 #: src/gs-update-monitor.c:731
 msgid ""
 "We’re sorry: the update failed to install. Please wait for another update "
 "and try again. If the problem persists, contact your software provider."
-msgstr "Özür dileriz: güncelleme yükleme başarısız. Lütfen başka bir güncellemeyi bekleyin ve yeniden deneyin. Eğer sorun devam ederse, yazılım sağlayıcınızla görüşün."
+msgstr ""
+"Özür dileriz: güncelleme yükleme başarısız. Lütfen başka bir güncellemeyi "
+"bekleyin ve yeniden deneyin. Eğer sorun devam ederse, yazılım sağlayıcınızla "
+"görüşün."
 
 #. TRANSLATORS: Time in 24h format
 #: src/gs-updates-page.c:297
@@ -3124,7 +3218,9 @@ msgstr "Ücret uygulanabilir"
 msgid ""
 "Checking for updates while using mobile broadband could cause you to incur "
 "charges."
-msgstr "Mobil geniş bant kullanımı sırasında güncellemeleri denetlemek sizin için ek masrafa neden olabilir."
+msgstr ""
+"Mobil geniş bant kullanımı sırasında güncellemeleri denetlemek sizin için ek "
+"masrafa neden olabilir."
 
 #. TRANSLATORS: this is a link to the
 #. * control-center network panel
@@ -3163,7 +3259,9 @@ msgstr "Yazılım güncel"
 msgid ""
 "Checking for updates when using mobile broadband could cause you to incur "
 "charges"
-msgstr "Mobil geniş bant kullanımı sırasında güncellemeleri denetlemek sizin için ek masrafa neden olabilir."
+msgstr ""
+"Mobil geniş bant kullanımı sırasında güncellemeleri denetlemek sizin için ek "
+"masrafa neden olabilir."
 
 #: src/gs-updates-page.ui:257
 msgid "_Check Anyway"
@@ -3228,22 +3326,27 @@ msgid "App Center"
 msgstr ""
 
 #: src/org.gnome.Software.desktop.in:4
+msgid "More Apps"
+msgstr "Daha Fazla Uygulama"
+
+#: src/org.gnome.Software.desktop.in:5
 msgid "Add, remove or update software on this computer"
 msgstr "Bu bilgisayarda yazılım ekleyin, kaldırın ya da güncelleyin"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
-#: src/org.gnome.Software.desktop.in:6
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: src/org.gnome.Software.desktop.in:7
 #: src/org.gnome.Software.Editor.desktop.in:6
 msgid "org.gnome.Software"
 msgstr "org.gnome.Software"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
-#: src/org.gnome.Software.desktop.in:12
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: src/org.gnome.Software.desktop.in:13
 msgid ""
-"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;"
-msgstr "Güncellemeler;Güncelleştirmeler;Yükseltme;Kaynaklar;Sürüm Depoları;Tercihler;Yükle;Kur;Kaldır;Program;Yazılım;Uygulama;Mağaza;"
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;"
+msgstr ""
+"Güncellemeler;Güncelleştirmeler;Yükseltme;Kaynaklar;Sürüm Depoları;Tercihler;"
+"Yükle;Kur;Kaldır;Program;Yazılım;Uygulama;Mağaza;"
 
 #: src/org.gnome.Software.Editor.desktop.in:3
 msgid "Banner Designer"
@@ -3253,8 +3356,7 @@ msgstr "Afiş Tasarlayıcı"
 msgid "Design the featured banners for GNOME Software"
 msgstr "GNOME Yazılımlar için vitrin afişleri tasarla"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: src/org.gnome.Software.Editor.desktop.in:13
 msgid "AppStream;Software;App;"
 msgstr "AppStream;Yazılım;Uygulama;App;"
@@ -3524,100 +3626,111 @@ msgctxt "Menu of Communication & News"
 msgid "Web Browsers"
 msgstr "Web Tarayıcıları"
 
-#: plugins/core/gs-desktop-common.c:247
-msgctxt "Menu of Reference"
-msgid "All"
-msgstr "Tümü"
-
-#: plugins/core/gs-desktop-common.c:250
-msgctxt "Menu of Reference"
-msgid "Featured"
-msgstr "Vitrin"
-
-#: plugins/core/gs-desktop-common.c:253
-msgctxt "Menu of Reference"
-msgid "Art"
-msgstr ""
-
-#: plugins/core/gs-desktop-common.c:256
-msgctxt "Menu of Reference"
-msgid "Biography"
-msgstr "Biyografi"
-
-#: plugins/core/gs-desktop-common.c:259
-msgctxt "Menu of Reference"
-msgid "Comics"
-msgstr "Çizgi Romanlar"
-
-#: plugins/core/gs-desktop-common.c:262
-msgctxt "Menu of Reference"
-msgid "Fiction"
-msgstr "Kurgu"
-
-#: plugins/core/gs-desktop-common.c:265
-msgctxt "Menu of Reference"
-msgid "Health"
-msgstr "Sağlık"
-
-#: plugins/core/gs-desktop-common.c:268
-msgctxt "Menu of Reference"
-msgid "History"
-msgstr "Tarih"
-
-#: plugins/core/gs-desktop-common.c:271
-msgctxt "Menu of Reference"
-msgid "Lifestyle"
-msgstr "Yaşam tarzı"
-
-#: plugins/core/gs-desktop-common.c:274
+#: plugins/core/gs-desktop-common.c:242
 msgctxt "Menu of Communication & News"
 msgid "News"
 msgstr "Haberler"
 
+#: plugins/core/gs-desktop-common.c:251
+msgctxt "Menu of Reference"
+msgid "All"
+msgstr "Tümü"
+
+#: plugins/core/gs-desktop-common.c:254
+msgctxt "Menu of Reference"
+msgid "Featured"
+msgstr "Vitrin"
+
+#: plugins/core/gs-desktop-common.c:257
+msgctxt "Menu of Reference"
+msgid "Art"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:260
+msgctxt "Menu of Reference"
+msgid "Biography"
+msgstr "Biyografi"
+
+#: plugins/core/gs-desktop-common.c:263
+msgctxt "Menu of Reference"
+msgid "Comics"
+msgstr "Çizgi Romanlar"
+
+#: plugins/core/gs-desktop-common.c:266
+msgctxt "Menu of Reference"
+msgid "Feed"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:269
+msgctxt "Menu of Reference"
+msgid "Fiction"
+msgstr "Kurgu"
+
+#: plugins/core/gs-desktop-common.c:272
+msgctxt "Menu of Reference"
+msgid "Health"
+msgstr "Sağlık"
+
+#: plugins/core/gs-desktop-common.c:275
+msgctxt "Menu of Reference"
+msgid "History"
+msgstr "Tarih"
+
 #: plugins/core/gs-desktop-common.c:278
+msgctxt "Menu of Reference"
+msgid "Lifestyle"
+msgstr "Yaşam tarzı"
+
+#: plugins/core/gs-desktop-common.c:281
+#, fuzzy
+msgctxt "Menu of Reference"
+msgid "News"
+msgstr "Haberler"
+
+#: plugins/core/gs-desktop-common.c:284
 msgctxt "Menu of Reference"
 msgid "Politics"
 msgstr "Politik"
 
-#: plugins/core/gs-desktop-common.c:281
+#: plugins/core/gs-desktop-common.c:287
 msgctxt "Menu of Reference"
 msgid "Sports"
 msgstr "Spor"
 
 #. TRANSLATORS: this is the menu spec main category for Learning
-#: plugins/core/gs-desktop-common.c:291
+#: plugins/core/gs-desktop-common.c:297
 msgid "Learning"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Game
-#: plugins/core/gs-desktop-common.c:294
+#: plugins/core/gs-desktop-common.c:300
 msgid "Games"
 msgstr "Oyunlar"
 
 #. TRANSLATORS: this is the menu spec main category for Multimedia
-#: plugins/core/gs-desktop-common.c:297
+#: plugins/core/gs-desktop-common.c:303
 msgid "Multimedia"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Work
-#: plugins/core/gs-desktop-common.c:300
+#: plugins/core/gs-desktop-common.c:306
 msgid "Work"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Reference
-#: plugins/core/gs-desktop-common.c:303
+#: plugins/core/gs-desktop-common.c:309
 msgid "Reference & News"
 msgstr ""
 
 #. TRANSLATORS: this is the menu spec main category for Utilities
-#: plugins/core/gs-desktop-common.c:306
+#: plugins/core/gs-desktop-common.c:312
 msgid "Utilities"
 msgstr "Araçlar"
 
 #. TRANSLATORS: this is the menu spec main category for Dev Tools; it
 #. * should be a relatively short label; as an example, in Portuguese and
 #. * Spanish the direct translation of "Programming" (noun) is used
-#: plugins/core/gs-desktop-common.c:311
+#: plugins/core/gs-desktop-common.c:317
 msgid "Dev Tools"
 msgstr ""
 
@@ -3643,16 +3756,16 @@ msgstr "Performans, kararlılık ve güvenlik geliştirmeleri içerir."
 msgid "Downloading featured images…"
 msgstr "Vitrin resimleri indiriliyor…"
 
-#: plugins/eos/gs-plugin-eos.c:1249
+#: plugins/eos/gs-plugin-eos.c:1233
 #, c-format
 msgid "Could not launch this application."
 msgstr ""
 
-#: plugins/eos/gs-plugin-eos.c:1305
+#: plugins/eos/gs-plugin-eos.c:1289
 msgid "Endless Platform"
 msgstr ""
 
-#: plugins/eos/gs-plugin-eos.c:1308
+#: plugins/eos/gs-plugin-eos.c:1292
 msgid "Framework for applications"
 msgstr ""
 
@@ -3712,13 +3825,13 @@ msgid "Flatpak is a framework for desktop applications on Linux"
 msgstr "Flatpak, Linux’taki masaüstü uygulamaları için bir çerçevedir"
 
 #. TRANSLATORS: status text when downloading new metadata
-#: plugins/flatpak/gs-flatpak.c:821
+#: plugins/flatpak/gs-flatpak.c:815
 #, c-format
 msgid "Getting flatpak metadata for %s…"
 msgstr "%s için flatpak üstverisi alınıyor…"
 
 #. TRANSLATORS: status text when downloading the RuntimeRepo
-#: plugins/flatpak/gs-flatpak.c:2796
+#: plugins/flatpak/gs-flatpak.c:2803
 msgid "Getting runtime source…"
 msgstr "Çalışma zamanı kaynağı alınıyor…"
 

--- a/po/vi.po
+++ b/po/vi.po
@@ -1,21 +1,22 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the gnome-software package.
-# 
+#
 # Translators:
 # Roddy Shuler <roddy@endlessm.com>, 2016-2017
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-software\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-12 22:31-0700\n"
+"POT-Creation-Date: 2017-11-02 16:28+0100\n"
 "PO-Revision-Date: 2017-10-16 09:08+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
-"Language-Team: Vietnamese (http://www.transifex.com/endless-mobile-inc/gnome-software/language/vi/)\n"
+"Language-Team: Vietnamese (http://www.transifex.com/endless-mobile-inc/gnome-"
+"software/language/vi/)\n"
+"Language: vi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: vi\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:7
@@ -30,7 +31,9 @@ msgstr "Trình quản lý ứng dụng cho GNOME"
 msgid ""
 "Software allows you to find and install new applications and system "
 "extensions and remove existing installed applications."
-msgstr "Phần mềm cho phép bạn tìm kiếm và cài đặt các ứng dụng mới và phần mở rộng hệ thống, cũng như loại bỏ các ứng dụng đã cài đặt hiện có."
+msgstr ""
+"Phần mềm cho phép bạn tìm kiếm và cài đặt các ứng dụng mới và phần mở rộng "
+"hệ thống, cũng như loại bỏ các ứng dụng đã cài đặt hiện có."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:14
 msgid ""
@@ -38,7 +41,11 @@ msgid ""
 "descriptions and multiple screenshots per application. Applications can be "
 "found either through browsing the list of categories or by searching. It "
 "also allows you to update your system using an offline update."
-msgstr "Phần mềm GNOME hiển thị các ứng dụng nổi bật và phổ biến với các mô tả hữu ích và nhiều ảnh chụp màn hình cho mỗi ứng dụng. Có thể tìm được các ứng dụng nhờ tìm duyệt danh sách các danh mục hoặc bằng cách tìm kiếm. Nó cũng cho phép bạn cập nhật hệ thống của mình bằng một bản cập nhật ngoại tuyến."
+msgstr ""
+"Phần mềm GNOME hiển thị các ứng dụng nổi bật và phổ biến với các mô tả hữu "
+"ích và nhiều ảnh chụp màn hình cho mỗi ứng dụng. Có thể tìm được các ứng "
+"dụng nhờ tìm duyệt danh sách các danh mục hoặc bằng cách tìm kiếm. Nó cũng "
+"cho phép bạn cập nhật hệ thống của mình bằng một bản cập nhật ngoại tuyến."
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:25
 msgid "Overview panel"
@@ -72,7 +79,9 @@ msgstr "Danh sách các dự án tương thích"
 msgid ""
 "This is a list of compatible projects we should show such as GNOME, KDE and "
 "XFCE."
-msgstr "Đây là danh sách các dự án tương thích mà chúng ta nên hiển thị như GNOME, KDE và XFCE."
+msgstr ""
+"Đây là danh sách các dự án tương thích mà chúng ta nên hiển thị như GNOME, "
+"KDE và XFCE."
 
 #: data/org.gnome.software.gschema.xml:10
 msgid "Whether to manage updates in GNOME Software"
@@ -82,7 +91,9 @@ msgstr "Có quản lý các cập nhật trong Phần mềm GNOME"
 msgid ""
 "If disabled, GNOME Software will hide the updates panel and not perform any "
 "automatic updates actions."
-msgstr "Nếu bị vô hiệu hóa, Phần mềm GNOME sẽ ẩn bảng cập nhật và không thực hiện bất kỳ hành động cập nhật tự động nào."
+msgstr ""
+"Nếu bị vô hiệu hóa, Phần mềm GNOME sẽ ẩn bảng cập nhật và không thực hiện "
+"bất kỳ hành động cập nhật tự động nào."
 
 #: data/org.gnome.software.gschema.xml:15
 msgid "Whether to automatically download updates"
@@ -90,9 +101,11 @@ msgstr "Có hay không tự động tải xuống các bản cập nhật"
 
 #: data/org.gnome.software.gschema.xml:16
 msgid ""
-"If enabled, GNOME Software automatically downloads updates in the background"
-" and prompts the user to install them when ready."
-msgstr "Nếu được kích hoạt, Phần mềm GNOME sẽ tự động tải các bản cập nhật về nền ẩn và nhắc người dùng cài đặt chúng khi sẵn sàng."
+"If enabled, GNOME Software automatically downloads updates in the background "
+"and prompts the user to install them when ready."
+msgstr ""
+"Nếu được kích hoạt, Phần mềm GNOME sẽ tự động tải các bản cập nhật về nền ẩn "
+"và nhắc người dùng cài đặt chúng khi sẵn sàng."
 
 #: data/org.gnome.software.gschema.xml:20
 msgid "Whether to automatically refresh when on a metered connection"
@@ -103,7 +116,10 @@ msgid ""
 "If enabled, GNOME Software automatically refreshes in the background even "
 "when using a metered connection (eventually downloading some metadata, "
 "checking for updates, etc., which may incur in costs for the user)."
-msgstr "Nếu được kích hoạt, Phần mềm GNOME sẽ tự động làm mới trên nền ngay cả khi sử dụng kết nối được đo lưu lượng (sẽ dẫn đến việc tải về lý lịch dữ liệu, kiểm tra cập nhật, v.v., có thể làm phát sinh chi phí cho người dùng)."
+msgstr ""
+"Nếu được kích hoạt, Phần mềm GNOME sẽ tự động làm mới trên nền ngay cả khi "
+"sử dụng kết nối được đo lưu lượng (sẽ dẫn đến việc tải về lý lịch dữ liệu, "
+"kiểm tra cập nhật, v.v., có thể làm phát sinh chi phí cho người dùng)."
 
 #: data/org.gnome.software.gschema.xml:25
 msgid "Whether it’s the very first run of GNOME Software"
@@ -119,13 +135,17 @@ msgstr "Các ứng dụng bộ lọc dựa trên bộ nhánh mặc định cho �
 
 #: data/org.gnome.software.gschema.xml:37
 msgid "Non-free applications show a warning dialog before install"
-msgstr "Các ứng dụng không miễn phí đều hiển thị một hộp thoại cảnh báo trước khi cài đặt"
+msgstr ""
+"Các ứng dụng không miễn phí đều hiển thị một hộp thoại cảnh báo trước khi "
+"cài đặt"
 
 #: data/org.gnome.software.gschema.xml:38
 msgid ""
-"When non-free applications are installed a warning dialog can be shown. This"
-" controls if that dialog is suppressed."
-msgstr "Khi các ứng dụng không miễn phí được cài đặt, một hộp thoại cảnh báo có thể sẽ hiển thị. Mục này kiểm soát việc có bỏ hộp thoại đó không."
+"When non-free applications are installed a warning dialog can be shown. This "
+"controls if that dialog is suppressed."
+msgstr ""
+"Khi các ứng dụng không miễn phí được cài đặt, một hộp thoại cảnh báo có thể "
+"sẽ hiển thị. Mục này kiểm soát việc có bỏ hộp thoại đó không."
 
 #: data/org.gnome.software.gschema.xml:42
 msgid "A list of popular applications"
@@ -133,7 +153,9 @@ msgstr "Một danh sách các ứng dụng phổ biến"
 
 #: data/org.gnome.software.gschema.xml:43
 msgid "A list of applications to use, overriding the system defined ones."
-msgstr "Một danh sách các ứng dụng để sử dụng, đè lên những ứng dụng được hệ thống định nghĩa."
+msgstr ""
+"Một danh sách các ứng dụng để sử dụng, đè lên những ứng dụng được hệ thống "
+"định nghĩa."
 
 #: data/org.gnome.software.gschema.xml:47
 msgid "The list of extra sources that have been previously enabled"
@@ -143,7 +165,9 @@ msgstr "Danh sách các mã nguồn bổ sung đã được kích hoạt trướ
 msgid ""
 "The list of sources that have been previously enabled when installing third-"
 "party applications."
-msgstr "Danh sách các nguồn đã được kích hoạt trước đó khi cài đặt ứng dụng của bên thứ ba."
+msgstr ""
+"Danh sách các nguồn đã được kích hoạt trước đó khi cài đặt ứng dụng của bên "
+"thứ ba."
 
 #: data/org.gnome.software.gschema.xml:52
 msgid "The last update check timestamp"
@@ -155,7 +179,8 @@ msgstr "Dấu thời gian truy cập thông báo nâng cấp gần nhất"
 
 #: data/org.gnome.software.gschema.xml:60
 msgid "The timestamp of the first security update, cleared after update"
-msgstr "Dấu thời gian của lần cập nhật bảo mật đầu tiên, đã xóa sau khi cập nhật"
+msgstr ""
+"Dấu thời gian của lần cập nhật bảo mật đầu tiên, đã xóa sau khi cập nhật"
 
 #: data/org.gnome.software.gschema.xml:64
 msgid "The last update timestamp"
@@ -163,14 +188,20 @@ msgstr "Dấu thời gian cập nhật cuối cùng"
 
 #: data/org.gnome.software.gschema.xml:68
 msgid "The age in seconds to verify the upstream screenshot is still valid"
-msgstr "Độ tuổi tính theo giây để xác định ảnh chụp màn hình ngược tuyến vẫn còn hiệu lực"
+msgstr ""
+"Độ tuổi tính theo giây để xác định ảnh chụp màn hình ngược tuyến vẫn còn "
+"hiệu lực"
 
 #: data/org.gnome.software.gschema.xml:69
 msgid ""
 "Choosing a larger value will mean less round-trips to the remote server but "
-"updates to the screenshots may take longer to show to the user. A value of 0"
-" means to never check the server if the image already exists in the cache."
-msgstr "Chọn giá trị lớn hơn sẽ có nghĩa là giảm thời gian trễ trọn vòng đến máy chủ từ xa, nhưng sẽ kéo dài thời gian hiển thị cho người dùng thấy các cập nhật về ảnh chụp màn hình. Giá trị bằng 0 nghĩa là không bao giờ kiểm tra máy chủ xem liệu hình ảnh đã tồn tại trong bộ nhớ đệm. "
+"updates to the screenshots may take longer to show to the user. A value of 0 "
+"means to never check the server if the image already exists in the cache."
+msgstr ""
+"Chọn giá trị lớn hơn sẽ có nghĩa là giảm thời gian trễ trọn vòng đến máy chủ "
+"từ xa, nhưng sẽ kéo dài thời gian hiển thị cho người dùng thấy các cập nhật "
+"về ảnh chụp màn hình. Giá trị bằng 0 nghĩa là không bao giờ kiểm tra máy chủ "
+"xem liệu hình ảnh đã tồn tại trong bộ nhớ đệm. "
 
 #: data/org.gnome.software.gschema.xml:78
 msgid "The server to use for application reviews"
@@ -194,14 +225,15 @@ msgstr "Một danh sách các mã nguồn chính thức có thể coi là phần
 
 #: data/org.gnome.software.gschema.xml:95
 msgid ""
-"The licence URL to use when an application should be considered free "
-"software"
-msgstr "Địa chỉ URL cấp phép để sử dụng khi một ứng dụng có thể coi là phần mềm miễn phí"
+"The licence URL to use when an application should be considered free software"
+msgstr ""
+"Địa chỉ URL cấp phép để sử dụng khi một ứng dụng có thể coi là phần mềm miễn "
+"phí"
 
 #: data/org.gnome.software.gschema.xml:99
-msgid ""
-"Install bundled applications for all users on the system where possible"
-msgstr "Cài đặt các ứng dụng tích hợp sẵn cho mọi người dùng trên hệ thống nếu có thể"
+msgid "Install bundled applications for all users on the system where possible"
+msgstr ""
+"Cài đặt các ứng dụng tích hợp sẵn cho mọi người dùng trên hệ thống nếu có thể"
 
 #: data/org.gnome.software.gschema.xml:103
 msgid "Show the folder management UI"
@@ -217,7 +249,9 @@ msgstr "Cung cấp các bản nâng cấp cho các bản phát hành trước"
 
 #: data/org.gnome.software.gschema.xml:115
 msgid "Show some UI elements informing the user that an app is non-free"
-msgstr "Hiển thị một số yếu tố giao diện người dùng cho người dùng biết rằng ứng dụng là không miễn phí "
+msgstr ""
+"Hiển thị một số yếu tố giao diện người dùng cho người dùng biết rằng ứng "
+"dụng là không miễn phí "
 
 #: data/org.gnome.software.gschema.xml:119
 msgid "Show the prompt to install nonfree software sources"
@@ -229,7 +263,9 @@ msgstr "Hiển thị phần mềm không miễn phí trong kết quả tìm ki�
 
 #: data/org.gnome.software.gschema.xml:127
 msgid "Show the installed size for apps in the list of installed applications"
-msgstr "Hiển thị dung lượng đã cài đặt cho các ứng dụng trong danh sách các ứng dụng đã cài đặt"
+msgstr ""
+"Hiển thị dung lượng đã cài đặt cho các ứng dụng trong danh sách các ứng dụng "
+"đã cài đặt"
 
 #: data/org.gnome.software.gschema.xml:131
 msgid "The URI that explains nonfree and proprietary software"
@@ -243,15 +279,21 @@ msgstr "Một danh sách các nguồn không miễn phí có thể được tùy
 msgid ""
 "A list of URLs pointing to appstream files that will be downloaded into an "
 "app-info folder"
-msgstr "Một danh sách các URL chỉ dẫn đến các tệp appstream sẽ được tải về một thư mục thông tin ứng dụng"
+msgstr ""
+"Một danh sách các URL chỉ dẫn đến các tệp appstream sẽ được tải về một thư "
+"mục thông tin ứng dụng"
 
 #: data/org.gnome.software.gschema.xml:143
 msgid "Install the AppStream files to a system-wide location for all users"
-msgstr "Cài đặt các file AppStream vào một vị trí dễ tiếp cận trên toàn hệ thống cho tất cả người dùng"
+msgstr ""
+"Cài đặt các file AppStream vào một vị trí dễ tiếp cận trên toàn hệ thống cho "
+"tất cả người dùng"
 
 #: data/org.gnome.software.gschema.xml:147
 msgid "Sorts the apps shown in the overview in alphabetical order"
-msgstr "Sắp xếp các ứng dụng hiển thị trong màn hình tổng quan theo thứ tự bảng chữ cái"
+msgstr ""
+"Sắp xếp các ứng dụng hiển thị trong màn hình tổng quan theo thứ tự bảng chữ "
+"cái"
 
 #: data/org.gnome.software.gschema.xml:151
 msgid ""
@@ -267,8 +309,7 @@ msgstr "Cài đặt Phần mềm"
 msgid "Install selected software on the system"
 msgstr "Cài đặt phần mềm đã chọn vào hệ thống"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 #: src/gnome-software-local-file.desktop.in:10
 msgid "system-software-install"
 msgstr "hệ thống-phần mềm-cài đặt"
@@ -295,14 +336,12 @@ msgstr "Trở lại"
 msgid "_All"
 msgstr "_Tất cả"
 
-#. Translators: A label for a button to show only software which is already
-#. installed.
+#. Translators: A label for a button to show only software which is already installed.
 #: src/gnome-software.ui:104
 msgid "_Installed"
 msgstr "_Đã cài đặt"
 
-#. Translators: A label for a button to show only updates which are available
-#. to install.
+#. Translators: A label for a button to show only updates which are available to install.
 #: src/gnome-software.ui:155
 msgid "_Updates"
 msgstr "_Bản cập nhật"
@@ -350,7 +389,7 @@ msgstr "Đã cài đặt"
 
 #. TRANSLATORS: this is a button next to the search results that
 #. * shows the status of an application being installed
-#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:443
+#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:439
 msgid "Installing"
 msgstr "Đang cài đặt"
 
@@ -365,7 +404,7 @@ msgid "Folder Name"
 msgstr "Tên Thư mục"
 
 #: src/gs-app-folder-dialog.c:321 src/gs-app-folder-dialog.ui:16
-#: src/gs-details-page.c:383 src/gs-details-page.ui:342 src/gs-editor.c:623
+#: src/gs-details-page.c:379 src/gs-details-page.ui:342 src/gs-editor.c:623
 #: src/gs-editor.c:655 src/gs-installed-page.c:609 src/gs-removal-dialog.ui:33
 #: src/gs-review-dialog.ui:23 src/gs-upgrade-banner.ui:131
 msgid "_Cancel"
@@ -380,90 +419,94 @@ msgid "Add to Application Folder"
 msgstr "Thêm vào Thư Mục Ứng Dụng"
 
 #. TRANSLATORS: this is a command line option
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "Start up mode: either ‘updates’, ‘updated’, ‘installed’ or ‘overview’"
-msgstr "Chế độ khởi đầu: \"bản cập nhật\", \"đã cập nhật\", \"đã cài đặt\" hoặc \"tổng quan\""
+msgstr ""
+"Chế độ khởi đầu: \"bản cập nhật\", \"đã cập nhật\", \"đã cài đặt\" hoặc "
+"\"tổng quan\""
 
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "MODE"
 msgstr "CHẾ ĐỘ"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "Search for applications"
 msgstr "Tìm kiếm các ứng dụng"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "SEARCH"
 msgstr "TÌM KIẾM"
 
-#: src/gs-application.c:105
+#: src/gs-application.c:133
 msgid "Show application details (using application ID)"
 msgstr "Hiển thị chi tiết ứng dụng (sử dụng ID ứng dụng)"
 
-#: src/gs-application.c:105 src/gs-application.c:109
+#: src/gs-application.c:133 src/gs-application.c:137
 msgid "ID"
 msgstr "ID"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "Show application details (using package name)"
 msgstr "Hiển thị thông tin chi tiết về ứng dụng (sử dụng tên gói)"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "PKGNAME"
 msgstr "TÊN GÓI"
 
-#: src/gs-application.c:109
+#: src/gs-application.c:137
 msgid "Install the application (using application ID)"
 msgstr "Cài đặt ứng dụng (sử dụng ID ứng dụng)"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "Open a local package file"
 msgstr "Mở một tập tin package trong hệ thống"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "FILENAME"
 msgstr "TÊN TẬP TIN"
 
-#: src/gs-application.c:113
+#: src/gs-application.c:141
 msgid ""
 "The kind of interaction expected for this action: either ‘none’, ‘notify’, "
 "or ‘full’"
-msgstr "Kiểu tương tác cần có cho hành động này: có thể là \"không\", \"thông báo\" hoặc \"đầy đủ\""
+msgstr ""
+"Kiểu tương tác cần có cho hành động này: có thể là \"không\", \"thông báo\" "
+"hoặc \"đầy đủ\""
 
-#: src/gs-application.c:116
+#: src/gs-application.c:144
 msgid "Show verbose debugging information"
 msgstr "Hiển thị thông tin gỡ rối chi tiết"
 
-#: src/gs-application.c:118
+#: src/gs-application.c:146
 msgid "Show profiling information for the service"
 msgstr "Hiển thị thông tin hồ sơ cá nhân cho dịch vụ"
 
-#: src/gs-application.c:120
+#: src/gs-application.c:148
 msgid "Quit the running instance"
 msgstr "Thoát tiến trình đang chạy"
 
-#: src/gs-application.c:122
+#: src/gs-application.c:150
 msgid "Prefer local file sources to AppStream"
 msgstr "Thích nguồn tập tin cục bộ hơn là AppStream"
 
-#: src/gs-application.c:124
+#: src/gs-application.c:152
 msgid "Show version number"
 msgstr " Hiển thị số phiên bản"
 
-#: src/gs-application.c:325
+#: src/gs-application.c:358
 msgid "translator-credits"
 msgstr "Tri ân người dịch"
 
 #. TRANSLATORS: this is the title of the about window, e.g.
 #. * 'About Software' or 'About Application Installer' where the %s is
 #. * the application name chosen by the distro
-#: src/gs-application.c:332
+#: src/gs-application.c:365
 #, c-format
 msgid "About %s"
 msgstr "Khoảng %s"
 
 #. TRANSLATORS: well, we seem to think so, anyway
-#: src/gs-application.c:336
+#: src/gs-application.c:369
 msgid "A nice way to manage the software on your system."
 msgstr "Một cách hay để quản lý phần mềm trên hệ thống của bạn."
 
@@ -578,7 +621,7 @@ msgid "All"
 msgstr "Tất cả"
 
 #. TRANSLATORS: this is a subcategory of featured apps
-#: lib/gs-category.c:202 src/gs-shell.c:2180
+#: lib/gs-category.c:202 src/gs-shell.c:2181
 msgid "Featured"
 msgstr "Nổi bật"
 
@@ -588,9 +631,11 @@ msgstr "Cài đặt Phần mở rộng"
 
 #: src/gs-category-page.ui:110
 msgid ""
-"Extensions are used at your own risk. If you have any system problems, it is"
-" recommended to disable them."
-msgstr "Bạn tự chịu trách nhiệm trong việc sử dụng các tiện ích bổ sung. Nếu bạn gặp bất kỳ vấn đề hệ thống nào, bạn nên tắt các tiện ích này."
+"Extensions are used at your own risk. If you have any system problems, it is "
+"recommended to disable them."
+msgstr ""
+"Bạn tự chịu trách nhiệm trong việc sử dụng các tiện ích bổ sung. Nếu bạn gặp "
+"bất kỳ vấn đề hệ thống nào, bạn nên tắt các tiện ích này."
 
 #. TRANSLATORS: the user isn't reading the question
 #: lib/gs-cmd.c:205
@@ -646,13 +691,16 @@ msgstr "Kích hoạt Mã nguồn Phần mềm Bên Thứ ba?"
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
 #. * 2. Software source name, e.g. fedora-optional
+#.
 #: src/gs-common.c:232
 #, c-format
 msgid ""
 "%s is not <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
-"source_software\">free and open source software</a>, and is provided by "
-"“%s”."
-msgstr "%s không phải là <a href=\"https://en.wikipedia.org/wiki/Free_and_open-source_software\">phần mềm nguồn mở và miễn phí</a>, phần mềm này do “%s” cung cấp."
+"source_software\">free and open source software</a>, and is provided by “%s”."
+msgstr ""
+"%s không phải là <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
+"source_software\">phần mềm nguồn mở và miễn phí</a>, phần mềm này do “%s” "
+"cung cấp."
 
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
@@ -676,7 +724,9 @@ msgstr "Việc cài đặt hoặc sử dụng %s có thể là trái phép tại
 #. TRANSLATORS: Laws are geographical, urgh...
 #: src/gs-common.c:268
 msgid "It may be illegal to install or use this codec in some countries."
-msgstr "Việc cài đặt hay sử dụng bộ mã hóa - giải mã này ở một số nước có thể là phi pháp."
+msgstr ""
+"Việc cài đặt hay sử dụng bộ mã hóa - giải mã này ở một số nước có thể là phi "
+"pháp."
 
 #. TRANSLATORS: this is button text to not ask about non-free content again
 #: src/gs-common.c:275
@@ -922,7 +972,9 @@ msgstr "Sự phân biệt đối xử được tạo ra để gây tổn thươn
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:207
 msgid "Explicit discrimination based on gender, sexuality, race or religion"
-msgstr "Sự phân biệt đối xử rõ rệt về giới tính, thiên hướng tình dục, sắc tộc hoặc tôn giáo"
+msgstr ""
+"Sự phân biệt đối xử rõ rệt về giới tính, thiên hướng tình dục, sắc tộc hoặc "
+"tôn giáo"
 
 #. TRANSLATORS: content rating description
 #: src/gs-content-rating.c:210
@@ -1034,14 +1086,12 @@ msgstr "Không chia sẻ vị trí thực tế với người dùng khác"
 msgid "Sharing physical location to other users"
 msgstr "Chia sẻ địa điểm vật lý với người dùng khác"
 
-#. TRANSLATORS: this is a what we use in notifications if the app's name is
-#. unknown
+#. TRANSLATORS: this is a what we use in notifications if the app's name is unknown
 #: src/gs-dbus-helper.c:294
 msgid "An application"
 msgstr "Một ứng dụng"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. MIME types.
+#. TRANSLATORS: this is a notification displayed when an app needs additional MIME types.
 #: src/gs-dbus-helper.c:300
 #, c-format
 msgid "%s is requesting additional file format support."
@@ -1052,8 +1102,7 @@ msgstr "%s đang yêu cầu bổ sung hỗ trợ định dạng tập tin."
 msgid "Additional MIME Types Required"
 msgstr "Yêu Cầu Các Loại MIME Bổ Sung"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. fonts.
+#. TRANSLATORS: this is a notification displayed when an app needs additional fonts.
 #: src/gs-dbus-helper.c:306
 #, c-format
 msgid "%s is requesting additional fonts."
@@ -1064,8 +1113,7 @@ msgstr "%s đang yêu cầu bổ sung kiểu chữ."
 msgid "Additional Fonts Required"
 msgstr "Yêu cầu Bổ sung Kiểu chữ"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. codecs.
+#. TRANSLATORS: this is a notification displayed when an app needs additional codecs.
 #: src/gs-dbus-helper.c:312
 #, c-format
 msgid "%s is requesting additional multimedia codecs."
@@ -1076,8 +1124,7 @@ msgstr "%s đang yêu cầu bổ sung bộ mã hóa - giải mã đa phương ti
 msgid "Additional Multimedia Codecs Required"
 msgstr "Cần có Bộ Mã hóa - Giải mã Đa phương tiện Bổ sung"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. printer drivers.
+#. TRANSLATORS: this is a notification displayed when an app needs additional printer drivers.
 #: src/gs-dbus-helper.c:318
 #, c-format
 msgid "%s is requesting additional printer drivers."
@@ -1088,8 +1135,7 @@ msgstr "%s đang yêu cầu bổ sung trình điều khiển máy in."
 msgid "Additional Printer Drivers Required"
 msgstr "Phải Bổ sung Trình Điều khiển Máy in"
 
-#. TRANSLATORS: this is a notification displayed when an app wants to install
-#. additional packages.
+#. TRANSLATORS: this is a notification displayed when an app wants to install additional packages.
 #: src/gs-dbus-helper.c:324
 #, c-format
 msgid "%s is requesting additional packages."
@@ -1109,14 +1155,14 @@ msgstr "Tìm trong Phần mềm"
 #. * can be installed
 #. TRANSLATORS: button text in the header when firmware
 #. * can be live-installed
-#: src/gs-details-page.c:281 src/gs-details-page.c:312
-#: src/gs-details-page.ui:206 src/gs-upgrade-banner.ui:146
+#: src/gs-details-page.c:280 src/gs-details-page.c:310
+#: src/gs-details-page.ui:237 src/gs-upgrade-banner.ui:146
 msgid "_Install"
 msgstr "_Cài đặt"
 
 #. TRANSLATORS: button text in the header when an application
 #. * can be live-updated
-#: src/gs-details-page.c:316
+#: src/gs-details-page.c:314
 msgid "_Update"
 msgstr "_Cập nhật"
 
@@ -1124,66 +1170,66 @@ msgstr "_Cập nhật"
 #. * be installed.
 #. * The ellipsis indicates that further steps are required,
 #. * e.g. enabling software sources or the like
-#: src/gs-details-page.c:330
+#: src/gs-details-page.c:326
 msgid "_Install…"
 msgstr "_Cài đặt..."
 
 #. TRANSLATORS: button text in the header when an application can be erased
-#: src/gs-details-page.c:377 src/gs-details-page.ui:547
+#: src/gs-details-page.c:373 src/gs-details-page.ui:547
 msgid "_Uninstall"
 msgstr "_Hủy cài đặt"
 
-#: src/gs-details-page.c:438 src/gs-sources-dialog.c:513
+#: src/gs-details-page.c:434 src/gs-sources-dialog.c:513
 msgid "Removing…"
 msgstr "Đang xóa..."
 
 #. TRANSLATORS: this is the warning box
-#: src/gs-details-page.c:748
+#: src/gs-details-page.c:744
 msgid ""
 "This application can only be used when there is an active internet "
 "connection."
 msgstr "Chỉ có thể dùng ứng dụng này khi có kết nối internet hoạt động."
 
 #. TRANSLATORS: this is where the version is not known
-#: src/gs-details-page.c:892
+#: src/gs-details-page.c:888
 msgctxt "version"
 msgid "Unknown"
 msgstr "Khuyết danh"
 
 #. TRANSLATORS: this is where we don't know the origin of the
 #. * application
-#: src/gs-details-page.c:971
+#: src/gs-details-page.c:967
 msgctxt "origin"
 msgid "Unknown"
 msgstr "Không xác định"
 
 #. TRANSLATORS: we need a remote server to process
-#: src/gs-details-page.c:1378
+#: src/gs-details-page.c:1374
 msgid "You need internet access to write a review"
 msgstr "Bạn cần truy cập internet để viết bình luận"
 
-#: src/gs-details-page.c:1507
+#: src/gs-details-page.c:1503
 #, c-format
 msgid "Unable to find “%s”"
 msgstr "Không tìm thấy “%s”"
 
 #. TRANSLATORS: see the wikipedia page
-#: src/gs-details-page.c:2087
+#: src/gs-details-page.c:2083
 msgid "Public domain"
 msgstr "Phạm vi công cộng"
 
 #. TRANSLATORS: see GNU page
-#: src/gs-details-page.c:2103 src/gs-details-page.ui:1397
+#: src/gs-details-page.c:2099 src/gs-details-page.ui:1397
 msgid "Free Software"
 msgstr "Phần mềm Miễn phí"
 
 #. TRANSLATORS: for the free software popover
-#: src/gs-details-page.c:2160
+#: src/gs-details-page.c:2156
 msgid "Users are bound by the following license:"
 msgid_plural "Users are bound by the following licenses:"
 msgstr[0] "Người dùng bị ràng buộc trong các quyền sử dụng sau đây:"
 
-#: src/gs-details-page.c:2176 src/gs-details-page.ui:1506
+#: src/gs-details-page.c:2172 src/gs-details-page.ui:1506
 msgid "More information"
 msgstr "Thêm thông tin"
 
@@ -1191,15 +1237,13 @@ msgstr "Thêm thông tin"
 msgid "Details page"
 msgstr "Trang thông tin chi tiết"
 
-#. Translators: A label for a button to add a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:228
+#. Translators: A label for a button to add a shortcut to the selected application.
+#: src/gs-details-page.ui:209
 msgid "_Add to Desktop"
 msgstr "_Thêm vào Màn hình nền"
 
-#. Translators: A label for a button to remove a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:245
+#. Translators: A label for a button to remove a shortcut to the selected application.
+#: src/gs-details-page.ui:226
 msgid "_Remove from Desktop"
 msgstr "_Gỡ khỏi Màn hình nền"
 
@@ -1220,7 +1264,9 @@ msgstr "Bao gồm Mã nguồn Phần mềm"
 msgid ""
 "This application includes a software source which provides updates, as well "
 "as access to other software."
-msgstr "Ứng dụng này bao gồm một nguồn phần mềm cung cấp các cập nhật cũng như quyền truy cập đến phần mềm khác."
+msgstr ""
+"Ứng dụng này bao gồm một nguồn phần mềm cung cấp các cập nhật cũng như quyền "
+"truy cập đến phần mềm khác."
 
 #: src/gs-details-page.ui:500
 msgid "No Software Source Included"
@@ -1230,16 +1276,19 @@ msgstr "Không bao gồm Mã nguồn Phần mềm"
 msgid ""
 "This application does not include a software source. It will not be updated "
 "with new versions."
-msgstr "Ứng dụng này không bao gồm mã nguồn phần mềm. Ứng dụng sẽ không được cập nhật các phiên bản mới."
+msgstr ""
+"Ứng dụng này không bao gồm mã nguồn phần mềm. Ứng dụng sẽ không được cập "
+"nhật các phiên bản mới."
 
 #: src/gs-details-page.ui:515
 msgid ""
 "This software is already provided by your distribution and should not be "
 "replaced."
-msgstr "Phần mềm này đã được nhà phân phối của bạn cung cấp và không nên được thay thế."
+msgstr ""
+"Phần mềm này đã được nhà phân phối của bạn cung cấp và không nên được thay "
+"thế."
 
-#. Translators: a repository file used for installing software has been
-#. discovered.
+#. Translators: a repository file used for installing software has been discovered.
 #: src/gs-details-page.ui:528
 msgid "Software Source Identified"
 msgstr "Đã Xác định Nguồn Phần mềm"
@@ -1248,7 +1297,9 @@ msgstr "Đã Xác định Nguồn Phần mềm"
 msgid ""
 "Adding this software source will give you access to additional software and "
 "upgrades."
-msgstr "Việc thêm mã nguồn phần mềm này sẽ cho phép bạn truy cập vào phần mềm bổ sung và các bản nâng cấp."
+msgstr ""
+"Việc thêm mã nguồn phần mềm này sẽ cho phép bạn truy cập vào phần mềm bổ "
+"sung và các bản nâng cấp."
 
 #: src/gs-details-page.ui:530
 msgid "Only use software sources that you trust."
@@ -1340,14 +1391,12 @@ msgstr "Tiện ích bổ sung"
 msgid "Selected add-ons will be installed with the application."
 msgstr "Các tiện tích bổ sung được chọn sẽ được cài đặt cùng với ứng dụng."
 
-#. Translators: Header of the section with other users' opinions about the
-#. app.
+#. Translators: Header of the section with other users' opinions about the app.
 #: src/gs-details-page.ui:1233
 msgid "Reviews"
 msgstr "Đánh giá"
 
-#. Translators: Button opening a dialog where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Button opening a dialog where the users can write and publish their opinions about the apps.
 #: src/gs-details-page.ui:1249
 msgid "_Write a Review"
 msgstr "_Viết Đánh giá"
@@ -1359,9 +1408,11 @@ msgstr "_Hiển Thị Thêm"
 
 #: src/gs-details-page.ui:1414
 msgid ""
-"This means that the software can be freely run, copied, distributed, studied"
-" and modified."
-msgstr "Điều này có nghĩa là phần mềm có thể được chạy, sao chép, phân phối, nghiên cứu và chỉnh sửa miễn phí."
+"This means that the software can be freely run, copied, distributed, studied "
+"and modified."
+msgstr ""
+"Điều này có nghĩa là phần mềm có thể được chạy, sao chép, phân phối, nghiên "
+"cứu và chỉnh sửa miễn phí."
 
 #: src/gs-details-page.ui:1473
 msgid "Proprietary Software"
@@ -1372,7 +1423,10 @@ msgid ""
 "This means that the software is owned by an individual or a company. There "
 "are often restrictions on its use and its source code cannot usually be "
 "accessed."
-msgstr "Điều này có nghĩa là phần mềm này được sở hữu bởi một cá nhân hoặc một công ty. Thông thường, việc sử dụng phần mềm này sẽ bị giới hạn và thường không thể truy cập được mã nguồn của nó."
+msgstr ""
+"Điều này có nghĩa là phần mềm này được sở hữu bởi một cá nhân hoặc một công "
+"ty. Thông thường, việc sử dụng phần mềm này sẽ bị giới hạn và thường không "
+"thể truy cập được mã nguồn của nó."
 
 #: src/gs-details-page.ui:1535
 msgid "Unknown Software License"
@@ -1456,8 +1510,7 @@ msgstr "Có thay đổi chưa lưu trong danh sách ứng dụng"
 msgid "Use verbose logging"
 msgstr "Sử dụng phương pháp đăng nhập đa thông tin"
 
-#. TRANSLATORS: program name, an application to add and remove software
-#. repositories
+#. TRANSLATORS: program name, an application to add and remove software repositories
 #: src/gs-editor.c:1119
 msgid "GNOME Software Banner Designer"
 msgstr "Nhà thiết kế Banner Phần mềm GNOME"
@@ -1486,8 +1539,7 @@ msgstr "Tóm tắt"
 msgid "Editor’s Pick"
 msgstr "Lựa chọn của Biên tập viên"
 
-#. This check button controls whether the application’s banner appears in the
-#. “Featured” category
+#. This check button controls whether the application’s banner appears in the “Featured” category
 #: src/gs-editor.ui:397
 msgid "Category Featured"
 msgstr "Hạng mục Nổi bật"
@@ -1574,9 +1626,11 @@ msgstr "Không có sẵn các ứng dụng cung cấp tập tin %s."
 #: src/gs-extras-page.c:337 src/gs-extras-page.c:348 src/gs-extras-page.c:359
 #, c-format
 msgid ""
-"Information about %s, as well as options for how to get missing applications"
-" might be found %s."
-msgstr "Có thể tìm thấy thông tin về %s cũng như các tùy chọn về cách lấy được các ứng dụng bỏ lỡ trên trang web %s."
+"Information about %s, as well as options for how to get missing applications "
+"might be found %s."
+msgstr ""
+"Có thể tìm thấy thông tin về %s cũng như các tùy chọn về cách lấy được các "
+"ứng dụng bỏ lỡ trên trang web %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1599,7 +1653,9 @@ msgstr "%s không khả dụng."
 msgid ""
 "Information about %s, as well as options for how to get an application that "
 "can support this format might be found %s."
-msgstr "Thông tin về %s, cũng như các tùy chọn về cách có thể tìm được ứng dụng hỗ trợ định dạng này %s."
+msgstr ""
+"Thông tin về %s, cũng như các tùy chọn về cách có thể tìm được ứng dụng hỗ "
+"trợ định dạng này %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1615,11 +1671,13 @@ msgstr "Không có phông chữ nào hỗ trợ kịch bản %s."
 msgid ""
 "Information about %s, as well as options for how to get additional fonts "
 "might be found %s."
-msgstr "Có thể tìm thấy thông tin về %s cũng như các tùy chọn về cách có được thêm kiểu chữ trên trang web %s."
+msgstr ""
+"Có thể tìm thấy thông tin về %s cũng như các tùy chọn về cách có được thêm "
+"kiểu chữ trên trang web %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
-#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1426
+#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1430
 #, c-format
 msgid "No addon codecs are available for the %s format."
 msgstr "Không có sẵn các bộ mã hóa-giải mã add-on cho định dạng %s."
@@ -1631,7 +1689,9 @@ msgstr "Không có sẵn các bộ mã hóa-giải mã add-on cho định dạng
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format might be found %s."
-msgstr "Thông tin về %s, cũng như các tùy chọn về cách có thể tìm được codec phát được định dạng này %s."
+msgstr ""
+"Thông tin về %s, cũng như các tùy chọn về cách có thể tìm được codec phát "
+"được định dạng này %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1647,7 +1707,9 @@ msgstr "Không có các tài nguyên Plasma khả dụng để hỗ trợ %s."
 msgid ""
 "Information about %s, as well as options for how to get additional Plasma "
 "resources might be found %s."
-msgstr "Thông tin về %s, cũng như các tùy chọn về cách có thể tìm được tài nguyên Plasma bổ sung %s."
+msgstr ""
+"Thông tin về %s, cũng như các tùy chọn về cách có thể tìm được tài nguyên "
+"Plasma bổ sung %s."
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1663,15 +1725,16 @@ msgstr "Không có trình điều khiển máy in khả dụng cho %s."
 msgid ""
 "Information about %s, as well as options for how to get a driver that "
 "supports this printer might be found %s."
-msgstr "Có thể tìm thấy thông tin về %s cũng như các tùy chọn về cách có được một trình điều khiển hỗ trợ máy in này trên trang web %s."
+msgstr ""
+"Có thể tìm thấy thông tin về %s cũng như các tùy chọn về cách có được một "
+"trình điều khiển hỗ trợ máy in này trên trang web %s."
 
 #. TRANSLATORS: hyperlink title
 #: src/gs-extras-page.c:459
 msgid "this website"
 msgstr "website này"
 
-#. TRANSLATORS: no codecs were found. First %s will be replaced by actual
-#. codec name(s), second %s is a link titled "this website"
+#. TRANSLATORS: no codecs were found. First %s will be replaced by actual codec name(s), second %s is a link titled "this website"
 #: src/gs-extras-page.c:463
 #, c-format
 msgid ""
@@ -1680,7 +1743,9 @@ msgid ""
 msgid_plural ""
 "Unfortunately, the %s you were searching for could not be found. Please see "
 "%s for more information."
-msgstr[0] "Rất tiếc, không thể tìm thấy %s mà bạn đang tìm kiếm. Vui lòng tham khảo %s để biết thêm thông tin."
+msgstr[0] ""
+"Rất tiếc, không thể tìm thấy %s mà bạn đang tìm kiếm. Vui lòng tham khảo %s "
+"để biết thêm thông tin."
 
 #: src/gs-extras-page.c:535 src/gs-extras-page.c:591 src/gs-extras-page.c:630
 msgid "Failed to find any search results"
@@ -1705,10 +1770,13 @@ msgstr "Chào mừng đến Phần mềm"
 
 #: src/gs-first-run-dialog.ui:66
 msgid ""
-"Software lets you install all the software you need, all from one place. See"
-" our recommendations, browse the categories, or search for the applications "
+"Software lets you install all the software you need, all from one place. See "
+"our recommendations, browse the categories, or search for the applications "
 "you want."
-msgstr "Phần mềm cho phép bạn cài đặt mọi phần mềm bạn cần chỉ từ một nơi. Hãy xem đề xuất của chúng tôi, duyệt các danh mục hoặc tìm kiếm các ứng dụng mà bạn muốn."
+msgstr ""
+"Phần mềm cho phép bạn cài đặt mọi phần mềm bạn cần chỉ từ một nơi. Hãy xem "
+"đề xuất của chúng tôi, duyệt các danh mục hoặc tìm kiếm các ứng dụng mà bạn "
+"muốn."
 
 #: src/gs-first-run-dialog.ui:85
 msgid "_Let’s Go Shopping"
@@ -1858,13 +1926,15 @@ msgstr "Ứng dụng về Hiệu suất Khuyên dùng"
 #: src/gs-overview-page.c:974
 msgid ""
 "Provides access to additional software, including web browsers and games."
-msgstr "Cung cấp quyền truy cập các phần mềm bổ sung, bao gồm các trình duyệt web và trò chơi."
+msgstr ""
+"Cung cấp quyền truy cập các phần mềm bổ sung, bao gồm các trình duyệt web và "
+"trò chơi."
 
 #. TRANSLATORS: this is the proprietary info bar
 #: src/gs-overview-page.c:978
-msgid ""
-"Proprietary software has restrictions on use and access to source code."
-msgstr "Các phần mềm sở hữu độc quyền giới hạn quyền sử dụng và truy cập mã nguồn"
+msgid "Proprietary software has restrictions on use and access to source code."
+msgstr ""
+"Các phần mềm sở hữu độc quyền giới hạn quyền sử dụng và truy cập mã nguồn"
 
 #. TRANSLATORS: this is the clickable
 #. * link on the proprietary info bar
@@ -1893,14 +1963,12 @@ msgstr "Ứng dụng Nổi bật"
 msgid "Categories"
 msgstr "Danh mục"
 
-#. Translators: This is a heading for software which has been featured
-#. ('picked') by the distribution.
+#. Translators: This is a heading for software which has been featured ('picked') by the distribution.
 #: src/gs-overview-page.ui:315
 msgid "Editor’s Picks"
 msgstr "Lựa chọn của Biên tập viên"
 
-#. Translators: This is a heading for software which has been recently
-#. released upstream.
+#. Translators: This is a heading for software which has been recently released upstream.
 #: src/gs-overview-page.ui:359
 msgid "Recent Releases"
 msgstr "Bản phát hành gần đây"
@@ -1947,7 +2015,9 @@ msgstr "Bạn có chắc là bạn muốn gỡ nguồn %s?"
 msgid ""
 "All applications from %s will be removed, and you will have to re-install "
 "the source to use them again."
-msgstr "Mọi ứng dụng từ %s sẽ được gỡ bỏ, và bạn sẽ phải cài đặt lại nguồn để sử dụng lại các ứng dụng này."
+msgstr ""
+"Mọi ứng dụng từ %s sẽ được gỡ bỏ, và bạn sẽ phải cài đặt lại nguồn để sử "
+"dụng lại các ứng dụng này."
 
 #. TRANSLATORS: this is a prompt message, and '%s' is an
 #. * application summary, e.g. 'GNOME Clocks'
@@ -1962,12 +2032,14 @@ msgstr "Bạn có chắc là bạn muốn gỡ %s?"
 msgid "%s will be removed, and you will have to install it to use it again."
 msgstr "%s sẽ được xóa bỏ, và bạn sẽ phải cài đặt lại để có thể sử dụng."
 
-#: lib/gs-plugin-loader.c:1429
+#: lib/gs-plugin-loader.c:1433
 #, c-format
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format can be found on the website."
-msgstr "Trên website có thể tìm thấy thông tin về %s cũng như các tùy chọn về cách tải một bộ mã hóa-giải mã có thể phát định dạng này."
+msgstr ""
+"Trên website có thể tìm thấy thông tin về %s cũng như các tùy chọn về cách "
+"tải một bộ mã hóa-giải mã có thể phát định dạng này."
 
 #: lib/gs-price.c:111
 #, c-format
@@ -2026,7 +2098,9 @@ msgstr "%s %f"
 msgid ""
 "Some of the currently installed software is not compatible with %s. If you "
 "continue, the following will be automatically removed during the upgrade:"
-msgstr "Một số phần mềm hiện được cài đặt không tương thích với %s. Nếu bạn tiếp tục, các phần mềm sau sẽ bị tự động gỡ bỏ trong quá trình nâng cấp:"
+msgstr ""
+"Một số phần mềm hiện được cài đặt không tương thích với %s. Nếu bạn tiếp "
+"tục, các phần mềm sau sẽ bị tự động gỡ bỏ trong quá trình nâng cấp:"
 
 #: src/gs-removal-dialog.ui:27
 msgid "Incompatible Software"
@@ -2096,8 +2170,7 @@ msgstr "Mô tả quá ngắn"
 msgid "The description is too long"
 msgstr "Mô tả quá dài"
 
-#. Translators: Title of the dialog box where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Title of the dialog box where the users can write and publish their opinions about the apps.
 #: src/gs-review-dialog.ui:11
 msgid "Post Review"
 msgstr "Đăng Bài đánh giá"
@@ -2115,7 +2188,9 @@ msgstr "Đánh giá"
 msgid ""
 "Give a short summary of your review, for example: “Great app, would "
 "recommend”."
-msgstr "Viết một câu tóm tắt ngắn về đánh giá của bạn, ví dụ: \"Ứng dụng tuyệt vời, sẽ giới thiệu sử dụng\"."
+msgstr ""
+"Viết một câu tóm tắt ngắn về đánh giá của bạn, ví dụ: \"Ứng dụng tuyệt vời, "
+"sẽ giới thiệu sử dụng\"."
 
 #. Translators: This is where the users enter their opinions about the apps.
 #: src/gs-review-dialog.ui:199
@@ -2125,7 +2200,8 @@ msgstr "Đánh giá"
 
 #: src/gs-review-dialog.ui:215
 msgid "What do you think of the app? Try to give reasons for your views."
-msgstr "Bạn nghĩ gì về ứng dụng này? Hãy cố đưa ra các lý do cho nhận xét của bạn."
+msgstr ""
+"Bạn nghĩ gì về ứng dụng này? Hãy cố đưa ra các lý do cho nhận xét của bạn."
 
 #. Translators: A label for the total number of reviews.
 #: src/gs-review-histogram.ui:413
@@ -2135,14 +2211,17 @@ msgstr "tổng số đánh giá"
 #. TRANSLATORS: we explain what the action is going to do
 #: src/gs-review-row.c:234
 msgid "You can report reviews for abusive, rude, or discriminatory behavior."
-msgstr "Bạn có thể báo cáo đánh giá về hành vi lăng mạ, thô lỗ, hoặc phân biệt đối xử."
+msgstr ""
+"Bạn có thể báo cáo đánh giá về hành vi lăng mạ, thô lỗ, hoặc phân biệt đối "
+"xử."
 
 #. TRANSLATORS: we ask the user if they really want to do this
 #: src/gs-review-row.c:239
 msgid ""
 "Once reported, a review will be hidden until it has been checked by an "
 "administrator."
-msgstr "Khi được báo cáo, một đánh giá sẽ bị ẩn đến khi được quản trị viên kiểm tra."
+msgstr ""
+"Khi được báo cáo, một đánh giá sẽ bị ẩn đến khi được quản trị viên kiểm tra."
 
 #. TRANSLATORS: window title when
 #. * reporting a user-submitted review
@@ -2157,8 +2236,7 @@ msgstr "Báo Cáo Đánh Giá?"
 msgid "Report"
 msgstr "Báo cáo"
 
-#. Translators: Users can express their opinions about other users' opinions
-#. about the apps.
+#. Translators: Users can express their opinions about other users' opinions about the apps.
 #: src/gs-review-row.ui:112
 msgid "Was this review useful to you?"
 msgstr "Đánh giá này có hữu ích đối với bạn không?"
@@ -2246,81 +2324,81 @@ msgstr "Không tìm thấy Ứng dụng"
 #. TRANSLATORS: this is part of the in-app notification,
 #. * where the %s is a multi-word localised app name
 #. * e.g. 'Getting things GNOME!"
-#: src/gs-shell.c:846 src/gs-shell.c:851 src/gs-shell.c:866 src/gs-shell.c:870
+#: src/gs-shell.c:847 src/gs-shell.c:852 src/gs-shell.c:867 src/gs-shell.c:871
 #, c-format
 msgid "“%s”"
 msgstr "“%s”"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:898
+#: src/gs-shell.c:899
 #, c-format
 msgid "Unable to download firmware updates from %s"
 msgstr "Không thể tải về các cập nhật phần sụn từ %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:904
+#: src/gs-shell.c:905
 #, c-format
 msgid "Unable to download updates from %s"
 msgstr "Không thể tải về các cập nhật từ %s"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:911
+#: src/gs-shell.c:912
 msgid "Unable to download updates"
 msgstr "Không thể cập nhật các cập nhật"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:916
+#: src/gs-shell.c:917
 msgid ""
-"Unable to download updates: internet access was required but wasn’t "
-"available"
-msgstr "Không thể tải về các bản cập nhật: cần truy cập internet mà không có sẵn"
+"Unable to download updates: internet access was required but wasn’t available"
+msgstr ""
+"Không thể tải về các bản cập nhật: cần truy cập internet mà không có sẵn"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:925
+#: src/gs-shell.c:926
 #, c-format
 msgid "Unable to download updates from %s: not enough disk space"
 msgstr "Không thể tải về các cập nhật từ %s: không đủ dung lượng ổ đĩa"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:930
+#: src/gs-shell.c:931
 msgid "Unable to download updates: not enough disk space"
 msgstr "Không thể tải về các cập nhật: không đủ dung lượng ổ đĩa"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:938
+#: src/gs-shell.c:939
 msgid "Unable to download updates: authentication was required"
 msgstr "Không thể tải về các cập nhật: phải có chứng thực"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:943
+#: src/gs-shell.c:944
 msgid "Unable to download updates: authentication was invalid"
 msgstr "Không thể tải về các bản cập nhật: xác thực không hợp lệ"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:948
+#: src/gs-shell.c:949
 msgid ""
 "Unable to download updates: you do not have permission to install software"
 msgstr "Không thể tải về các cập nhật: bạn không có quyền cài đặt phần mềm"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:955
+#: src/gs-shell.c:956
 msgid "Unable to get list of updates"
 msgstr "Không thể nhận danh sách các cập nhật"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the application name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1001
+#: src/gs-shell.c:1002
 #, c-format
 msgid "Unable to install %s as download failed from %s"
 msgstr "Không thể cài đặt %s do không tải về được từ %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1007
+#: src/gs-shell.c:1008
 #, c-format
 msgid "Unable to install %s as download failed"
 msgstr "Không thể cài đặt %s do không tải về được"
@@ -2329,51 +2407,52 @@ msgstr "Không thể cài đặt %s do không tải về được"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1019
+#: src/gs-shell.c:1020
 #, c-format
 msgid "Unable to install %s as runtime %s not available"
 msgstr "Không thể cài đặt %s do %s chạy thực không khả dụng"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1025
+#: src/gs-shell.c:1026
 #, c-format
 msgid "Unable to install %s as not supported"
 msgstr "Không thể cài đặt %s do không được hỗ trợ"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1032
+#: src/gs-shell.c:1033
 msgid "Unable to install: internet access was required but wasn’t available"
-msgstr "Không thể cài đặt: quyền truy cập internet là bắt buộc nhưng không khả dụng"
+msgstr ""
+"Không thể cài đặt: quyền truy cập internet là bắt buộc nhưng không khả dụng"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1038
+#: src/gs-shell.c:1039
 msgid "Unable to install: the application has an invalid format"
 msgstr "Không thể cài đặt: ứng dụng có định dạng không hợp lệ"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1043
+#: src/gs-shell.c:1044
 #, c-format
 msgid "Unable to install %s: not enough disk space"
 msgstr "Không thể cài đặt %s: không đủ dung lượng ổ đĩa"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1051
+#: src/gs-shell.c:1052
 #, c-format
 msgid "Unable to install %s: authentication was required"
 msgstr "Không thể cài đặt %s: phải có chứng thực"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1058
+#: src/gs-shell.c:1059
 #, c-format
 msgid "Unable to install %s: authentication was invalid"
 msgstr "Không thể cài đặt %s: chứng thực không hợp lệ"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1065
+#: src/gs-shell.c:1066
 #, c-format
 msgid "Unable to install %s: you do not have permission to install software"
 msgstr "Không thể cài đặt %s: bạn không có quyền cài đặt phần mềm"
@@ -2381,34 +2460,34 @@ msgstr "Không thể cài đặt %s: bạn không có quyền cài đặt phần
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the name of the authentication service,
 #. * e.g. "Ubuntu One"
-#: src/gs-shell.c:1078
+#: src/gs-shell.c:1079
 #, c-format
 msgid "Your %s account has been suspended."
 msgstr "Tài khoản %s của bạn đã bị khóa."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1082
+#: src/gs-shell.c:1083
 msgid "It is not possible to install software until this has been resolved."
 msgstr "Không thể cài đặt phần mềm khi vấn đề này chưa được giải quyết."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the clickable link (e.g.
 #. * "http://example.com/what-did-i-do-wrong/")
-#: src/gs-shell.c:1093
+#: src/gs-shell.c:1094
 #, c-format
 msgid "For more information, visit %s."
 msgstr "Để biết thêm thông tin, hãy truy cập %s."
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1102
+#: src/gs-shell.c:1103
 #, c-format
 msgid "Unable to install %s: AC power is required"
 msgstr "Không thể cài đặt %s: Cần phải có nguồn điện xoay chiều"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1111
+#: src/gs-shell.c:1112
 #, c-format
 msgid "Unable to install %s"
 msgstr "Không thể cài đặt %s"
@@ -2417,61 +2496,61 @@ msgstr "Không thể cài đặt %s"
 #. * where the first %s is the app name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1157
+#: src/gs-shell.c:1158
 #, c-format
 msgid "Unable to update %s from %s"
 msgstr "Không thể cập nhật %s từ %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1163
+#: src/gs-shell.c:1164
 #, c-format
 msgid "Unable to update %s as download failed"
 msgstr "Không thể cập nhật %s do không tải về được"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1169
+#: src/gs-shell.c:1170
 msgid "Unable to update: internet access was required but wasn’t available"
 msgstr "Không thể cập nhật: cần truy cập internet nhưng không có sẵn"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1177
+#: src/gs-shell.c:1178
 #, c-format
 msgid "Unable to update %s: not enough disk space"
 msgstr "Không thể cập nhật %s: không đủ dung lượng ổ đĩa"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1186
+#: src/gs-shell.c:1187
 #, c-format
 msgid "Unable to update %s: authentication was required"
 msgstr "Không thể cập nhật %s: cần có chứng thực"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1193
+#: src/gs-shell.c:1194
 #, c-format
 msgid "Unable to update %s: authentication was invalid"
 msgstr "Không thể cập nhật %s: chứng thực không hợp lệ"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1200
+#: src/gs-shell.c:1201
 #, c-format
 msgid "Unable to update %s: you do not have permission to update software"
 msgstr "Không thể cập nhật %s: bạn không được phép cập nhật phần mềm"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1208
+#: src/gs-shell.c:1209
 #, c-format
 msgid "Unable to update %s: AC power is required"
 msgstr "Không thể cập nhật %s: cần phải có nguồn điện xoay chiều"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1217
+#: src/gs-shell.c:1218
 #, c-format
 msgid "Unable to update %s"
 msgstr "Không thể cập nhật %s"
@@ -2479,96 +2558,96 @@ msgstr "Không thể cập nhật %s"
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the distro name (e.g. "Fedora 25") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1262
+#: src/gs-shell.c:1263
 #, c-format
 msgid "Unable to upgrade to %s from %s"
 msgstr "Không thể nâng cấp lên %s từ %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the app name (e.g. "GIMP")
-#: src/gs-shell.c:1267
+#: src/gs-shell.c:1268
 #, c-format
 msgid "Unable to upgrade to %s as download failed"
 msgstr "Không thể nâng cấp lên %s do không tải về được"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1274
+#: src/gs-shell.c:1275
 msgid "Unable to upgrade: internet access was required but wasn’t available"
 msgstr "Không thể nâng cấp: cần truy cập internet nhưng không có sẵn"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1282
+#: src/gs-shell.c:1283
 #, c-format
 msgid "Unable to upgrade to %s: not enough disk space"
 msgstr "Không thể nâng cấp lên %s: không đủ dung lượng ổ đĩa"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1291
+#: src/gs-shell.c:1292
 #, c-format
 msgid "Unable to upgrade to %s: authentication was required"
 msgstr "Không thể nâng cấp lên %s: cần có chứng thực"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1298
+#: src/gs-shell.c:1299
 #, c-format
 msgid "Unable to upgrade to %s: authentication was invalid"
 msgstr "Không thể nâng cấp lên %s: chứng thực không hợp lệ"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1305
+#: src/gs-shell.c:1306
 #, c-format
 msgid "Unable to upgrade to %s: you do not have permission to upgrade"
 msgstr "Không thể nâng cấp lên %s: bạn không có quyền nâng cấp"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1312
+#: src/gs-shell.c:1313
 #, c-format
 msgid "Unable to upgrade to %s: AC power is required"
 msgstr "Không thể nâng cấp lên %s: cần phải có nguồn điện xoay chiều"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1321
+#: src/gs-shell.c:1322
 #, c-format
 msgid "Unable to upgrade to %s"
 msgstr "Không thể nâng cấp lên %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1363
+#: src/gs-shell.c:1364
 #, c-format
 msgid "Unable to remove %s: authentication was required"
 msgstr "Không thể gỡ bỏ %s: cần có chứng thực"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1369
+#: src/gs-shell.c:1370
 #, c-format
 msgid "Unable to remove %s: authentication was invalid"
 msgstr "Không thể gỡ bỏ %s: chứng thực không hợp lệ"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1375
+#: src/gs-shell.c:1376
 #, c-format
 msgid "Unable to remove %s: you do not have permission to remove software"
 msgstr "Không thể xóa bỏ %s: bạn không được phép xóa bỏ phần mềm"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1382
+#: src/gs-shell.c:1383
 #, c-format
 msgid "Unable to remove %s: AC power is required"
 msgstr "Không thể di chuyển %s: Cần phải có nguồn điện xoay chiều"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1391
+#: src/gs-shell.c:1392
 #, c-format
 msgid "Unable to remove %s"
 msgstr "Không thể gỡ %s"
@@ -2577,48 +2656,49 @@ msgstr "Không thể gỡ %s"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1437
+#: src/gs-shell.c:1438
 #, c-format
 msgid "Unable to launch %s: %s is not installed"
 msgstr "Không thể khởi chạy %s: %s không được cài đặt"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1444 src/gs-shell.c:1492 src/gs-shell.c:1540
+#: src/gs-shell.c:1445 src/gs-shell.c:1493 src/gs-shell.c:1541
 msgid "Not enough disk space — free up some space and try again"
 msgstr "Không đủ dung lượng ổ đĩa — giải phóng một ít dung lượng và thử lại"
 
 #. TRANSLATORS: we failed to get a proper error code
-#: src/gs-shell.c:1452 src/gs-shell.c:1500 src/gs-shell.c:1567
+#: src/gs-shell.c:1453 src/gs-shell.c:1501 src/gs-shell.c:1568
 msgid "Sorry, something went wrong"
 msgstr "Rấc tiếc, có lỗi xảy ra"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1487
+#: src/gs-shell.c:1488
 msgid "Failed to install file: authentication failed"
 msgstr "Không cài đặt được tệp: quá trình chứng thực thất bại"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1534
+#: src/gs-shell.c:1535
 #, c-format
 msgid "Unable to contact %s"
 msgstr "Không thể liên hệ %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1549
+#: src/gs-shell.c:1550
 #, c-format
 msgid "%s needs to be restarted to use new plugins."
 msgstr "Cần phải khởi động lại %s để sử dụng các plugin mới."
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1554
+#: src/gs-shell.c:1555
 msgid "This application needs to be restarted to use new plugins."
-msgstr "Cần phải khởi động lại ứng dụng này để sử dụng các tiện ích (plugin) mới."
+msgstr ""
+"Cần phải khởi động lại ứng dụng này để sử dụng các tiện ích (plugin) mới."
 
 #. TRANSLATORS: need to be connected to the AC power
-#: src/gs-shell.c:1561
+#: src/gs-shell.c:1562
 msgid "AC power is required"
 msgstr "Cần phải có nguồn điền xoay chiều"
 
@@ -2626,7 +2706,9 @@ msgstr "Cần phải có nguồn điền xoay chiều"
 #. has no software installed from it.
 #: src/gs-sources-dialog.c:98
 msgid "No applications or addons installed; other software might still be"
-msgstr "Không có ứng dụng hoặc tiện ích bổ sung nào được cài đặt; các ứng dụng khác có thể vẫn được cài đặt"
+msgstr ""
+"Không có ứng dụng hoặc tiện ích bổ sung nào được cài đặt; các ứng dụng khác "
+"có thể vẫn được cài đặt"
 
 #. TRANSLATORS: This string is used to construct the 'X applications
 #. installed' sentence, describing a software source.
@@ -2700,7 +2782,9 @@ msgstr "hệ điều hành"
 msgid ""
 "Software sources can be downloaded from the internet. They give you access "
 "to additional software that is not provided by %s."
-msgstr "Có thể tải các mã nguồn phần mềm từ internet. Chúng cho phép bạn truy cập vào phần mềm bổ sung mà %s không cung cấp."
+msgstr ""
+"Có thể tải các mã nguồn phần mềm từ internet. Chúng cho phép bạn truy cập "
+"vào phần mềm bổ sung mà %s không cung cấp."
 
 #: src/gs-sources-dialog.ui:155
 msgid "Additional Sources"
@@ -2709,7 +2793,8 @@ msgstr "Nguồn Bổ sung"
 #: src/gs-sources-dialog.ui:175
 msgid ""
 "Removing a source will also remove any software you have installed from it."
-msgstr "Khi gỡ một nguồn, bất kỳ phần mềm nào mà bạn đã cài đặt từ đó cũng sẽ bị gỡ."
+msgstr ""
+"Khi gỡ một nguồn, bất kỳ phần mềm nào mà bạn đã cài đặt từ đó cũng sẽ bị gỡ."
 
 #: src/gs-sources-dialog.ui:260
 msgid "No software installed from this source"
@@ -2816,7 +2901,8 @@ msgstr "Đã có các Bản cập nhật Phần mềm"
 
 #: src/gs-update-monitor.c:97
 msgid "Important OS and application updates are ready to be installed"
-msgstr "Các cập nhật ứng dụng và hệ điều hành quan trọng đã sẵn sàng để được cài đặt"
+msgstr ""
+"Các cập nhật ứng dụng và hệ điều hành quan trọng đã sẵn sàng để được cài đặt"
 
 #. TRANSLATORS: button text
 #: src/gs-update-monitor.c:100 src/gs-updates-page.c:775
@@ -2905,16 +2991,20 @@ msgstr "Bản cập nhật đã bị hủy bỏ."
 #. * something with no network available
 #: src/gs-update-monitor.c:714
 msgid ""
-"Internet access was required but wasn’t available. Please make sure that you"
-" have internet access and try again."
-msgstr "Cần truy cập Internet nhưng đã không có sẵn. Vui lòng đảm bảo rằng bạn có truy cập internet và thử lại."
+"Internet access was required but wasn’t available. Please make sure that you "
+"have internet access and try again."
+msgstr ""
+"Cần truy cập Internet nhưng đã không có sẵn. Vui lòng đảm bảo rằng bạn có "
+"truy cập internet và thử lại."
 
 #. TRANSLATORS: if the package is not signed correctly
 #: src/gs-update-monitor.c:720
 msgid ""
 "There were security issues with the update. Please consult your software "
 "provider for more details."
-msgstr "Có vấn đề về an ninh với bản cập nhật. Vui lòng tham vấn nhà cung cấp phần mềm của bạn để biết thêm chi tiết."
+msgstr ""
+"Có vấn đề về an ninh với bản cập nhật. Vui lòng tham vấn nhà cung cấp phần "
+"mềm của bạn để biết thêm chi tiết."
 
 #. TRANSLATORS: we ran out of disk space
 #: src/gs-update-monitor.c:726
@@ -2927,7 +3017,10 @@ msgstr "Dung lượng đĩa không đủ. Vui lòng giải phóng dung lượng 
 msgid ""
 "We’re sorry: the update failed to install. Please wait for another update "
 "and try again. If the problem persists, contact your software provider."
-msgstr "Chúng tôi rất tiếc: không cài đặt được bản cập nhật này. Vui lòng đợi bản cập nhật khác và thử lại. Nếu vấn đề còn tiếp diễn, hãy liên hệ với nhà cung cấp phần mềm của bạn."
+msgstr ""
+"Chúng tôi rất tiếc: không cài đặt được bản cập nhật này. Vui lòng đợi bản "
+"cập nhật khác và thử lại. Nếu vấn đề còn tiếp diễn, hãy liên hệ với nhà cung "
+"cấp phần mềm của bạn."
 
 #. TRANSLATORS: Time in 24h format
 #: src/gs-updates-page.c:297
@@ -3089,7 +3182,8 @@ msgstr "HĐH của bạn không còn được hỗ trợ."
 #. TRANSLATORS: EOL distros do not get important updates
 #: src/gs-updates-page.c:1144
 msgid "This means that it does not receive security updates."
-msgstr "Điều này có nghĩa là distro EOL không nhận được những cập nhật bảo mật."
+msgstr ""
+"Điều này có nghĩa là distro EOL không nhận được những cập nhật bảo mật."
 
 #. TRANSLATORS: upgrade refers to a major update, e.g. Fedora 25 to 26
 #: src/gs-updates-page.c:1148
@@ -3107,7 +3201,9 @@ msgstr "Có thể thu phí"
 msgid ""
 "Checking for updates while using mobile broadband could cause you to incur "
 "charges."
-msgstr "Việc kiểm tra các cập nhật trong khi sử dụng băng thông rộng di động có thể khiến bạn phải trả phí."
+msgstr ""
+"Việc kiểm tra các cập nhật trong khi sử dụng băng thông rộng di động có thể "
+"khiến bạn phải trả phí."
 
 #. TRANSLATORS: this is a link to the
 #. * control-center network panel
@@ -3146,7 +3242,9 @@ msgstr "Phần mềm hiện đã cập nhật"
 msgid ""
 "Checking for updates when using mobile broadband could cause you to incur "
 "charges"
-msgstr "Tìm duyệt các bản cập nhật khi đang truy cập Internet băng rộng di động có thể khiến bạn bị phát sinh chi phí"
+msgstr ""
+"Tìm duyệt các bản cập nhật khi đang truy cập Internet băng rộng di động có "
+"thể khiến bạn bị phát sinh chi phí"
 
 #: src/gs-updates-page.ui:257
 msgid "_Check Anyway"
@@ -3211,22 +3309,27 @@ msgid "App Center"
 msgstr "Trung tâm Ứng dụng"
 
 #: src/org.gnome.Software.desktop.in:4
+msgid "More Apps"
+msgstr "Ứng dụng khác"
+
+#: src/org.gnome.Software.desktop.in:5
 msgid "Add, remove or update software on this computer"
 msgstr "Cài thêm, xóa hoặc cập nhật phần mềm trên máy tính này"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
-#: src/org.gnome.Software.desktop.in:6
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: src/org.gnome.Software.desktop.in:7
 #: src/org.gnome.Software.Editor.desktop.in:6
 msgid "org.gnome.Software"
 msgstr "org.gnome.Software"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
-#: src/org.gnome.Software.desktop.in:12
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: src/org.gnome.Software.desktop.in:13
 msgid ""
-"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;"
-msgstr "Bản cập nhật;Nâng cấp;Mã nguồn;Kho chứa mã;Ưu tiên;Cài đặt;Hủy cài đặt;Chương trình;Phần mềm;Ứng dụng;Cửa hàng;"
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;"
+msgstr ""
+"Bản cập nhật;Nâng cấp;Mã nguồn;Kho chứa mã;Ưu tiên;Cài đặt;Hủy cài đặt;"
+"Chương trình;Phần mềm;Ứng dụng;Cửa hàng;"
 
 #: src/org.gnome.Software.Editor.desktop.in:3
 msgid "Banner Designer"
@@ -3236,8 +3339,7 @@ msgstr "Nhà thiết kế Banner"
 msgid "Design the featured banners for GNOME Software"
 msgstr "Thiết kế các banner đặc sắc cho Phần mềm GNOME"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: src/org.gnome.Software.Editor.desktop.in:13
 msgid "AppStream;Software;App;"
 msgstr "AppStream;Phần mềm;Ứng dụng;"
@@ -3507,100 +3609,111 @@ msgctxt "Menu of Communication & News"
 msgid "Web Browsers"
 msgstr "Trình duyệt Web"
 
-#: plugins/core/gs-desktop-common.c:247
-msgctxt "Menu of Reference"
-msgid "All"
-msgstr "Tất cả"
-
-#: plugins/core/gs-desktop-common.c:250
-msgctxt "Menu of Reference"
-msgid "Featured"
-msgstr "Nổi bật"
-
-#: plugins/core/gs-desktop-common.c:253
-msgctxt "Menu of Reference"
-msgid "Art"
-msgstr "Nghệ thuật"
-
-#: plugins/core/gs-desktop-common.c:256
-msgctxt "Menu of Reference"
-msgid "Biography"
-msgstr "Tiểu sử"
-
-#: plugins/core/gs-desktop-common.c:259
-msgctxt "Menu of Reference"
-msgid "Comics"
-msgstr "Truyện tranh"
-
-#: plugins/core/gs-desktop-common.c:262
-msgctxt "Menu of Reference"
-msgid "Fiction"
-msgstr "Tiểu thuyết"
-
-#: plugins/core/gs-desktop-common.c:265
-msgctxt "Menu of Reference"
-msgid "Health"
-msgstr "Sức khỏe"
-
-#: plugins/core/gs-desktop-common.c:268
-msgctxt "Menu of Reference"
-msgid "History"
-msgstr "Lịch sử"
-
-#: plugins/core/gs-desktop-common.c:271
-msgctxt "Menu of Reference"
-msgid "Lifestyle"
-msgstr "Lối sống"
-
-#: plugins/core/gs-desktop-common.c:274
+#: plugins/core/gs-desktop-common.c:242
 msgctxt "Menu of Communication & News"
 msgid "News"
 msgstr "TIn tức"
 
+#: plugins/core/gs-desktop-common.c:251
+msgctxt "Menu of Reference"
+msgid "All"
+msgstr "Tất cả"
+
+#: plugins/core/gs-desktop-common.c:254
+msgctxt "Menu of Reference"
+msgid "Featured"
+msgstr "Nổi bật"
+
+#: plugins/core/gs-desktop-common.c:257
+msgctxt "Menu of Reference"
+msgid "Art"
+msgstr "Nghệ thuật"
+
+#: plugins/core/gs-desktop-common.c:260
+msgctxt "Menu of Reference"
+msgid "Biography"
+msgstr "Tiểu sử"
+
+#: plugins/core/gs-desktop-common.c:263
+msgctxt "Menu of Reference"
+msgid "Comics"
+msgstr "Truyện tranh"
+
+#: plugins/core/gs-desktop-common.c:266
+msgctxt "Menu of Reference"
+msgid "Feed"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:269
+msgctxt "Menu of Reference"
+msgid "Fiction"
+msgstr "Tiểu thuyết"
+
+#: plugins/core/gs-desktop-common.c:272
+msgctxt "Menu of Reference"
+msgid "Health"
+msgstr "Sức khỏe"
+
+#: plugins/core/gs-desktop-common.c:275
+msgctxt "Menu of Reference"
+msgid "History"
+msgstr "Lịch sử"
+
 #: plugins/core/gs-desktop-common.c:278
+msgctxt "Menu of Reference"
+msgid "Lifestyle"
+msgstr "Lối sống"
+
+#: plugins/core/gs-desktop-common.c:281
+#, fuzzy
+msgctxt "Menu of Reference"
+msgid "News"
+msgstr "TIn tức"
+
+#: plugins/core/gs-desktop-common.c:284
 msgctxt "Menu of Reference"
 msgid "Politics"
 msgstr "Chính trị"
 
-#: plugins/core/gs-desktop-common.c:281
+#: plugins/core/gs-desktop-common.c:287
 msgctxt "Menu of Reference"
 msgid "Sports"
 msgstr "Thể thao"
 
 #. TRANSLATORS: this is the menu spec main category for Learning
-#: plugins/core/gs-desktop-common.c:291
+#: plugins/core/gs-desktop-common.c:297
 msgid "Learning"
 msgstr "Học tập"
 
 #. TRANSLATORS: this is the menu spec main category for Game
-#: plugins/core/gs-desktop-common.c:294
+#: plugins/core/gs-desktop-common.c:300
 msgid "Games"
 msgstr "Trò chơi"
 
 #. TRANSLATORS: this is the menu spec main category for Multimedia
-#: plugins/core/gs-desktop-common.c:297
+#: plugins/core/gs-desktop-common.c:303
 msgid "Multimedia"
 msgstr "Đa phương tiện"
 
 #. TRANSLATORS: this is the menu spec main category for Work
-#: plugins/core/gs-desktop-common.c:300
+#: plugins/core/gs-desktop-common.c:306
 msgid "Work"
 msgstr "Công việc"
 
 #. TRANSLATORS: this is the menu spec main category for Reference
-#: plugins/core/gs-desktop-common.c:303
+#: plugins/core/gs-desktop-common.c:309
 msgid "Reference & News"
 msgstr "Thông tin tham khảo & Tin tức"
 
 #. TRANSLATORS: this is the menu spec main category for Utilities
-#: plugins/core/gs-desktop-common.c:306
+#: plugins/core/gs-desktop-common.c:312
 msgid "Utilities"
 msgstr "Các tiện ích"
 
 #. TRANSLATORS: this is the menu spec main category for Dev Tools; it
 #. * should be a relatively short label; as an example, in Portuguese and
 #. * Spanish the direct translation of "Programming" (noun) is used
-#: plugins/core/gs-desktop-common.c:311
+#: plugins/core/gs-desktop-common.c:317
 msgid "Dev Tools"
 msgstr "Lập trình"
 
@@ -3626,16 +3739,16 @@ msgstr "Bao gồm cải thiện về hiệu suất, tính ổn định và bảo
 msgid "Downloading featured images…"
 msgstr "Đang tải hình ảnh đặc sắc..."
 
-#: plugins/eos/gs-plugin-eos.c:1249
+#: plugins/eos/gs-plugin-eos.c:1233
 #, c-format
 msgid "Could not launch this application."
 msgstr "Không thể khởi chạy ứng dụng này"
 
-#: plugins/eos/gs-plugin-eos.c:1305
+#: plugins/eos/gs-plugin-eos.c:1289
 msgid "Endless Platform"
 msgstr "Nền tảng Endless"
 
-#: plugins/eos/gs-plugin-eos.c:1308
+#: plugins/eos/gs-plugin-eos.c:1292
 msgid "Framework for applications"
 msgstr "Khung cho các ứng dụng"
 
@@ -3684,7 +3797,8 @@ msgstr "Đang tải xuống thông tin nâng cấp..."
 #. TRANSLATORS: this is a title for Fedora distro upgrades
 #: plugins/fedora-pkgdb-collections/gs-plugin-fedora-pkgdb-collections.c:303
 msgid "Upgrade your Fedora system to the latest features and improvements."
-msgstr "Nâng cấp hệ thống Fedora của bạn lên các tính năng và cải tiến mới nhất."
+msgstr ""
+"Nâng cấp hệ thống Fedora của bạn lên các tính năng và cải tiến mới nhất."
 
 #: plugins/flatpak/org.gnome.Software.Plugin.Flatpak.metainfo.xml.in:6
 msgid "Flatpak Support"
@@ -3692,16 +3806,17 @@ msgstr "Hỗ trợ Flatpak"
 
 #: plugins/flatpak/org.gnome.Software.Plugin.Flatpak.metainfo.xml.in:7
 msgid "Flatpak is a framework for desktop applications on Linux"
-msgstr "Flatpak là một chương trình khung cho các ứng dụng máy tính chạy trên Linux"
+msgstr ""
+"Flatpak là một chương trình khung cho các ứng dụng máy tính chạy trên Linux"
 
 #. TRANSLATORS: status text when downloading new metadata
-#: plugins/flatpak/gs-flatpak.c:821
+#: plugins/flatpak/gs-flatpak.c:815
 #, c-format
 msgid "Getting flatpak metadata for %s…"
 msgstr "Đang tải siêu dữ liệu flatapak cho %s..."
 
 #. TRANSLATORS: status text when downloading the RuntimeRepo
-#: plugins/flatpak/gs-flatpak.c:2796
+#: plugins/flatpak/gs-flatpak.c:2803
 msgid "Getting runtime source…"
 msgstr "Đang nhận nguồn thời gian chạy..."
 
@@ -3734,7 +3849,8 @@ msgstr "Hỗ trợ Limba"
 
 #: plugins/limba/org.gnome.Software.Plugin.Limba.metainfo.xml.in:7
 msgid "Limba provides developers a way to easily create software bundles"
-msgstr "Limba mang đến cho các lập trình viên một cách tạo các gói phần mềm dễ dàng"
+msgstr ""
+"Limba mang đến cho các lập trình viên một cách tạo các gói phần mềm dễ dàng"
 
 #. TRANSLATORS: status text when downloading
 #: plugins/odrs/gs-plugin-odrs.c:205
@@ -3747,7 +3863,9 @@ msgstr "Hỗ trợ Đánh giá Desktop Mở (ODRS)"
 
 #: plugins/odrs/org.gnome.Software.Plugin.Odrs.metainfo.xml.in:7
 msgid "ODRS is a service providing user reviews of applications"
-msgstr "ODRS là một dịch vụ cung cấp các nhận xét, bình luận của người dùng về các ứng dụng"
+msgstr ""
+"ODRS là một dịch vụ cung cấp các nhận xét, bình luận của người dùng về các "
+"ứng dụng"
 
 #. TRANSLATORS: status text when downloading
 #: plugins/shell-extensions/gs-plugin-shell-extensions.c:669

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the gnome-software package.
-# 
+#
 # Translators:
 # Bin Li <binli@gnome.org>, 2016
 # chenzibing <chenzibing_endless@126.com>, 2016
@@ -28,14 +28,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-software\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-12 22:31-0700\n"
+"POT-Creation-Date: 2017-11-02 16:28+0100\n"
 "PO-Revision-Date: 2017-10-17 04:25+0000\n"
 "Last-Translator: CN C2 <e2f48d4sf5ds@outlook.com>\n"
-"Language-Team: Chinese (China) (http://www.transifex.com/endless-mobile-inc/gnome-software/language/zh_CN/)\n"
+"Language-Team: Chinese (China) (http://www.transifex.com/endless-mobile-inc/"
+"gnome-software/language/zh_CN/)\n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_CN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:7
@@ -58,7 +59,10 @@ msgid ""
 "descriptions and multiple screenshots per application. Applications can be "
 "found either through browsing the list of categories or by searching. It "
 "also allows you to update your system using an offline update."
-msgstr "GNOME 软件 向您展示特色和流行的应用程序，并提供每个应用程序的描述、截图等有用信息。您可以通过浏览分类列表或搜索来找到应用程序。您还可以用它离线更新您的系统。"
+msgstr ""
+"GNOME 软件 向您展示特色和流行的应用程序，并提供每个应用程序的描述、截图等有用"
+"信息。您可以通过浏览分类列表或搜索来找到应用程序。您还可以用它离线更新您的系"
+"统。"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:25
 msgid "Overview panel"
@@ -102,7 +106,8 @@ msgstr "是否管理GNOME Software中的更新"
 msgid ""
 "If disabled, GNOME Software will hide the updates panel and not perform any "
 "automatic updates actions."
-msgstr "如果已禁用，则 GNOME Software 将隐藏更新面板且不会执行任何自动更新操作。"
+msgstr ""
+"如果已禁用，则 GNOME Software 将隐藏更新面板且不会执行任何自动更新操作。"
 
 #: data/org.gnome.software.gschema.xml:15
 msgid "Whether to automatically download updates"
@@ -110,8 +115,8 @@ msgstr "是否自动下载更新"
 
 #: data/org.gnome.software.gschema.xml:16
 msgid ""
-"If enabled, GNOME Software automatically downloads updates in the background"
-" and prompts the user to install them when ready."
+"If enabled, GNOME Software automatically downloads updates in the background "
+"and prompts the user to install them when ready."
 msgstr "如开启，GNOME 软件 将自动在后台下载更新并在准备好时提示用户安装。"
 
 #: data/org.gnome.software.gschema.xml:20
@@ -123,7 +128,9 @@ msgid ""
 "If enabled, GNOME Software automatically refreshes in the background even "
 "when using a metered connection (eventually downloading some metadata, "
 "checking for updates, etc., which may incur in costs for the user)."
-msgstr "如果已启用，即使使用按流量计费的连接，GNOME Software 仍会在后台自动刷新（最终会下载某些元数据、检查更新等，上述操作可能会消耗用户成本）。"
+msgstr ""
+"如果已启用，即使使用按流量计费的连接，GNOME Software 仍会在后台自动刷新（最终"
+"会下载某些元数据、检查更新等，上述操作可能会消耗用户成本）。"
 
 #: data/org.gnome.software.gschema.xml:25
 msgid "Whether it’s the very first run of GNOME Software"
@@ -143,8 +150,8 @@ msgstr "在安装非自由应用程序前显示警告对话框"
 
 #: data/org.gnome.software.gschema.xml:38
 msgid ""
-"When non-free applications are installed a warning dialog can be shown. This"
-" controls if that dialog is suppressed."
+"When non-free applications are installed a warning dialog can be shown. This "
+"controls if that dialog is suppressed."
 msgstr "在安装非自由应用程序时显示警告对话框。该选项控制是否禁用此对话框。"
 
 #: data/org.gnome.software.gschema.xml:42
@@ -188,9 +195,11 @@ msgstr "以秒为单位的时间用于验证上游截图是否仍有效"
 #: data/org.gnome.software.gschema.xml:69
 msgid ""
 "Choosing a larger value will mean less round-trips to the remote server but "
-"updates to the screenshots may take longer to show to the user. A value of 0"
-" means to never check the server if the image already exists in the cache."
-msgstr "选择较大值将意味着减少到远程服务器的往返行程，而用户需要更长时间才会看到截图的更新。如果图像已经存在于高速缓存中，则值0意味着从不检查服务器。"
+"updates to the screenshots may take longer to show to the user. A value of 0 "
+"means to never check the server if the image already exists in the cache."
+msgstr ""
+"选择较大值将意味着减少到远程服务器的往返行程，而用户需要更长时间才会看到截图"
+"的更新。如果图像已经存在于高速缓存中，则值0意味着从不检查服务器。"
 
 #: data/org.gnome.software.gschema.xml:78
 msgid "The server to use for application reviews"
@@ -214,13 +223,11 @@ msgstr "被当作自由软件的官方源列表"
 
 #: data/org.gnome.software.gschema.xml:95
 msgid ""
-"The licence URL to use when an application should be considered free "
-"software"
+"The licence URL to use when an application should be considered free software"
 msgstr "应用程序为自由软件时要使用的许可 URL"
 
 #: data/org.gnome.software.gschema.xml:99
-msgid ""
-"Install bundled applications for all users on the system where possible"
+msgid "Install bundled applications for all users on the system where possible"
 msgstr "尝试为系统上所有的用户安装套装软件"
 
 #: data/org.gnome.software.gschema.xml:103
@@ -287,8 +294,7 @@ msgstr "软件安装"
 msgid "Install selected software on the system"
 msgstr "安装选中的软件到系统上"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 #: src/gnome-software-local-file.desktop.in:10
 msgid "system-software-install"
 msgstr "system-software-install"
@@ -315,14 +321,12 @@ msgstr "返回"
 msgid "_All"
 msgstr "全部(_A)"
 
-#. Translators: A label for a button to show only software which is already
-#. installed.
+#. Translators: A label for a button to show only software which is already installed.
 #: src/gnome-software.ui:104
 msgid "_Installed"
 msgstr "已安装(_I)"
 
-#. Translators: A label for a button to show only updates which are available
-#. to install.
+#. Translators: A label for a button to show only updates which are available to install.
 #: src/gnome-software.ui:155
 msgid "_Updates"
 msgstr "更新(_U)"
@@ -370,7 +374,7 @@ msgstr "已安装"
 
 #. TRANSLATORS: this is a button next to the search results that
 #. * shows the status of an application being installed
-#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:443
+#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:439
 msgid "Installing"
 msgstr "正在安装"
 
@@ -385,7 +389,7 @@ msgid "Folder Name"
 msgstr "目录名"
 
 #: src/gs-app-folder-dialog.c:321 src/gs-app-folder-dialog.ui:16
-#: src/gs-details-page.c:383 src/gs-details-page.ui:342 src/gs-editor.c:623
+#: src/gs-details-page.c:379 src/gs-details-page.ui:342 src/gs-editor.c:623
 #: src/gs-editor.c:655 src/gs-installed-page.c:609 src/gs-removal-dialog.ui:33
 #: src/gs-review-dialog.ui:23 src/gs-upgrade-banner.ui:131
 msgid "_Cancel"
@@ -400,90 +404,98 @@ msgid "Add to Application Folder"
 msgstr "添加到应用程序文件夹"
 
 #. TRANSLATORS: this is a command line option
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "Start up mode: either ‘updates’, ‘updated’, ‘installed’ or ‘overview’"
 msgstr "启动模式：可选“updates”、“updated”、“installed”或“overview”"
 
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "MODE"
 msgstr "模式"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "Search for applications"
 msgstr "搜索应用程序"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "SEARCH"
 msgstr "搜索"
 
-#: src/gs-application.c:105
+#: src/gs-application.c:133
 msgid "Show application details (using application ID)"
 msgstr "显示应用程序详情（使用应用程序 ID）"
 
-#: src/gs-application.c:105 src/gs-application.c:109
+#: src/gs-application.c:133 src/gs-application.c:137
 msgid "ID"
 msgstr "ID"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "Show application details (using package name)"
 msgstr "显示应用程序详情（使用软件包名）"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "PKGNAME"
 msgstr "软件包名"
 
-#: src/gs-application.c:109
+#: src/gs-application.c:137
 msgid "Install the application (using application ID)"
 msgstr "安装应用（使用应用ID）"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "Open a local package file"
 msgstr "打开一个本地的软件包文件"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "FILENAME"
 msgstr "文件名"
 
-#: src/gs-application.c:113
+#: src/gs-application.c:141
 msgid ""
 "The kind of interaction expected for this action: either ‘none’, ‘notify’, "
 "or ‘full’"
 msgstr "此操作的预期交互类型为：“无”、“通知”或“全部”"
 
-#: src/gs-application.c:116
+#: src/gs-application.c:144
 msgid "Show verbose debugging information"
 msgstr "显示详细的调试信息"
 
-#: src/gs-application.c:118
+#: src/gs-application.c:146
 msgid "Show profiling information for the service"
 msgstr "显示服务分析信息"
 
-#: src/gs-application.c:120
+#: src/gs-application.c:148
 msgid "Quit the running instance"
 msgstr "退出运行中的实例"
 
-#: src/gs-application.c:122
+#: src/gs-application.c:150
 msgid "Prefer local file sources to AppStream"
 msgstr "对 AppStream 优先使用本地文件源"
 
-#: src/gs-application.c:124
+#: src/gs-application.c:152
 msgid "Show version number"
 msgstr "显示版本号"
 
-#: src/gs-application.c:325
+#: src/gs-application.c:358
 msgid "translator-credits"
-msgstr "eternalhui <www.eternalhui@gmail.com>, 2013\ntuhaihe <1132321739qq@gmail.com>, 2013\nTong Hui <tonghuix@gmail.com>, 2014\nMingye Wang <arthur2e5@gmail.com>, 2015\nJeff Bai <jeffbai@aosc.xyz>, 2015, 2016\nBin Li <binli@gnome.org>, 2016\nDingzhong Chen <wsxy162@gmail.com>, 2015, 2016\nMichael Chen <searchends@gnu.hk>, 2016"
+msgstr ""
+"eternalhui <www.eternalhui@gmail.com>, 2013\n"
+"tuhaihe <1132321739qq@gmail.com>, 2013\n"
+"Tong Hui <tonghuix@gmail.com>, 2014\n"
+"Mingye Wang <arthur2e5@gmail.com>, 2015\n"
+"Jeff Bai <jeffbai@aosc.xyz>, 2015, 2016\n"
+"Bin Li <binli@gnome.org>, 2016\n"
+"Dingzhong Chen <wsxy162@gmail.com>, 2015, 2016\n"
+"Michael Chen <searchends@gnu.hk>, 2016"
 
 #. TRANSLATORS: this is the title of the about window, e.g.
 #. * 'About Software' or 'About Application Installer' where the %s is
 #. * the application name chosen by the distro
-#: src/gs-application.c:332
+#: src/gs-application.c:365
 #, c-format
 msgid "About %s"
 msgstr "关于 %s"
 
 #. TRANSLATORS: well, we seem to think so, anyway
-#: src/gs-application.c:336
+#: src/gs-application.c:369
 msgid "A nice way to manage the software on your system."
 msgstr "一种管理您系统中软件的好方法。"
 
@@ -598,7 +610,7 @@ msgid "All"
 msgstr "全部"
 
 #. TRANSLATORS: this is a subcategory of featured apps
-#: lib/gs-category.c:202 src/gs-shell.c:2180
+#: lib/gs-category.c:202 src/gs-shell.c:2181
 msgid "Featured"
 msgstr "特色软件"
 
@@ -608,8 +620,8 @@ msgstr "扩展设置"
 
 #: src/gs-category-page.ui:110
 msgid ""
-"Extensions are used at your own risk. If you have any system problems, it is"
-" recommended to disable them."
+"Extensions are used at your own risk. If you have any system problems, it is "
+"recommended to disable them."
 msgstr "使用扩展时风险自负。如果你遇到了系统问题，推荐禁用这些扩展。"
 
 #. TRANSLATORS: the user isn't reading the question
@@ -666,13 +678,15 @@ msgstr "启用第三方软件源？"
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
 #. * 2. Software source name, e.g. fedora-optional
+#.
 #: src/gs-common.c:232
 #, c-format
 msgid ""
 "%s is not <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
-"source_software\">free and open source software</a>, and is provided by "
-"“%s”."
-msgstr "%s 不是 <a href=\"https://en.wikipedia.org/wiki/Free_and_open-source_software\">自由开源软件</a>，它由 “%s” 提供。"
+"source_software\">free and open source software</a>, and is provided by “%s”."
+msgstr ""
+"%s 不是 <a href=\"https://en.wikipedia.org/wiki/Free_and_open-source_software"
+"\">自由开源软件</a>，它由 “%s” 提供。"
 
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
@@ -1054,14 +1068,12 @@ msgstr "不与其他用户共享物理地址"
 msgid "Sharing physical location to other users"
 msgstr "与其他用户共享物理位置"
 
-#. TRANSLATORS: this is a what we use in notifications if the app's name is
-#. unknown
+#. TRANSLATORS: this is a what we use in notifications if the app's name is unknown
 #: src/gs-dbus-helper.c:294
 msgid "An application"
 msgstr "应用程序"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. MIME types.
+#. TRANSLATORS: this is a notification displayed when an app needs additional MIME types.
 #: src/gs-dbus-helper.c:300
 #, c-format
 msgid "%s is requesting additional file format support."
@@ -1072,8 +1084,7 @@ msgstr "%s 需要额外的文件格式的支持。"
 msgid "Additional MIME Types Required"
 msgstr "需要额外的 MIME 类型"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. fonts.
+#. TRANSLATORS: this is a notification displayed when an app needs additional fonts.
 #: src/gs-dbus-helper.c:306
 #, c-format
 msgid "%s is requesting additional fonts."
@@ -1084,8 +1095,7 @@ msgstr "%s 需要额外的字体。"
 msgid "Additional Fonts Required"
 msgstr "需要额外的字体"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. codecs.
+#. TRANSLATORS: this is a notification displayed when an app needs additional codecs.
 #: src/gs-dbus-helper.c:312
 #, c-format
 msgid "%s is requesting additional multimedia codecs."
@@ -1096,8 +1106,7 @@ msgstr "%s 需要额外的多媒体编解码器。"
 msgid "Additional Multimedia Codecs Required"
 msgstr "需要额外的多媒体编解码器"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. printer drivers.
+#. TRANSLATORS: this is a notification displayed when an app needs additional printer drivers.
 #: src/gs-dbus-helper.c:318
 #, c-format
 msgid "%s is requesting additional printer drivers."
@@ -1108,8 +1117,7 @@ msgstr "%s 需要额外的打印机驱动程序。"
 msgid "Additional Printer Drivers Required"
 msgstr "需要额外的打印机驱动程序"
 
-#. TRANSLATORS: this is a notification displayed when an app wants to install
-#. additional packages.
+#. TRANSLATORS: this is a notification displayed when an app wants to install additional packages.
 #: src/gs-dbus-helper.c:324
 #, c-format
 msgid "%s is requesting additional packages."
@@ -1129,14 +1137,14 @@ msgstr "在“软件”中查找"
 #. * can be installed
 #. TRANSLATORS: button text in the header when firmware
 #. * can be live-installed
-#: src/gs-details-page.c:281 src/gs-details-page.c:312
-#: src/gs-details-page.ui:206 src/gs-upgrade-banner.ui:146
+#: src/gs-details-page.c:280 src/gs-details-page.c:310
+#: src/gs-details-page.ui:237 src/gs-upgrade-banner.ui:146
 msgid "_Install"
 msgstr "安装(_I)"
 
 #. TRANSLATORS: button text in the header when an application
 #. * can be live-updated
-#: src/gs-details-page.c:316
+#: src/gs-details-page.c:314
 msgid "_Update"
 msgstr "更新(_U)"
 
@@ -1144,66 +1152,66 @@ msgstr "更新(_U)"
 #. * be installed.
 #. * The ellipsis indicates that further steps are required,
 #. * e.g. enabling software sources or the like
-#: src/gs-details-page.c:330
+#: src/gs-details-page.c:326
 msgid "_Install…"
 msgstr "安装(_I)…"
 
 #. TRANSLATORS: button text in the header when an application can be erased
-#: src/gs-details-page.c:377 src/gs-details-page.ui:547
+#: src/gs-details-page.c:373 src/gs-details-page.ui:547
 msgid "_Uninstall"
 msgstr "卸载(_U)"
 
-#: src/gs-details-page.c:438 src/gs-sources-dialog.c:513
+#: src/gs-details-page.c:434 src/gs-sources-dialog.c:513
 msgid "Removing…"
 msgstr "正在移除…"
 
 #. TRANSLATORS: this is the warning box
-#: src/gs-details-page.c:748
+#: src/gs-details-page.c:744
 msgid ""
 "This application can only be used when there is an active internet "
 "connection."
 msgstr "这个应用只能在联网情况下使用。"
 
 #. TRANSLATORS: this is where the version is not known
-#: src/gs-details-page.c:892
+#: src/gs-details-page.c:888
 msgctxt "version"
 msgid "Unknown"
 msgstr "未知"
 
 #. TRANSLATORS: this is where we don't know the origin of the
 #. * application
-#: src/gs-details-page.c:971
+#: src/gs-details-page.c:967
 msgctxt "origin"
 msgid "Unknown"
 msgstr "未知"
 
 #. TRANSLATORS: we need a remote server to process
-#: src/gs-details-page.c:1378
+#: src/gs-details-page.c:1374
 msgid "You need internet access to write a review"
 msgstr "您需要互联网连接来输入评价"
 
-#: src/gs-details-page.c:1507
+#: src/gs-details-page.c:1503
 #, c-format
 msgid "Unable to find “%s”"
 msgstr "找不到“%s”"
 
 #. TRANSLATORS: see the wikipedia page
-#: src/gs-details-page.c:2087
+#: src/gs-details-page.c:2083
 msgid "Public domain"
 msgstr "公有领域"
 
 #. TRANSLATORS: see GNU page
-#: src/gs-details-page.c:2103 src/gs-details-page.ui:1397
+#: src/gs-details-page.c:2099 src/gs-details-page.ui:1397
 msgid "Free Software"
 msgstr "自由软件"
 
 #. TRANSLATORS: for the free software popover
-#: src/gs-details-page.c:2160
+#: src/gs-details-page.c:2156
 msgid "Users are bound by the following license:"
 msgid_plural "Users are bound by the following licenses:"
 msgstr[0] "用户受以下许可证的约束："
 
-#: src/gs-details-page.c:2176 src/gs-details-page.ui:1506
+#: src/gs-details-page.c:2172 src/gs-details-page.ui:1506
 msgid "More information"
 msgstr "更多信息"
 
@@ -1211,15 +1219,13 @@ msgstr "更多信息"
 msgid "Details page"
 msgstr "详细信息页面"
 
-#. Translators: A label for a button to add a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:228
+#. Translators: A label for a button to add a shortcut to the selected application.
+#: src/gs-details-page.ui:209
 msgid "_Add to Desktop"
 msgstr "添加到桌面(_A)"
 
-#. Translators: A label for a button to remove a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:245
+#. Translators: A label for a button to remove a shortcut to the selected application.
+#: src/gs-details-page.ui:226
 msgid "_Remove from Desktop"
 msgstr "从桌面移除(_R)"
 
@@ -1258,8 +1264,7 @@ msgid ""
 "replaced."
 msgstr "该软件已由您的发行版提供，而且不应被替换。"
 
-#. Translators: a repository file used for installing software has been
-#. discovered.
+#. Translators: a repository file used for installing software has been discovered.
 #: src/gs-details-page.ui:528
 msgid "Software Source Identified"
 msgstr "认证软件源"
@@ -1360,14 +1365,12 @@ msgstr "附加组件"
 msgid "Selected add-ons will be installed with the application."
 msgstr "选中的附加组件将随应用程序一起安装。"
 
-#. Translators: Header of the section with other users' opinions about the
-#. app.
+#. Translators: Header of the section with other users' opinions about the app.
 #: src/gs-details-page.ui:1233
 msgid "Reviews"
 msgstr "评论"
 
-#. Translators: Button opening a dialog where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Button opening a dialog where the users can write and publish their opinions about the apps.
 #: src/gs-details-page.ui:1249
 msgid "_Write a Review"
 msgstr "编写评论(_W)"
@@ -1379,8 +1382,8 @@ msgstr "显示更多(_S)"
 
 #: src/gs-details-page.ui:1414
 msgid ""
-"This means that the software can be freely run, copied, distributed, studied"
-" and modified."
+"This means that the software can be freely run, copied, distributed, studied "
+"and modified."
 msgstr "这表示该软件可以被自由地运行、复制、分发、研究和修改。"
 
 #: src/gs-details-page.ui:1473
@@ -1392,7 +1395,9 @@ msgid ""
 "This means that the software is owned by an individual or a company. There "
 "are often restrictions on its use and its source code cannot usually be "
 "accessed."
-msgstr "这表示该软件由个人或公司拥有。对该软件的使用常常伴有限制而且它的源码通常也无法被获取。"
+msgstr ""
+"这表示该软件由个人或公司拥有。对该软件的使用常常伴有限制而且它的源码通常也无"
+"法被获取。"
 
 #: src/gs-details-page.ui:1535
 msgid "Unknown Software License"
@@ -1476,8 +1481,7 @@ msgstr "应用列表包含未保存的更改。"
 msgid "Use verbose logging"
 msgstr "使用详细日志记录"
 
-#. TRANSLATORS: program name, an application to add and remove software
-#. repositories
+#. TRANSLATORS: program name, an application to add and remove software repositories
 #: src/gs-editor.c:1119
 msgid "GNOME Software Banner Designer"
 msgstr "GNOME 软件横幅设计器"
@@ -1506,8 +1510,7 @@ msgstr "摘要"
 msgid "Editor’s Pick"
 msgstr "编辑器选取"
 
-#. This check button controls whether the application’s banner appears in the
-#. “Featured” category
+#. This check button controls whether the application’s banner appears in the “Featured” category
 #: src/gs-editor.ui:397
 msgid "Category Featured"
 msgstr "特别类别"
@@ -1594,8 +1597,8 @@ msgstr "没有提供 %s 文件的可用程序。"
 #: src/gs-extras-page.c:337 src/gs-extras-page.c:348 src/gs-extras-page.c:359
 #, c-format
 msgid ""
-"Information about %s, as well as options for how to get missing applications"
-" might be found %s."
+"Information about %s, as well as options for how to get missing applications "
+"might be found %s."
 msgstr "%s 的相关信息，以及如何获取缺失的应用程序的选项有可能在 %s 找到。"
 
 #. TRANSLATORS: this is when we know about an application or
@@ -1619,7 +1622,8 @@ msgstr "%s 不可用。"
 msgid ""
 "Information about %s, as well as options for how to get an application that "
 "can support this format might be found %s."
-msgstr "%s 的相关信息，以及如何获取支持此格式的应用程序的选项有可能在 %s 找到。"
+msgstr ""
+"%s 的相关信息，以及如何获取支持此格式的应用程序的选项有可能在 %s 找到。"
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1639,7 +1643,7 @@ msgstr "%s 的相关信息，以及如何获取额外字体的选项有可能在
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
-#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1426
+#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1430
 #, c-format
 msgid "No addon codecs are available for the %s format."
 msgstr "没有对应 %s 格式的附加编解码器。"
@@ -1690,8 +1694,7 @@ msgstr "%s 的相关信息，以及如何获取支持此打印机的驱动的选
 msgid "this website"
 msgstr "这个网站"
 
-#. TRANSLATORS: no codecs were found. First %s will be replaced by actual
-#. codec name(s), second %s is a link titled "this website"
+#. TRANSLATORS: no codecs were found. First %s will be replaced by actual codec name(s), second %s is a link titled "this website"
 #: src/gs-extras-page.c:463
 #, c-format
 msgid ""
@@ -1725,10 +1728,12 @@ msgstr "欢迎使用"
 
 #: src/gs-first-run-dialog.ui:66
 msgid ""
-"Software lets you install all the software you need, all from one place. See"
-" our recommendations, browse the categories, or search for the applications "
+"Software lets you install all the software you need, all from one place. See "
+"our recommendations, browse the categories, or search for the applications "
 "you want."
-msgstr "\"软件\"让您在一个地方安装所有软件。请查看我们的推荐，浏览分类或者搜索想要的软件。"
+msgstr ""
+"\"软件\"让您在一个地方安装所有软件。请查看我们的推荐，浏览分类或者搜索想要的"
+"软件。"
 
 #: src/gs-first-run-dialog.ui:85
 msgid "_Let’s Go Shopping"
@@ -1882,8 +1887,7 @@ msgstr "提供了附加软件的获取通道，包括 web 浏览器和游戏。"
 
 #. TRANSLATORS: this is the proprietary info bar
 #: src/gs-overview-page.c:978
-msgid ""
-"Proprietary software has restrictions on use and access to source code."
+msgid "Proprietary software has restrictions on use and access to source code."
 msgstr "专有软件在使用和源码的获取上有限制。"
 
 #. TRANSLATORS: this is the clickable
@@ -1913,14 +1917,12 @@ msgstr "特色应用"
 msgid "Categories"
 msgstr "软件分类"
 
-#. Translators: This is a heading for software which has been featured
-#. ('picked') by the distribution.
+#. Translators: This is a heading for software which has been featured ('picked') by the distribution.
 #: src/gs-overview-page.ui:315
 msgid "Editor’s Picks"
 msgstr "编辑推荐"
 
-#. Translators: This is a heading for software which has been recently
-#. released upstream.
+#. Translators: This is a heading for software which has been recently released upstream.
 #: src/gs-overview-page.ui:359
 msgid "Recent Releases"
 msgstr "最新版本"
@@ -1982,7 +1984,7 @@ msgstr "您确定要移除 %s 吗？"
 msgid "%s will be removed, and you will have to install it to use it again."
 msgstr "%s 将被移除，想再次使用它您必须重新安装。"
 
-#: lib/gs-plugin-loader.c:1429
+#: lib/gs-plugin-loader.c:1433
 #, c-format
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
@@ -2046,7 +2048,9 @@ msgstr "%s %f"
 msgid ""
 "Some of the currently installed software is not compatible with %s. If you "
 "continue, the following will be automatically removed during the upgrade:"
-msgstr "当前已安装的一些软件与 %s 不兼容。如果您想继续，更新过程中下列软件将被自动移除："
+msgstr ""
+"当前已安装的一些软件与 %s 不兼容。如果您想继续，更新过程中下列软件将被自动移"
+"除："
 
 #: src/gs-removal-dialog.ui:27
 msgid "Incompatible Software"
@@ -2116,8 +2120,7 @@ msgstr "描述太短了"
 msgid "The description is too long"
 msgstr "描述太长了"
 
-#. Translators: Title of the dialog box where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Title of the dialog box where the users can write and publish their opinions about the apps.
 #: src/gs-review-dialog.ui:11
 msgid "Post Review"
 msgstr "发布评论"
@@ -2177,8 +2180,7 @@ msgstr "要举报评论吗？"
 msgid "Report"
 msgstr "举报"
 
-#. Translators: Users can express their opinions about other users' opinions
-#. about the apps.
+#. Translators: Users can express their opinions about other users' opinions about the apps.
 #: src/gs-review-row.ui:112
 msgid "Was this review useful to you?"
 msgstr "这条评论对你有用吗？"
@@ -2266,81 +2268,80 @@ msgstr "未找到应用程序"
 #. TRANSLATORS: this is part of the in-app notification,
 #. * where the %s is a multi-word localised app name
 #. * e.g. 'Getting things GNOME!"
-#: src/gs-shell.c:846 src/gs-shell.c:851 src/gs-shell.c:866 src/gs-shell.c:870
+#: src/gs-shell.c:847 src/gs-shell.c:852 src/gs-shell.c:867 src/gs-shell.c:871
 #, c-format
 msgid "“%s”"
 msgstr "“%s”"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:898
+#: src/gs-shell.c:899
 #, c-format
 msgid "Unable to download firmware updates from %s"
 msgstr "无法从%s下载固件更新"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:904
+#: src/gs-shell.c:905
 #, c-format
 msgid "Unable to download updates from %s"
 msgstr "无法从%s下载更新"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:911
+#: src/gs-shell.c:912
 msgid "Unable to download updates"
 msgstr "无法下载更新"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:916
+#: src/gs-shell.c:917
 msgid ""
-"Unable to download updates: internet access was required but wasn’t "
-"available"
+"Unable to download updates: internet access was required but wasn’t available"
 msgstr "无法下载更新:需要访问互联网但互联网不可用"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:925
+#: src/gs-shell.c:926
 #, c-format
 msgid "Unable to download updates from %s: not enough disk space"
 msgstr "无法从%s下载更新: 磁盘空间不足"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:930
+#: src/gs-shell.c:931
 msgid "Unable to download updates: not enough disk space"
 msgstr "无法下载更新：磁盘空间不足"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:938
+#: src/gs-shell.c:939
 msgid "Unable to download updates: authentication was required"
 msgstr "无法下载更新:：要求进行身份验证"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:943
+#: src/gs-shell.c:944
 msgid "Unable to download updates: authentication was invalid"
 msgstr "无法下载更新：身份验证无效"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:948
+#: src/gs-shell.c:949
 msgid ""
 "Unable to download updates: you do not have permission to install software"
 msgstr "无法下载更新：您没有安装软件的权限"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:955
+#: src/gs-shell.c:956
 msgid "Unable to get list of updates"
 msgstr "无法获得更新列表"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the application name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1001
+#: src/gs-shell.c:1002
 #, c-format
 msgid "Unable to install %s as download failed from %s"
 msgstr "由于从%s下载失败而无法安装%s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1007
+#: src/gs-shell.c:1008
 #, c-format
 msgid "Unable to install %s as download failed"
 msgstr "由于下载失败而无法安装%s"
@@ -2349,51 +2350,51 @@ msgstr "由于下载失败而无法安装%s"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1019
+#: src/gs-shell.c:1020
 #, c-format
 msgid "Unable to install %s as runtime %s not available"
 msgstr "由于运行时%s不可用而无法安装%s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1025
+#: src/gs-shell.c:1026
 #, c-format
 msgid "Unable to install %s as not supported"
 msgstr "由于不支持而无法安装%s"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1032
+#: src/gs-shell.c:1033
 msgid "Unable to install: internet access was required but wasn’t available"
 msgstr "无法安装：需要访问互联网但互联网不可用"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1038
+#: src/gs-shell.c:1039
 msgid "Unable to install: the application has an invalid format"
 msgstr "无法安装：应用格式无效"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1043
+#: src/gs-shell.c:1044
 #, c-format
 msgid "Unable to install %s: not enough disk space"
 msgstr "无法安装%s：磁盘空间不足"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1051
+#: src/gs-shell.c:1052
 #, c-format
 msgid "Unable to install %s: authentication was required"
 msgstr "无法安装%s：要求进行身份验证"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1058
+#: src/gs-shell.c:1059
 #, c-format
 msgid "Unable to install %s: authentication was invalid"
 msgstr "无法安装%s：身份验证无效"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1065
+#: src/gs-shell.c:1066
 #, c-format
 msgid "Unable to install %s: you do not have permission to install software"
 msgstr "无法安装%s：您没有安装软件的权限"
@@ -2401,34 +2402,34 @@ msgstr "无法安装%s：您没有安装软件的权限"
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the name of the authentication service,
 #. * e.g. "Ubuntu One"
-#: src/gs-shell.c:1078
+#: src/gs-shell.c:1079
 #, c-format
 msgid "Your %s account has been suspended."
 msgstr "您的%s帐户已被暂停。"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1082
+#: src/gs-shell.c:1083
 msgid "It is not possible to install software until this has been resolved."
 msgstr "解决此问题后才能安装软件。"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the clickable link (e.g.
 #. * "http://example.com/what-did-i-do-wrong/")
-#: src/gs-shell.c:1093
+#: src/gs-shell.c:1094
 #, c-format
 msgid "For more information, visit %s."
 msgstr "有关更多信息，请访问%s。"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1102
+#: src/gs-shell.c:1103
 #, c-format
 msgid "Unable to install %s: AC power is required"
 msgstr "无法安装 %s：需要交流电源"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1111
+#: src/gs-shell.c:1112
 #, c-format
 msgid "Unable to install %s"
 msgstr "无法安装%s"
@@ -2437,61 +2438,61 @@ msgstr "无法安装%s"
 #. * where the first %s is the app name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1157
+#: src/gs-shell.c:1158
 #, c-format
 msgid "Unable to update %s from %s"
 msgstr "无法从%s更新%s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1163
+#: src/gs-shell.c:1164
 #, c-format
 msgid "Unable to update %s as download failed"
 msgstr "由于下载失败而无法更新%s"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1169
+#: src/gs-shell.c:1170
 msgid "Unable to update: internet access was required but wasn’t available"
 msgstr "无法更新：需要访问互联网但互联网不可用"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1177
+#: src/gs-shell.c:1178
 #, c-format
 msgid "Unable to update %s: not enough disk space"
 msgstr "无法更新%s：磁盘空间不足"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1186
+#: src/gs-shell.c:1187
 #, c-format
 msgid "Unable to update %s: authentication was required"
 msgstr "无法更新%s：要求进行身份验证"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1193
+#: src/gs-shell.c:1194
 #, c-format
 msgid "Unable to update %s: authentication was invalid"
 msgstr "无法更新%s：身份验证无效"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1200
+#: src/gs-shell.c:1201
 #, c-format
 msgid "Unable to update %s: you do not have permission to update software"
 msgstr "无法更新%s：您没有更新软件的权限"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1208
+#: src/gs-shell.c:1209
 #, c-format
 msgid "Unable to update %s: AC power is required"
 msgstr "无法更新 %s：需要交流电源"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1217
+#: src/gs-shell.c:1218
 #, c-format
 msgid "Unable to update %s"
 msgstr "无法更新%s"
@@ -2499,96 +2500,96 @@ msgstr "无法更新%s"
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the distro name (e.g. "Fedora 25") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1262
+#: src/gs-shell.c:1263
 #, c-format
 msgid "Unable to upgrade to %s from %s"
 msgstr "无法从%s升级到%s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the app name (e.g. "GIMP")
-#: src/gs-shell.c:1267
+#: src/gs-shell.c:1268
 #, c-format
 msgid "Unable to upgrade to %s as download failed"
 msgstr "由于下载失败而无法升级到%s"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1274
+#: src/gs-shell.c:1275
 msgid "Unable to upgrade: internet access was required but wasn’t available"
 msgstr "无法升级：需要访问互联网但互联网不可用"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1282
+#: src/gs-shell.c:1283
 #, c-format
 msgid "Unable to upgrade to %s: not enough disk space"
 msgstr "无法升级到%s：磁盘空间不足"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1291
+#: src/gs-shell.c:1292
 #, c-format
 msgid "Unable to upgrade to %s: authentication was required"
 msgstr "无法升级到%s：要求进行身份验证"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1298
+#: src/gs-shell.c:1299
 #, c-format
 msgid "Unable to upgrade to %s: authentication was invalid"
 msgstr "无法升级到%s：身份验证无效"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1305
+#: src/gs-shell.c:1306
 #, c-format
 msgid "Unable to upgrade to %s: you do not have permission to upgrade"
 msgstr "无法升级到%s：您没有升级的权限"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1312
+#: src/gs-shell.c:1313
 #, c-format
 msgid "Unable to upgrade to %s: AC power is required"
 msgstr "无法升级到 %s：需要交流电源"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1321
+#: src/gs-shell.c:1322
 #, c-format
 msgid "Unable to upgrade to %s"
 msgstr "无法升级到%s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1363
+#: src/gs-shell.c:1364
 #, c-format
 msgid "Unable to remove %s: authentication was required"
 msgstr "无法删除%s：要求进行身份验证"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1369
+#: src/gs-shell.c:1370
 #, c-format
 msgid "Unable to remove %s: authentication was invalid"
 msgstr "无法删除%s：身份验证无效"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1375
+#: src/gs-shell.c:1376
 #, c-format
 msgid "Unable to remove %s: you do not have permission to remove software"
 msgstr "无法删除%s：您没有删除软件的权限"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1382
+#: src/gs-shell.c:1383
 #, c-format
 msgid "Unable to remove %s: AC power is required"
 msgstr "无法删除 %s：需要交流电源"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1391
+#: src/gs-shell.c:1392
 #, c-format
 msgid "Unable to remove %s"
 msgstr "无法删除%s"
@@ -2597,48 +2598,48 @@ msgstr "无法删除%s"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1437
+#: src/gs-shell.c:1438
 #, c-format
 msgid "Unable to launch %s: %s is not installed"
 msgstr "无法启动%s：%s未安装"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1444 src/gs-shell.c:1492 src/gs-shell.c:1540
+#: src/gs-shell.c:1445 src/gs-shell.c:1493 src/gs-shell.c:1541
 msgid "Not enough disk space — free up some space and try again"
 msgstr "磁盘空间不足 - 请释放一些空间后再试一次。"
 
 #. TRANSLATORS: we failed to get a proper error code
-#: src/gs-shell.c:1452 src/gs-shell.c:1500 src/gs-shell.c:1567
+#: src/gs-shell.c:1453 src/gs-shell.c:1501 src/gs-shell.c:1568
 msgid "Sorry, something went wrong"
 msgstr "抱歉，出现错误"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1487
+#: src/gs-shell.c:1488
 msgid "Failed to install file: authentication failed"
 msgstr "无法安装文件：身份验证失败"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1534
+#: src/gs-shell.c:1535
 #, c-format
 msgid "Unable to contact %s"
 msgstr "无法联系%s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1549
+#: src/gs-shell.c:1550
 #, c-format
 msgid "%s needs to be restarted to use new plugins."
 msgstr "需要重新启动%s以使用新的插件。"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1554
+#: src/gs-shell.c:1555
 msgid "This application needs to be restarted to use new plugins."
 msgstr "需要重新启动此应用以使用新的插件。"
 
 #. TRANSLATORS: need to be connected to the AC power
-#: src/gs-shell.c:1561
+#: src/gs-shell.c:1562
 msgid "AC power is required"
 msgstr "需要交流电源"
 
@@ -2925,8 +2926,8 @@ msgstr "更新被取消。"
 #. * something with no network available
 #: src/gs-update-monitor.c:714
 msgid ""
-"Internet access was required but wasn’t available. Please make sure that you"
-" have internet access and try again."
+"Internet access was required but wasn’t available. Please make sure that you "
+"have internet access and try again."
 msgstr "需要互联网连接但是未发现有效连接。请确认您有接入互联网并在此尝试。"
 
 #. TRANSLATORS: if the package is not signed correctly
@@ -2947,7 +2948,9 @@ msgstr "没有足够的磁盘空间。请释放一些空间后再试一次。"
 msgid ""
 "We’re sorry: the update failed to install. Please wait for another update "
 "and try again. If the problem persists, contact your software provider."
-msgstr "很抱歉：更新安装失败。请等待下一次更新时再试一次。如果问题仍存在，请联系您的软件提供商。"
+msgstr ""
+"很抱歉：更新安装失败。请等待下一次更新时再试一次。如果问题仍存在，请联系您的"
+"软件提供商。"
 
 #. TRANSLATORS: Time in 24h format
 #: src/gs-updates-page.c:297
@@ -3231,22 +3234,27 @@ msgid "App Center"
 msgstr "应用中心"
 
 #: src/org.gnome.Software.desktop.in:4
+msgid "More Apps"
+msgstr "更多的Apps"
+
+#: src/org.gnome.Software.desktop.in:5
 msgid "Add, remove or update software on this computer"
 msgstr "添加、移除或更新计算机软件"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
-#: src/org.gnome.Software.desktop.in:6
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: src/org.gnome.Software.desktop.in:7
 #: src/org.gnome.Software.Editor.desktop.in:6
 msgid "org.gnome.Software"
 msgstr "org.gnome.Software"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
-#: src/org.gnome.Software.desktop.in:12
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: src/org.gnome.Software.desktop.in:13
 msgid ""
-"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;"
-msgstr "Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;更新;升级;源;仓库;首选项;安装;卸载;程序;软件;应用;商店;"
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;"
+msgstr ""
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;更新;升级;源;仓库;首选项;安装;卸载;程序;软件;应用;商店;"
 
 #: src/org.gnome.Software.Editor.desktop.in:3
 msgid "Banner Designer"
@@ -3256,8 +3264,7 @@ msgstr "横幅设计器"
 msgid "Design the featured banners for GNOME Software"
 msgstr "设计 GNOME 软件的特色横幅"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: src/org.gnome.Software.Editor.desktop.in:13
 msgid "AppStream;Software;App;"
 msgstr "AppStream;软件;应用;"
@@ -3527,100 +3534,111 @@ msgctxt "Menu of Communication & News"
 msgid "Web Browsers"
 msgstr "网页浏览器"
 
-#: plugins/core/gs-desktop-common.c:247
-msgctxt "Menu of Reference"
-msgid "All"
-msgstr "全部"
-
-#: plugins/core/gs-desktop-common.c:250
-msgctxt "Menu of Reference"
-msgid "Featured"
-msgstr "精选"
-
-#: plugins/core/gs-desktop-common.c:253
-msgctxt "Menu of Reference"
-msgid "Art"
-msgstr "艺术"
-
-#: plugins/core/gs-desktop-common.c:256
-msgctxt "Menu of Reference"
-msgid "Biography"
-msgstr "传记"
-
-#: plugins/core/gs-desktop-common.c:259
-msgctxt "Menu of Reference"
-msgid "Comics"
-msgstr "漫画"
-
-#: plugins/core/gs-desktop-common.c:262
-msgctxt "Menu of Reference"
-msgid "Fiction"
-msgstr "小说"
-
-#: plugins/core/gs-desktop-common.c:265
-msgctxt "Menu of Reference"
-msgid "Health"
-msgstr "健康"
-
-#: plugins/core/gs-desktop-common.c:268
-msgctxt "Menu of Reference"
-msgid "History"
-msgstr "历史"
-
-#: plugins/core/gs-desktop-common.c:271
-msgctxt "Menu of Reference"
-msgid "Lifestyle"
-msgstr "生活"
-
-#: plugins/core/gs-desktop-common.c:274
+#: plugins/core/gs-desktop-common.c:242
 msgctxt "Menu of Communication & News"
 msgid "News"
 msgstr "新闻"
 
+#: plugins/core/gs-desktop-common.c:251
+msgctxt "Menu of Reference"
+msgid "All"
+msgstr "全部"
+
+#: plugins/core/gs-desktop-common.c:254
+msgctxt "Menu of Reference"
+msgid "Featured"
+msgstr "精选"
+
+#: plugins/core/gs-desktop-common.c:257
+msgctxt "Menu of Reference"
+msgid "Art"
+msgstr "艺术"
+
+#: plugins/core/gs-desktop-common.c:260
+msgctxt "Menu of Reference"
+msgid "Biography"
+msgstr "传记"
+
+#: plugins/core/gs-desktop-common.c:263
+msgctxt "Menu of Reference"
+msgid "Comics"
+msgstr "漫画"
+
+#: plugins/core/gs-desktop-common.c:266
+msgctxt "Menu of Reference"
+msgid "Feed"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:269
+msgctxt "Menu of Reference"
+msgid "Fiction"
+msgstr "小说"
+
+#: plugins/core/gs-desktop-common.c:272
+msgctxt "Menu of Reference"
+msgid "Health"
+msgstr "健康"
+
+#: plugins/core/gs-desktop-common.c:275
+msgctxt "Menu of Reference"
+msgid "History"
+msgstr "历史"
+
 #: plugins/core/gs-desktop-common.c:278
+msgctxt "Menu of Reference"
+msgid "Lifestyle"
+msgstr "生活"
+
+#: plugins/core/gs-desktop-common.c:281
+#, fuzzy
+msgctxt "Menu of Reference"
+msgid "News"
+msgstr "新闻"
+
+#: plugins/core/gs-desktop-common.c:284
 msgctxt "Menu of Reference"
 msgid "Politics"
 msgstr "政治"
 
-#: plugins/core/gs-desktop-common.c:281
+#: plugins/core/gs-desktop-common.c:287
 msgctxt "Menu of Reference"
 msgid "Sports"
 msgstr "体育"
 
 #. TRANSLATORS: this is the menu spec main category for Learning
-#: plugins/core/gs-desktop-common.c:291
+#: plugins/core/gs-desktop-common.c:297
 msgid "Learning"
 msgstr "学习"
 
 #. TRANSLATORS: this is the menu spec main category for Game
-#: plugins/core/gs-desktop-common.c:294
+#: plugins/core/gs-desktop-common.c:300
 msgid "Games"
 msgstr "游戏"
 
 #. TRANSLATORS: this is the menu spec main category for Multimedia
-#: plugins/core/gs-desktop-common.c:297
+#: plugins/core/gs-desktop-common.c:303
 msgid "Multimedia"
 msgstr "多媒体"
 
 #. TRANSLATORS: this is the menu spec main category for Work
-#: plugins/core/gs-desktop-common.c:300
+#: plugins/core/gs-desktop-common.c:306
 msgid "Work"
 msgstr "工作"
 
 #. TRANSLATORS: this is the menu spec main category for Reference
-#: plugins/core/gs-desktop-common.c:303
+#: plugins/core/gs-desktop-common.c:309
 msgid "Reference & News"
 msgstr "参考消息&新闻"
 
 #. TRANSLATORS: this is the menu spec main category for Utilities
-#: plugins/core/gs-desktop-common.c:306
+#: plugins/core/gs-desktop-common.c:312
 msgid "Utilities"
 msgstr "实用工具"
 
 #. TRANSLATORS: this is the menu spec main category for Dev Tools; it
 #. * should be a relatively short label; as an example, in Portuguese and
 #. * Spanish the direct translation of "Programming" (noun) is used
-#: plugins/core/gs-desktop-common.c:311
+#: plugins/core/gs-desktop-common.c:317
 msgid "Dev Tools"
 msgstr "开发工具"
 
@@ -3646,16 +3664,16 @@ msgstr "包括性能、稳定性及安全改进。"
 msgid "Downloading featured images…"
 msgstr "正在下载特色图像…"
 
-#: plugins/eos/gs-plugin-eos.c:1249
+#: plugins/eos/gs-plugin-eos.c:1233
 #, c-format
 msgid "Could not launch this application."
 msgstr "无法启动此应用程序。"
 
-#: plugins/eos/gs-plugin-eos.c:1305
+#: plugins/eos/gs-plugin-eos.c:1289
 msgid "Endless Platform"
 msgstr "Endless 平台"
 
-#: plugins/eos/gs-plugin-eos.c:1308
+#: plugins/eos/gs-plugin-eos.c:1292
 msgid "Framework for applications"
 msgstr "应用框架"
 
@@ -3715,13 +3733,13 @@ msgid "Flatpak is a framework for desktop applications on Linux"
 msgstr "Flatpak 是 Linux 平台的桌面应用框架"
 
 #. TRANSLATORS: status text when downloading new metadata
-#: plugins/flatpak/gs-flatpak.c:821
+#: plugins/flatpak/gs-flatpak.c:815
 #, c-format
 msgid "Getting flatpak metadata for %s…"
 msgstr "正在获取 %s 的 flatpak 元数据…"
 
 #. TRANSLATORS: status text when downloading the RuntimeRepo
-#: plugins/flatpak/gs-flatpak.c:2796
+#: plugins/flatpak/gs-flatpak.c:2803
 msgid "Getting runtime source…"
 msgstr "正在获取运行时源…"
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1,21 +1,22 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the gnome-software package.
-# 
+#
 # Translators:
 # Roddy Shuler <roddy@endlessm.com>, 2017
 msgid ""
 msgstr ""
 "Project-Id-Version: gnome-software\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-12 22:31-0700\n"
+"POT-Creation-Date: 2017-11-02 16:28+0100\n"
 "PO-Revision-Date: 2017-10-16 05:36+0000\n"
 "Last-Translator: Roddy Shuler <roddy@endlessm.com>\n"
-"Language-Team: Chinese (Taiwan) (http://www.transifex.com/endless-mobile-inc/gnome-software/language/zh_TW/)\n"
+"Language-Team: Chinese (Taiwan) (http://www.transifex.com/endless-mobile-inc/"
+"gnome-software/language/zh_TW/)\n"
+"Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_TW\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:7
@@ -30,7 +31,8 @@ msgstr "為 GNOME 設計的應用程式管理員"
 msgid ""
 "Software allows you to find and install new applications and system "
 "extensions and remove existing installed applications."
-msgstr "《軟體》讓您可以找尋、安裝新程式與系統擴充套件，以及移除所安裝的應用程式。"
+msgstr ""
+"《軟體》讓您可以找尋、安裝新程式與系統擴充套件，以及移除所安裝的應用程式。"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:14
 msgid ""
@@ -38,7 +40,10 @@ msgid ""
 "descriptions and multiple screenshots per application. Applications can be "
 "found either through browsing the list of categories or by searching. It "
 "also allows you to update your system using an offline update."
-msgstr "GNOME《軟體》陳列各種具有特色，以及廣受歡迎的應用程式，並附上有用的描述與多張螢幕擷圖。除了瀏覽類別清單之外，您還可以透過搜尋的方式來找出想要的應用程式。此外，它也可讓您採用離線更新的方式更新系統。"
+msgstr ""
+"GNOME《軟體》陳列各種具有特色，以及廣受歡迎的應用程式，並附上有用的描述與多張"
+"螢幕擷圖。除了瀏覽類別清單之外，您還可以透過搜尋的方式來找出想要的應用程式。"
+"此外，它也可讓您採用離線更新的方式更新系統。"
 
 #: data/appdata/org.gnome.Software.appdata.xml.in:25
 msgid "Overview panel"
@@ -90,9 +95,10 @@ msgstr "是否自動下載更新"
 
 #: data/org.gnome.software.gschema.xml:16
 msgid ""
-"If enabled, GNOME Software automatically downloads updates in the background"
-" and prompts the user to install them when ready."
-msgstr "若啟用，則 GNOME《軟體》會自動在背景下載更新，並在準備就緒後提示使用者安裝。"
+"If enabled, GNOME Software automatically downloads updates in the background "
+"and prompts the user to install them when ready."
+msgstr ""
+"若啟用，則 GNOME《軟體》會自動在背景下載更新，並在準備就緒後提示使用者安裝。"
 
 #: data/org.gnome.software.gschema.xml:20
 msgid "Whether to automatically refresh when on a metered connection"
@@ -103,7 +109,9 @@ msgid ""
 "If enabled, GNOME Software automatically refreshes in the background even "
 "when using a metered connection (eventually downloading some metadata, "
 "checking for updates, etc., which may incur in costs for the user)."
-msgstr "若啟用，則 GNOME《軟體》即使在使用計價連線時仍會自動在背景重新整理（甚至下載一些中介資料、檢查是否有更新…等，這代表使用者可能必須負擔更多費用）。"
+msgstr ""
+"若啟用，則 GNOME《軟體》即使在使用計價連線時仍會自動在背景重新整理（甚至下載"
+"一些中介資料、檢查是否有更新…等，這代表使用者可能必須負擔更多費用）。"
 
 #: data/org.gnome.software.gschema.xml:25
 msgid "Whether it’s the very first run of GNOME Software"
@@ -123,9 +131,10 @@ msgstr "非自由的應用程式會在安裝前顯示警告對話盒"
 
 #: data/org.gnome.software.gschema.xml:38
 msgid ""
-"When non-free applications are installed a warning dialog can be shown. This"
-" controls if that dialog is suppressed."
-msgstr "安裝非自由應用程式之時會顯示警告對話盒。這個選項控制是否要解除該對話盒。"
+"When non-free applications are installed a warning dialog can be shown. This "
+"controls if that dialog is suppressed."
+msgstr ""
+"安裝非自由應用程式之時會顯示警告對話盒。這個選項控制是否要解除該對話盒。"
 
 #: data/org.gnome.software.gschema.xml:42
 msgid "A list of popular applications"
@@ -168,9 +177,12 @@ msgstr "用來驗證上游螢幕快照仍否有效的時間秒數"
 #: data/org.gnome.software.gschema.xml:69
 msgid ""
 "Choosing a larger value will mean less round-trips to the remote server but "
-"updates to the screenshots may take longer to show to the user. A value of 0"
-" means to never check the server if the image already exists in the cache."
-msgstr "若採取較大的數值則代表較少從遠端伺服器來回，但是螢幕快照的後續更新可能要花上較長時間才會顯示給使用者觀看。數值為 0 表示若快取中已有影像存在，則永不檢查伺服器。"
+"updates to the screenshots may take longer to show to the user. A value of 0 "
+"means to never check the server if the image already exists in the cache."
+msgstr ""
+"若採取較大的數值則代表較少從遠端伺服器來回，但是螢幕快照的後續更新可能要花上"
+"較長時間才會顯示給使用者觀看。數值為 0 表示若快取中已有影像存在，則永不檢查伺"
+"服器。"
 
 #: data/org.gnome.software.gschema.xml:78
 msgid "The server to use for application reviews"
@@ -194,13 +206,11 @@ msgstr "不應視為自由軟體的官方來源列表"
 
 #: data/org.gnome.software.gschema.xml:95
 msgid ""
-"The licence URL to use when an application should be considered free "
-"software"
+"The licence URL to use when an application should be considered free software"
 msgstr "將應用程式視為自由軟體的授權方式 URL"
 
 #: data/org.gnome.software.gschema.xml:99
-msgid ""
-"Install bundled applications for all users on the system where possible"
+msgid "Install bundled applications for all users on the system where possible"
 msgstr "只要可以便為系統上的所有使用者安裝應用程式套組"
 
 #: data/org.gnome.software.gschema.xml:103
@@ -267,8 +277,7 @@ msgstr "軟體安裝"
 msgid "Install selected software on the system"
 msgstr "安裝選取的軟體到系統中"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 #: src/gnome-software-local-file.desktop.in:10
 msgid "system-software-install"
 msgstr "system-software-install"
@@ -295,14 +304,12 @@ msgstr "返回"
 msgid "_All"
 msgstr "全部(_A)"
 
-#. Translators: A label for a button to show only software which is already
-#. installed.
+#. Translators: A label for a button to show only software which is already installed.
 #: src/gnome-software.ui:104
 msgid "_Installed"
 msgstr "已安裝(_I)"
 
-#. Translators: A label for a button to show only updates which are available
-#. to install.
+#. Translators: A label for a button to show only updates which are available to install.
 #: src/gnome-software.ui:155
 msgid "_Updates"
 msgstr "更新(_U)"
@@ -350,7 +357,7 @@ msgstr "已安裝"
 
 #. TRANSLATORS: this is a button next to the search results that
 #. * shows the status of an application being installed
-#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:443
+#: src/gs-app-addon-row.c:105 src/gs-app-row.c:218 src/gs-details-page.c:439
 msgid "Installing"
 msgstr "安裝中"
 
@@ -365,7 +372,7 @@ msgid "Folder Name"
 msgstr "資料夾名稱"
 
 #: src/gs-app-folder-dialog.c:321 src/gs-app-folder-dialog.ui:16
-#: src/gs-details-page.c:383 src/gs-details-page.ui:342 src/gs-editor.c:623
+#: src/gs-details-page.c:379 src/gs-details-page.ui:342 src/gs-editor.c:623
 #: src/gs-editor.c:655 src/gs-installed-page.c:609 src/gs-removal-dialog.ui:33
 #: src/gs-review-dialog.ui:23 src/gs-upgrade-banner.ui:131
 msgid "_Cancel"
@@ -380,90 +387,94 @@ msgid "Add to Application Folder"
 msgstr "加入到應用程式資料夾中"
 
 #. TRANSLATORS: this is a command line option
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "Start up mode: either ‘updates’, ‘updated’, ‘installed’ or ‘overview’"
-msgstr "初始啟動模式：可以是「updates」(更新)、「updated」(已更新)、「installed」(已安裝) 或「overview」(概覽)"
+msgstr ""
+"初始啟動模式：可以是「updates」(更新)、「updated」(已更新)、「installed」(已"
+"安裝) 或「overview」(概覽)"
 
-#: src/gs-application.c:101
+#: src/gs-application.c:129
 msgid "MODE"
 msgstr "模式"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "Search for applications"
 msgstr "搜尋用程式"
 
-#: src/gs-application.c:103
+#: src/gs-application.c:131
 msgid "SEARCH"
 msgstr "搜尋"
 
-#: src/gs-application.c:105
+#: src/gs-application.c:133
 msgid "Show application details (using application ID)"
 msgstr "顯示應用程式細節（使用應用程式 ID）"
 
-#: src/gs-application.c:105 src/gs-application.c:109
+#: src/gs-application.c:133 src/gs-application.c:137
 msgid "ID"
 msgstr "ID"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "Show application details (using package name)"
 msgstr "顯示應用程式細節（使用軟體包名稱）"
 
-#: src/gs-application.c:107
+#: src/gs-application.c:135
 msgid "PKGNAME"
 msgstr "PKGNAME"
 
-#: src/gs-application.c:109
+#: src/gs-application.c:137
 msgid "Install the application (using application ID)"
 msgstr "安裝應用程式（使用應用程式 ID）"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "Open a local package file"
 msgstr "開啟本機軟體包檔案"
 
-#: src/gs-application.c:111
+#: src/gs-application.c:139
 msgid "FILENAME"
 msgstr "FILENAME"
 
-#: src/gs-application.c:113
+#: src/gs-application.c:141
 msgid ""
 "The kind of interaction expected for this action: either ‘none’, ‘notify’, "
 "or ‘full’"
-msgstr "這個動作預期的互動種類：可以是「none」(沒有)、「notify」(通知)或「full」(完整)"
+msgstr ""
+"這個動作預期的互動種類：可以是「none」(沒有)、「notify」(通知)或「full」(完"
+"整)"
 
-#: src/gs-application.c:116
+#: src/gs-application.c:144
 msgid "Show verbose debugging information"
 msgstr "詳細顯示除錯用訊息"
 
-#: src/gs-application.c:118
+#: src/gs-application.c:146
 msgid "Show profiling information for the service"
 msgstr "顯示該服務的評測資訊"
 
-#: src/gs-application.c:120
+#: src/gs-application.c:148
 msgid "Quit the running instance"
 msgstr "退出執行中的實體"
 
-#: src/gs-application.c:122
+#: src/gs-application.c:150
 msgid "Prefer local file sources to AppStream"
 msgstr "AppStream 偏好使用本地端檔案來源"
 
-#: src/gs-application.c:124
+#: src/gs-application.c:152
 msgid "Show version number"
 msgstr "顯示版本號碼"
 
-#: src/gs-application.c:325
+#: src/gs-application.c:358
 msgid "translator-credits"
 msgstr "Cheng-Chia Tseng <pswo10680@gmail.com>, 2013-15."
 
 #. TRANSLATORS: this is the title of the about window, e.g.
 #. * 'About Software' or 'About Application Installer' where the %s is
 #. * the application name chosen by the distro
-#: src/gs-application.c:332
+#: src/gs-application.c:365
 #, c-format
 msgid "About %s"
 msgstr "關於 %s"
 
 #. TRANSLATORS: well, we seem to think so, anyway
-#: src/gs-application.c:336
+#: src/gs-application.c:369
 msgid "A nice way to manage the software on your system."
 msgstr "管理系統中軟體的絕佳方式。"
 
@@ -578,7 +589,7 @@ msgid "All"
 msgstr "全部"
 
 #. TRANSLATORS: this is a subcategory of featured apps
-#: lib/gs-category.c:202 src/gs-shell.c:2180
+#: lib/gs-category.c:202 src/gs-shell.c:2181
 msgid "Featured"
 msgstr "特選"
 
@@ -588,9 +599,10 @@ msgstr "擴充套件設定值"
 
 #: src/gs-category-page.ui:110
 msgid ""
-"Extensions are used at your own risk. If you have any system problems, it is"
-" recommended to disable them."
-msgstr "請自行承擔擴充套件的使用風險。若您遇上任何系統問題，建議將擴充套件停用。"
+"Extensions are used at your own risk. If you have any system problems, it is "
+"recommended to disable them."
+msgstr ""
+"請自行承擔擴充套件的使用風險。若您遇上任何系統問題，建議將擴充套件停用。"
 
 #. TRANSLATORS: the user isn't reading the question
 #: lib/gs-cmd.c:205
@@ -646,13 +658,15 @@ msgstr "啟用第三方軟體來源？"
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
 #. * 2. Software source name, e.g. fedora-optional
+#.
 #: src/gs-common.c:232
 #, c-format
 msgid ""
 "%s is not <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
-"source_software\">free and open source software</a>, and is provided by "
-"“%s”."
-msgstr "%s 並不是 <a href=\"https://en.wikipedia.org/wiki/Free_and_open-source_software\">自由與開源軟體</a>，此外它是由「%s」提供。"
+"source_software\">free and open source software</a>, and is provided by “%s”."
+msgstr ""
+"%s 並不是 <a href=\"https://en.wikipedia.org/wiki/Free_and_open-"
+"source_software\">自由與開源軟體</a>，此外它是由「%s」提供。"
 
 #. TRANSLATORS: the replacements are as follows:
 #. * 1. Application name, e.g. "Firefox"
@@ -1034,14 +1048,12 @@ msgstr "不會和其他使用者分享實際地理位置"
 msgid "Sharing physical location to other users"
 msgstr "和其他使用者分享實際地理位置"
 
-#. TRANSLATORS: this is a what we use in notifications if the app's name is
-#. unknown
+#. TRANSLATORS: this is a what we use in notifications if the app's name is unknown
 #: src/gs-dbus-helper.c:294
 msgid "An application"
 msgstr "應用程式"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. MIME types.
+#. TRANSLATORS: this is a notification displayed when an app needs additional MIME types.
 #: src/gs-dbus-helper.c:300
 #, c-format
 msgid "%s is requesting additional file format support."
@@ -1052,8 +1064,7 @@ msgstr "%s 要求額外的檔案格式支援。"
 msgid "Additional MIME Types Required"
 msgstr "需要額外的 MIME 類型"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. fonts.
+#. TRANSLATORS: this is a notification displayed when an app needs additional fonts.
 #: src/gs-dbus-helper.c:306
 #, c-format
 msgid "%s is requesting additional fonts."
@@ -1064,8 +1075,7 @@ msgstr "%s 正在要求額外的字型。"
 msgid "Additional Fonts Required"
 msgstr "需要額外的字型"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. codecs.
+#. TRANSLATORS: this is a notification displayed when an app needs additional codecs.
 #: src/gs-dbus-helper.c:312
 #, c-format
 msgid "%s is requesting additional multimedia codecs."
@@ -1076,8 +1086,7 @@ msgstr "%s 要求額外的多媒體編解碼器支援。"
 msgid "Additional Multimedia Codecs Required"
 msgstr "需要額外的多媒體編解碼器"
 
-#. TRANSLATORS: this is a notification displayed when an app needs additional
-#. printer drivers.
+#. TRANSLATORS: this is a notification displayed when an app needs additional printer drivers.
 #: src/gs-dbus-helper.c:318
 #, c-format
 msgid "%s is requesting additional printer drivers."
@@ -1088,8 +1097,7 @@ msgstr "%s 要求額外的印表機驅動程式支援。"
 msgid "Additional Printer Drivers Required"
 msgstr "需要額外的印表機驅動程式"
 
-#. TRANSLATORS: this is a notification displayed when an app wants to install
-#. additional packages.
+#. TRANSLATORS: this is a notification displayed when an app wants to install additional packages.
 #: src/gs-dbus-helper.c:324
 #, c-format
 msgid "%s is requesting additional packages."
@@ -1109,14 +1117,14 @@ msgstr "在軟體中尋找"
 #. * can be installed
 #. TRANSLATORS: button text in the header when firmware
 #. * can be live-installed
-#: src/gs-details-page.c:281 src/gs-details-page.c:312
-#: src/gs-details-page.ui:206 src/gs-upgrade-banner.ui:146
+#: src/gs-details-page.c:280 src/gs-details-page.c:310
+#: src/gs-details-page.ui:237 src/gs-upgrade-banner.ui:146
 msgid "_Install"
 msgstr "安裝(_I)"
 
 #. TRANSLATORS: button text in the header when an application
 #. * can be live-updated
-#: src/gs-details-page.c:316
+#: src/gs-details-page.c:314
 msgid "_Update"
 msgstr "更新(_U)"
 
@@ -1124,66 +1132,66 @@ msgstr "更新(_U)"
 #. * be installed.
 #. * The ellipsis indicates that further steps are required,
 #. * e.g. enabling software sources or the like
-#: src/gs-details-page.c:330
+#: src/gs-details-page.c:326
 msgid "_Install…"
 msgstr "安裝(_I)…"
 
 #. TRANSLATORS: button text in the header when an application can be erased
-#: src/gs-details-page.c:377 src/gs-details-page.ui:547
+#: src/gs-details-page.c:373 src/gs-details-page.ui:547
 msgid "_Uninstall"
 msgstr "_解除安裝"
 
-#: src/gs-details-page.c:438 src/gs-sources-dialog.c:513
+#: src/gs-details-page.c:434 src/gs-sources-dialog.c:513
 msgid "Removing…"
 msgstr "移除中…"
 
 #. TRANSLATORS: this is the warning box
-#: src/gs-details-page.c:748
+#: src/gs-details-page.c:744
 msgid ""
 "This application can only be used when there is an active internet "
 "connection."
 msgstr "此類應用程式僅可在有網際網路連線時可以使用。"
 
 #. TRANSLATORS: this is where the version is not known
-#: src/gs-details-page.c:892
+#: src/gs-details-page.c:888
 msgctxt "version"
 msgid "Unknown"
 msgstr "不明"
 
 #. TRANSLATORS: this is where we don't know the origin of the
 #. * application
-#: src/gs-details-page.c:971
+#: src/gs-details-page.c:967
 msgctxt "origin"
 msgid "Unknown"
 msgstr "不明"
 
 #. TRANSLATORS: we need a remote server to process
-#: src/gs-details-page.c:1378
+#: src/gs-details-page.c:1374
 msgid "You need internet access to write a review"
 msgstr "您需要網際網路存取才能寫評論"
 
-#: src/gs-details-page.c:1507
+#: src/gs-details-page.c:1503
 #, c-format
 msgid "Unable to find “%s”"
 msgstr "找不到「%s」"
 
 #. TRANSLATORS: see the wikipedia page
-#: src/gs-details-page.c:2087
+#: src/gs-details-page.c:2083
 msgid "Public domain"
 msgstr "公版著作"
 
 #. TRANSLATORS: see GNU page
-#: src/gs-details-page.c:2103 src/gs-details-page.ui:1397
+#: src/gs-details-page.c:2099 src/gs-details-page.ui:1397
 msgid "Free Software"
 msgstr "自由軟體"
 
 #. TRANSLATORS: for the free software popover
-#: src/gs-details-page.c:2160
+#: src/gs-details-page.c:2156
 msgid "Users are bound by the following license:"
 msgid_plural "Users are bound by the following licenses:"
 msgstr[0] "使用者受下列授權條款約束："
 
-#: src/gs-details-page.c:2176 src/gs-details-page.ui:1506
+#: src/gs-details-page.c:2172 src/gs-details-page.ui:1506
 msgid "More information"
 msgstr "詳細資訊"
 
@@ -1191,15 +1199,13 @@ msgstr "詳細資訊"
 msgid "Details page"
 msgstr "細節頁"
 
-#. Translators: A label for a button to add a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:228
+#. Translators: A label for a button to add a shortcut to the selected application.
+#: src/gs-details-page.ui:209
 msgid "_Add to Desktop"
 msgstr "_添加至桌面"
 
-#. Translators: A label for a button to remove a shortcut to the selected
-#. application.
-#: src/gs-details-page.ui:245
+#. Translators: A label for a button to remove a shortcut to the selected application.
+#: src/gs-details-page.ui:226
 msgid "_Remove from Desktop"
 msgstr "從桌面移除(_R)"
 
@@ -1238,8 +1244,7 @@ msgid ""
 "replaced."
 msgstr "此軟體已經由您的散布版提供，不應替換。"
 
-#. Translators: a repository file used for installing software has been
-#. discovered.
+#. Translators: a repository file used for installing software has been discovered.
 #: src/gs-details-page.ui:528
 msgid "Software Source Identified"
 msgstr "已識明軟體來源"
@@ -1340,14 +1345,12 @@ msgstr "附加元件"
 msgid "Selected add-ons will be installed with the application."
 msgstr "選取的附加元件會隨該程式一併安裝。"
 
-#. Translators: Header of the section with other users' opinions about the
-#. app.
+#. Translators: Header of the section with other users' opinions about the app.
 #: src/gs-details-page.ui:1233
 msgid "Reviews"
 msgstr "評論"
 
-#. Translators: Button opening a dialog where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Button opening a dialog where the users can write and publish their opinions about the apps.
 #: src/gs-details-page.ui:1249
 msgid "_Write a Review"
 msgstr "撰寫評論(_W)"
@@ -1359,8 +1362,8 @@ msgstr "顯示更多(_S)"
 
 #: src/gs-details-page.ui:1414
 msgid ""
-"This means that the software can be freely run, copied, distributed, studied"
-" and modified."
+"This means that the software can be freely run, copied, distributed, studied "
+"and modified."
 msgstr "這代表該軟體著作可以讓您自由運用、複製、散布、研究、和修改。"
 
 #: src/gs-details-page.ui:1473
@@ -1372,7 +1375,9 @@ msgid ""
 "This means that the software is owned by an individual or a company. There "
 "are often restrictions on its use and its source code cannot usually be "
 "accessed."
-msgstr "這代表該軟體著作屬於特定人士或公司所有。他們通常會限制您的使用方式，而且一般來說無法存取其軟體源始碼。"
+msgstr ""
+"這代表該軟體著作屬於特定人士或公司所有。他們通常會限制您的使用方式，而且一般"
+"來說無法存取其軟體源始碼。"
 
 #: src/gs-details-page.ui:1535
 msgid "Unknown Software License"
@@ -1456,8 +1461,7 @@ msgstr "尚未儲存應用程式清單的更動。"
 msgid "Use verbose logging"
 msgstr "使用詳盡紀錄"
 
-#. TRANSLATORS: program name, an application to add and remove software
-#. repositories
+#. TRANSLATORS: program name, an application to add and remove software repositories
 #: src/gs-editor.c:1119
 msgid "GNOME Software Banner Designer"
 msgstr "GNOME 軟體橫幅設計師"
@@ -1486,8 +1490,7 @@ msgstr "摘要"
 msgid "Editor’s Pick"
 msgstr "編輯精選"
 
-#. This check button controls whether the application’s banner appears in the
-#. “Featured” category
+#. This check button controls whether the application’s banner appears in the “Featured” category
 #: src/gs-editor.ui:397
 msgid "Category Featured"
 msgstr "類別特選"
@@ -1574,8 +1577,8 @@ msgstr "沒有應用程式可開啟檔案 %s。"
 #: src/gs-extras-page.c:337 src/gs-extras-page.c:348 src/gs-extras-page.c:359
 #, c-format
 msgid ""
-"Information about %s, as well as options for how to get missing applications"
-" might be found %s."
+"Information about %s, as well as options for how to get missing applications "
+"might be found %s."
 msgstr "%s 的相關資訊，以及該如何取得缺少的應用程式的選項可以在 %s 找到。"
 
 #. TRANSLATORS: this is when we know about an application or
@@ -1619,7 +1622,7 @@ msgstr "%s 的相關資訊，以及該如何取得額外字型的選項可在 %s
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
-#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1426
+#: src/gs-extras-page.c:388 lib/gs-plugin-loader.c:1430
 #, c-format
 msgid "No addon codecs are available for the %s format."
 msgstr "沒有可用的 %s 格式附加編解碼器。"
@@ -1631,7 +1634,8 @@ msgstr "沒有可用的 %s 格式附加編解碼器。"
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format might be found %s."
-msgstr "%s 的相關資訊，以及該如何取得可播放這個格式的編解碼器的選項可在 %s 找到。"
+msgstr ""
+"%s 的相關資訊，以及該如何取得可播放這個格式的編解碼器的選項可在 %s 找到。"
 
 #. TRANSLATORS: this is when we know about an application or
 #. * addon, but it can't be listed for some reason
@@ -1663,15 +1667,15 @@ msgstr "沒有 %s 的印表機驅動程式可用。"
 msgid ""
 "Information about %s, as well as options for how to get a driver that "
 "supports this printer might be found %s."
-msgstr "%s 的相關資訊，以及該如何取得支援這個印表機的驅動程式的選項可在 %s 找到。"
+msgstr ""
+"%s 的相關資訊，以及該如何取得支援這個印表機的驅動程式的選項可在 %s 找到。"
 
 #. TRANSLATORS: hyperlink title
 #: src/gs-extras-page.c:459
 msgid "this website"
 msgstr "這個網站"
 
-#. TRANSLATORS: no codecs were found. First %s will be replaced by actual
-#. codec name(s), second %s is a link titled "this website"
+#. TRANSLATORS: no codecs were found. First %s will be replaced by actual codec name(s), second %s is a link titled "this website"
 #: src/gs-extras-page.c:463
 #, c-format
 msgid ""
@@ -1705,10 +1709,12 @@ msgstr "歡迎使用《軟體》"
 
 #: src/gs-first-run-dialog.ui:66
 msgid ""
-"Software lets you install all the software you need, all from one place. See"
-" our recommendations, browse the categories, or search for the applications "
+"Software lets you install all the software you need, all from one place. See "
+"our recommendations, browse the categories, or search for the applications "
 "you want."
-msgstr "《軟體》讓您安裝所有您需要的軟體，在一個地方滿足所有需求。請看看我們的推薦項目，瀏覽各項分類，或是直接搜尋您想要使用的應用程式。"
+msgstr ""
+"《軟體》讓您安裝所有您需要的軟體，在一個地方滿足所有需求。請看看我們的推薦項"
+"目，瀏覽各項分類，或是直接搜尋您想要使用的應用程式。"
 
 #: src/gs-first-run-dialog.ui:85
 msgid "_Let’s Go Shopping"
@@ -1862,8 +1868,7 @@ msgstr "提供額外軟體，包含一些網頁瀏覽器和遊戲。"
 
 #. TRANSLATORS: this is the proprietary info bar
 #: src/gs-overview-page.c:978
-msgid ""
-"Proprietary software has restrictions on use and access to source code."
+msgid "Proprietary software has restrictions on use and access to source code."
 msgstr "專有軟體對於使用用途、軟體源碼存取與否都有所限制。"
 
 #. TRANSLATORS: this is the clickable
@@ -1893,14 +1898,12 @@ msgstr "特色應用程式"
 msgid "Categories"
 msgstr "類別"
 
-#. Translators: This is a heading for software which has been featured
-#. ('picked') by the distribution.
+#. Translators: This is a heading for software which has been featured ('picked') by the distribution.
 #: src/gs-overview-page.ui:315
 msgid "Editor’s Picks"
 msgstr "編輯精選"
 
-#. Translators: This is a heading for software which has been recently
-#. released upstream.
+#. Translators: This is a heading for software which has been recently released upstream.
 #: src/gs-overview-page.ui:359
 msgid "Recent Releases"
 msgstr "最近發行"
@@ -1962,12 +1965,13 @@ msgstr "您確定要移除 %s？"
 msgid "%s will be removed, and you will have to install it to use it again."
 msgstr "%s 將被移除，將來若您想使用時則須再次安裝。"
 
-#: lib/gs-plugin-loader.c:1429
+#: lib/gs-plugin-loader.c:1433
 #, c-format
 msgid ""
 "Information about %s, as well as options for how to get a codec that can "
 "play this format can be found on the website."
-msgstr "%s 的相關資訊，以及網站上提供的該如何取得可播放此格式的編解碼器之選項。"
+msgstr ""
+"%s 的相關資訊，以及網站上提供的該如何取得可播放此格式的編解碼器之選項。"
 
 #: lib/gs-price.c:111
 #, c-format
@@ -2026,7 +2030,9 @@ msgstr "%s %f"
 msgid ""
 "Some of the currently installed software is not compatible with %s. If you "
 "continue, the following will be automatically removed during the upgrade:"
-msgstr "目前安裝的軟體有些和 %s 並不相容。若您希望繼續，則下列軟體在升級過程中會自動移除："
+msgstr ""
+"目前安裝的軟體有些和 %s 並不相容。若您希望繼續，則下列軟體在升級過程中會自動"
+"移除："
 
 #: src/gs-removal-dialog.ui:27
 msgid "Incompatible Software"
@@ -2096,8 +2102,7 @@ msgstr "描述太短"
 msgid "The description is too long"
 msgstr "描述太長"
 
-#. Translators: Title of the dialog box where the users can write and publish
-#. their opinions about the apps.
+#. Translators: Title of the dialog box where the users can write and publish their opinions about the apps.
 #: src/gs-review-dialog.ui:11
 msgid "Post Review"
 msgstr "張貼評論"
@@ -2157,8 +2162,7 @@ msgstr "提報評論？"
 msgid "Report"
 msgstr "提報"
 
-#. Translators: Users can express their opinions about other users' opinions
-#. about the apps.
+#. Translators: Users can express their opinions about other users' opinions about the apps.
 #: src/gs-review-row.ui:112
 msgid "Was this review useful to you?"
 msgstr "這則評論對您有用嗎?"
@@ -2246,81 +2250,80 @@ msgstr "找不到應用程式"
 #. TRANSLATORS: this is part of the in-app notification,
 #. * where the %s is a multi-word localised app name
 #. * e.g. 'Getting things GNOME!"
-#: src/gs-shell.c:846 src/gs-shell.c:851 src/gs-shell.c:866 src/gs-shell.c:870
+#: src/gs-shell.c:847 src/gs-shell.c:852 src/gs-shell.c:867 src/gs-shell.c:871
 #, c-format
 msgid "“%s”"
 msgstr "「%s」"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:898
+#: src/gs-shell.c:899
 #, c-format
 msgid "Unable to download firmware updates from %s"
 msgstr "無法從 %s 下載韌體更新"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:904
+#: src/gs-shell.c:905
 #, c-format
 msgid "Unable to download updates from %s"
 msgstr "無法從 %s 下載更新"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:911
+#: src/gs-shell.c:912
 msgid "Unable to download updates"
 msgstr "無法下載更新"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:916
+#: src/gs-shell.c:917
 msgid ""
-"Unable to download updates: internet access was required but wasn’t "
-"available"
+"Unable to download updates: internet access was required but wasn’t available"
 msgstr "無法下載更新：必須要有網際網路存取但卻無法使用。"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the source (e.g. "alt.fedoraproject.org")
-#: src/gs-shell.c:925
+#: src/gs-shell.c:926
 #, c-format
 msgid "Unable to download updates from %s: not enough disk space"
 msgstr "無法從 %s 下載更新：磁碟空間不足"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:930
+#: src/gs-shell.c:931
 msgid "Unable to download updates: not enough disk space"
 msgstr "無法下載更新：磁碟空間不足"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:938
+#: src/gs-shell.c:939
 msgid "Unable to download updates: authentication was required"
 msgstr "無法下載更新：需要核對身份"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:943
+#: src/gs-shell.c:944
 msgid "Unable to download updates: authentication was invalid"
 msgstr "無法下載更新：身份核對無效"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:948
+#: src/gs-shell.c:949
 msgid ""
 "Unable to download updates: you do not have permission to install software"
 msgstr "無法下載更新：您的權限不足以安裝軟體"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:955
+#: src/gs-shell.c:956
 msgid "Unable to get list of updates"
 msgstr "無法取得更新清單"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the application name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1001
+#: src/gs-shell.c:1002
 #, c-format
 msgid "Unable to install %s as download failed from %s"
 msgstr "無法安裝 %s，因為從 %s 下載失敗"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1007
+#: src/gs-shell.c:1008
 #, c-format
 msgid "Unable to install %s as download failed"
 msgstr "無法安裝 %s，因為下載失敗"
@@ -2329,51 +2332,51 @@ msgstr "無法安裝 %s，因為下載失敗"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1019
+#: src/gs-shell.c:1020
 #, c-format
 msgid "Unable to install %s as runtime %s not available"
 msgstr "無法安裝 %s，因為無法使用 %s 執行時期環境"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1025
+#: src/gs-shell.c:1026
 #, c-format
 msgid "Unable to install %s as not supported"
 msgstr "無法安裝 %s，因為尚未支援"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1032
+#: src/gs-shell.c:1033
 msgid "Unable to install: internet access was required but wasn’t available"
 msgstr "無法安裝：必須要有網際網路存取但卻無法使用。"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1038
+#: src/gs-shell.c:1039
 msgid "Unable to install: the application has an invalid format"
 msgstr "無法安裝：應用程式內含無效格式"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1043
+#: src/gs-shell.c:1044
 #, c-format
 msgid "Unable to install %s: not enough disk space"
 msgstr "無法安裝 %s：磁碟空間不足"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1051
+#: src/gs-shell.c:1052
 #, c-format
 msgid "Unable to install %s: authentication was required"
 msgstr "無法安裝 %s：需要核對身份"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1058
+#: src/gs-shell.c:1059
 #, c-format
 msgid "Unable to install %s: authentication was invalid"
 msgstr "無法安裝 %s：身份核對無效"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1065
+#: src/gs-shell.c:1066
 #, c-format
 msgid "Unable to install %s: you do not have permission to install software"
 msgstr "無法安裝 %s：您的權限不足以安裝軟體"
@@ -2381,34 +2384,34 @@ msgstr "無法安裝 %s：您的權限不足以安裝軟體"
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the name of the authentication service,
 #. * e.g. "Ubuntu One"
-#: src/gs-shell.c:1078
+#: src/gs-shell.c:1079
 #, c-format
 msgid "Your %s account has been suspended."
 msgstr "您的 %s 帳號已經停用。"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1082
+#: src/gs-shell.c:1083
 msgid "It is not possible to install software until this has been resolved."
 msgstr "除非此問題得到解決，否則無法安裝程式。"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the clickable link (e.g.
 #. * "http://example.com/what-did-i-do-wrong/")
-#: src/gs-shell.c:1093
+#: src/gs-shell.c:1094
 #, c-format
 msgid "For more information, visit %s."
 msgstr "若想瞭解詳細資訊，請造訪 %s。"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1102
+#: src/gs-shell.c:1103
 #, c-format
 msgid "Unable to install %s: AC power is required"
 msgstr "無法安裝 %s：需要交流電源"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1111
+#: src/gs-shell.c:1112
 #, c-format
 msgid "Unable to install %s"
 msgstr "無法安裝 %s"
@@ -2417,61 +2420,61 @@ msgstr "無法安裝 %s"
 #. * where the first %s is the app name (e.g. "GIMP") and
 #. * the second %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1157
+#: src/gs-shell.c:1158
 #, c-format
 msgid "Unable to update %s from %s"
 msgstr "無法安裝 %s，來源為 %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1163
+#: src/gs-shell.c:1164
 #, c-format
 msgid "Unable to update %s as download failed"
 msgstr "無法更新 %s，因為下載失敗"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1169
+#: src/gs-shell.c:1170
 msgid "Unable to update: internet access was required but wasn’t available"
 msgstr "無法更新：必須要有網際網路存取但卻無法使用。"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1177
+#: src/gs-shell.c:1178
 #, c-format
 msgid "Unable to update %s: not enough disk space"
 msgstr "無法更新 %s：磁碟空間不足"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1186
+#: src/gs-shell.c:1187
 #, c-format
 msgid "Unable to update %s: authentication was required"
 msgstr "無法更新 %s：需要核對身份"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1193
+#: src/gs-shell.c:1194
 #, c-format
 msgid "Unable to update %s: authentication was invalid"
 msgstr "無法更新 %s：身份核對無效"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1200
+#: src/gs-shell.c:1201
 #, c-format
 msgid "Unable to update %s: you do not have permission to update software"
 msgstr "無法更新 %s：您的權限不足以更新軟體"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "Dell XPS 13")
-#: src/gs-shell.c:1208
+#: src/gs-shell.c:1209
 #, c-format
 msgid "Unable to update %s: AC power is required"
 msgstr "無法更新 %s：需要交流電源"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1217
+#: src/gs-shell.c:1218
 #, c-format
 msgid "Unable to update %s"
 msgstr "無法更新 %s"
@@ -2479,96 +2482,96 @@ msgstr "無法更新 %s"
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the first %s is the distro name (e.g. "Fedora 25") and
 #. * the second %s is the origin, e.g. "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1262
+#: src/gs-shell.c:1263
 #, c-format
 msgid "Unable to upgrade to %s from %s"
 msgstr "無法升級成 %s，來源為 %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the app name (e.g. "GIMP")
-#: src/gs-shell.c:1267
+#: src/gs-shell.c:1268
 #, c-format
 msgid "Unable to upgrade to %s as download failed"
 msgstr "無法升級成 %s，因為下載失敗"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1274
+#: src/gs-shell.c:1275
 msgid "Unable to upgrade: internet access was required but wasn’t available"
 msgstr "無法升級：必須要有網際網路存取但卻無法使用。"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1282
+#: src/gs-shell.c:1283
 #, c-format
 msgid "Unable to upgrade to %s: not enough disk space"
 msgstr "無法升級成 %s：磁碟空間不足"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1291
+#: src/gs-shell.c:1292
 #, c-format
 msgid "Unable to upgrade to %s: authentication was required"
 msgstr "無法升級成 %s：需要核對身份"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1298
+#: src/gs-shell.c:1299
 #, c-format
 msgid "Unable to upgrade to %s: authentication was invalid"
 msgstr "無法升級成 %s：身份核對無效"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1305
+#: src/gs-shell.c:1306
 #, c-format
 msgid "Unable to upgrade to %s: you do not have permission to upgrade"
 msgstr "無法升級成 %s：您的權限不足以升級"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1312
+#: src/gs-shell.c:1313
 #, c-format
 msgid "Unable to upgrade to %s: AC power is required"
 msgstr "無法升級成 %s：需要交流電源"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the distro name (e.g. "Fedora 25")
-#: src/gs-shell.c:1321
+#: src/gs-shell.c:1322
 #, c-format
 msgid "Unable to upgrade to %s"
 msgstr "%s 的升級失敗。"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1363
+#: src/gs-shell.c:1364
 #, c-format
 msgid "Unable to remove %s: authentication was required"
 msgstr "無法移除 %s：需要核對身份"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1369
+#: src/gs-shell.c:1370
 #, c-format
 msgid "Unable to remove %s: authentication was invalid"
 msgstr "無法移除 %s：身份核對無效"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1375
+#: src/gs-shell.c:1376
 #, c-format
 msgid "Unable to remove %s: you do not have permission to remove software"
 msgstr "無法移除 %s：您的權限不足以移除軟體"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1382
+#: src/gs-shell.c:1383
 #, c-format
 msgid "Unable to remove %s: AC power is required"
 msgstr "無法移除 %s：需要交流電源"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1391
+#: src/gs-shell.c:1392
 #, c-format
 msgid "Unable to remove %s"
 msgstr "無法移除 %s"
@@ -2577,48 +2580,48 @@ msgstr "無法移除 %s"
 #. * where the first %s is the application name (e.g. "GIMP")
 #. * and the second %s is the name of the runtime, e.g.
 #. * "GNOME SDK [flatpak.gnome.org]"
-#: src/gs-shell.c:1437
+#: src/gs-shell.c:1438
 #, c-format
 msgid "Unable to launch %s: %s is not installed"
 msgstr "無法啟動 %s：%s 未安裝"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1444 src/gs-shell.c:1492 src/gs-shell.c:1540
+#: src/gs-shell.c:1445 src/gs-shell.c:1493 src/gs-shell.c:1541
 msgid "Not enough disk space — free up some space and try again"
 msgstr "沒有足夠的磁碟空間 — 請空出部分空間後再試一次"
 
 #. TRANSLATORS: we failed to get a proper error code
-#: src/gs-shell.c:1452 src/gs-shell.c:1500 src/gs-shell.c:1567
+#: src/gs-shell.c:1453 src/gs-shell.c:1501 src/gs-shell.c:1568
 msgid "Sorry, something went wrong"
 msgstr "很抱歉，有事情出錯了"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1487
+#: src/gs-shell.c:1488
 msgid "Failed to install file: authentication failed"
 msgstr "無法安裝檔案：核對失敗"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * the %s is the origin, e.g. "Fedora" or
 #. * "Fedora Project [fedoraproject.org]"
-#: src/gs-shell.c:1534
+#: src/gs-shell.c:1535
 #, c-format
 msgid "Unable to contact %s"
 msgstr "無法聯絡 %s"
 
 #. TRANSLATORS: failure text for the in-app notification,
 #. * where the %s is the application name (e.g. "GIMP")
-#: src/gs-shell.c:1549
+#: src/gs-shell.c:1550
 #, c-format
 msgid "%s needs to be restarted to use new plugins."
 msgstr "%s 需要重新開機才能使用新的外掛程式。"
 
 #. TRANSLATORS: failure text for the in-app notification
-#: src/gs-shell.c:1554
+#: src/gs-shell.c:1555
 msgid "This application needs to be restarted to use new plugins."
 msgstr "這個應用程式需要重新開機才能使用新的外掛程式。"
 
 #. TRANSLATORS: need to be connected to the AC power
-#: src/gs-shell.c:1561
+#: src/gs-shell.c:1562
 msgid "AC power is required"
 msgstr "需要交流電源"
 
@@ -2905,8 +2908,8 @@ msgstr "更新已取消。"
 #. * something with no network available
 #: src/gs-update-monitor.c:714
 msgid ""
-"Internet access was required but wasn’t available. Please make sure that you"
-" have internet access and try again."
+"Internet access was required but wasn’t available. Please make sure that you "
+"have internet access and try again."
 msgstr "需要存取網際網路但無法使用。請確定您能使用網際網路後再試一次。"
 
 #. TRANSLATORS: if the package is not signed correctly
@@ -2927,7 +2930,9 @@ msgstr "沒有足夠的磁碟空間。請空出部分空間後再試一次。"
 msgid ""
 "We’re sorry: the update failed to install. Please wait for another update "
 "and try again. If the problem persists, contact your software provider."
-msgstr "我們很抱歉：更新無法安裝。請等待下一次更新時再試一次。如果問題持續出現，請連絡您的軟體供應商。"
+msgstr ""
+"我們很抱歉：更新無法安裝。請等待下一次更新時再試一次。如果問題持續出現，請連"
+"絡您的軟體供應商。"
 
 #. TRANSLATORS: Time in 24h format
 #: src/gs-updates-page.c:297
@@ -3211,22 +3216,28 @@ msgid "App Center"
 msgstr "應用中心"
 
 #: src/org.gnome.Software.desktop.in:4
+msgid "More Apps"
+msgstr "更多應用程式"
+
+#: src/org.gnome.Software.desktop.in:5
 msgid "Add, remove or update software on this computer"
 msgstr "在這臺電腦上加入、移除、或更新軟體"
 
-#. Translators: Do NOT translate or transliterate this text (this is an icon
-#. file name)!
-#: src/org.gnome.Software.desktop.in:6
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: src/org.gnome.Software.desktop.in:7
 #: src/org.gnome.Software.Editor.desktop.in:6
 msgid "org.gnome.Software"
 msgstr "org.gnome.Software"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
-#: src/org.gnome.Software.desktop.in:12
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: src/org.gnome.Software.desktop.in:13
 msgid ""
-"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;"
-msgstr "Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;Software;App;Store;;更新;升級;來源;套件庫;軟體庫;倉庫;偏好設定;安裝;解除安裝;程式;軟體;應用;商店;"
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;"
+msgstr ""
+"Updates;Upgrade;Sources;Repositories;Preferences;Install;Uninstall;Program;"
+"Software;App;Store;;更新;升級;來源;套件庫;軟體庫;倉庫;偏好設定;安裝;解除安裝;"
+"程式;軟體;應用;商店;"
 
 #: src/org.gnome.Software.Editor.desktop.in:3
 msgid "Banner Designer"
@@ -3236,8 +3247,7 @@ msgstr "橫幅設計師"
 msgid "Design the featured banners for GNOME Software"
 msgstr "設計 GNOME《軟體》的特選橫幅"
 
-#. Translators: Search terms to find this application. Do NOT translate or
-#. localize the semicolons! The list MUST also end with a semicolon!
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: src/org.gnome.Software.Editor.desktop.in:13
 msgid "AppStream;Software;App;"
 msgstr "AppStream;Software;App;軟體;程式;"
@@ -3507,100 +3517,111 @@ msgctxt "Menu of Communication & News"
 msgid "Web Browsers"
 msgstr "網頁瀏覽器"
 
-#: plugins/core/gs-desktop-common.c:247
-msgctxt "Menu of Reference"
-msgid "All"
-msgstr "全部"
-
-#: plugins/core/gs-desktop-common.c:250
-msgctxt "Menu of Reference"
-msgid "Featured"
-msgstr "特選"
-
-#: plugins/core/gs-desktop-common.c:253
-msgctxt "Menu of Reference"
-msgid "Art"
-msgstr "藝術"
-
-#: plugins/core/gs-desktop-common.c:256
-msgctxt "Menu of Reference"
-msgid "Biography"
-msgstr "傳記"
-
-#: plugins/core/gs-desktop-common.c:259
-msgctxt "Menu of Reference"
-msgid "Comics"
-msgstr "漫畫"
-
-#: plugins/core/gs-desktop-common.c:262
-msgctxt "Menu of Reference"
-msgid "Fiction"
-msgstr "小說"
-
-#: plugins/core/gs-desktop-common.c:265
-msgctxt "Menu of Reference"
-msgid "Health"
-msgstr "健康"
-
-#: plugins/core/gs-desktop-common.c:268
-msgctxt "Menu of Reference"
-msgid "History"
-msgstr "歷史"
-
-#: plugins/core/gs-desktop-common.c:271
-msgctxt "Menu of Reference"
-msgid "Lifestyle"
-msgstr "生活風格"
-
-#: plugins/core/gs-desktop-common.c:274
+#: plugins/core/gs-desktop-common.c:242
 msgctxt "Menu of Communication & News"
 msgid "News"
 msgstr "新聞"
 
+#: plugins/core/gs-desktop-common.c:251
+msgctxt "Menu of Reference"
+msgid "All"
+msgstr "全部"
+
+#: plugins/core/gs-desktop-common.c:254
+msgctxt "Menu of Reference"
+msgid "Featured"
+msgstr "特選"
+
+#: plugins/core/gs-desktop-common.c:257
+msgctxt "Menu of Reference"
+msgid "Art"
+msgstr "藝術"
+
+#: plugins/core/gs-desktop-common.c:260
+msgctxt "Menu of Reference"
+msgid "Biography"
+msgstr "傳記"
+
+#: plugins/core/gs-desktop-common.c:263
+msgctxt "Menu of Reference"
+msgid "Comics"
+msgstr "漫畫"
+
+#: plugins/core/gs-desktop-common.c:266
+msgctxt "Menu of Reference"
+msgid "Feed"
+msgstr ""
+
+#: plugins/core/gs-desktop-common.c:269
+msgctxt "Menu of Reference"
+msgid "Fiction"
+msgstr "小說"
+
+#: plugins/core/gs-desktop-common.c:272
+msgctxt "Menu of Reference"
+msgid "Health"
+msgstr "健康"
+
+#: plugins/core/gs-desktop-common.c:275
+msgctxt "Menu of Reference"
+msgid "History"
+msgstr "歷史"
+
 #: plugins/core/gs-desktop-common.c:278
+msgctxt "Menu of Reference"
+msgid "Lifestyle"
+msgstr "生活風格"
+
+#: plugins/core/gs-desktop-common.c:281
+#, fuzzy
+msgctxt "Menu of Reference"
+msgid "News"
+msgstr "新聞"
+
+#: plugins/core/gs-desktop-common.c:284
 msgctxt "Menu of Reference"
 msgid "Politics"
 msgstr "政治"
 
-#: plugins/core/gs-desktop-common.c:281
+#: plugins/core/gs-desktop-common.c:287
 msgctxt "Menu of Reference"
 msgid "Sports"
 msgstr "運動"
 
 #. TRANSLATORS: this is the menu spec main category for Learning
-#: plugins/core/gs-desktop-common.c:291
+#: plugins/core/gs-desktop-common.c:297
 msgid "Learning"
 msgstr "教學"
 
 #. TRANSLATORS: this is the menu spec main category for Game
-#: plugins/core/gs-desktop-common.c:294
+#: plugins/core/gs-desktop-common.c:300
 msgid "Games"
 msgstr "遊戲"
 
 #. TRANSLATORS: this is the menu spec main category for Multimedia
-#: plugins/core/gs-desktop-common.c:297
+#: plugins/core/gs-desktop-common.c:303
 msgid "Multimedia"
 msgstr "多媒體"
 
 #. TRANSLATORS: this is the menu spec main category for Work
-#: plugins/core/gs-desktop-common.c:300
+#: plugins/core/gs-desktop-common.c:306
 msgid "Work"
 msgstr "工作"
 
 #. TRANSLATORS: this is the menu spec main category for Reference
-#: plugins/core/gs-desktop-common.c:303
+#: plugins/core/gs-desktop-common.c:309
 msgid "Reference & News"
 msgstr "參考資料與最新消息"
 
 #. TRANSLATORS: this is the menu spec main category for Utilities
-#: plugins/core/gs-desktop-common.c:306
+#: plugins/core/gs-desktop-common.c:312
 msgid "Utilities"
 msgstr "公用程式"
 
 #. TRANSLATORS: this is the menu spec main category for Dev Tools; it
 #. * should be a relatively short label; as an example, in Portuguese and
 #. * Spanish the direct translation of "Programming" (noun) is used
-#: plugins/core/gs-desktop-common.c:311
+#: plugins/core/gs-desktop-common.c:317
 msgid "Dev Tools"
 msgstr "開發者工具"
 
@@ -3626,16 +3647,16 @@ msgstr "包括效能、穩定性、安全性等改善。"
 msgid "Downloading featured images…"
 msgstr "下載特選影像中…"
 
-#: plugins/eos/gs-plugin-eos.c:1249
+#: plugins/eos/gs-plugin-eos.c:1233
 #, c-format
 msgid "Could not launch this application."
 msgstr "無法啟動本應用程序。"
 
-#: plugins/eos/gs-plugin-eos.c:1305
+#: plugins/eos/gs-plugin-eos.c:1289
 msgid "Endless Platform"
 msgstr "Endless 平台"
 
-#: plugins/eos/gs-plugin-eos.c:1308
+#: plugins/eos/gs-plugin-eos.c:1292
 msgid "Framework for applications"
 msgstr "應用程式的架構"
 
@@ -3695,13 +3716,13 @@ msgid "Flatpak is a framework for desktop applications on Linux"
 msgstr "Flatpak 是一個用於 Linux 桌面應用程式框架"
 
 #. TRANSLATORS: status text when downloading new metadata
-#: plugins/flatpak/gs-flatpak.c:821
+#: plugins/flatpak/gs-flatpak.c:815
 #, c-format
 msgid "Getting flatpak metadata for %s…"
 msgstr "取得 %s 的 flatpak 中介資料…"
 
 #. TRANSLATORS: status text when downloading the RuntimeRepo
-#: plugins/flatpak/gs-flatpak.c:2796
+#: plugins/flatpak/gs-flatpak.c:2803
 msgid "Getting runtime source…"
 msgstr "取得執行時期來源中…"
 

--- a/src/org.gnome.Software.desktop.in
+++ b/src/org.gnome.Software.desktop.in
@@ -1,5 +1,6 @@
 [Desktop Entry]
 Name=App Center
+GenericName=More Apps
 Comment=Add, remove or update software on this computer
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=org.gnome.Software


### PR DESCRIPTION
This will allow us to use it from the shell in the desktop grid, as well as to make this particular string searchable from the desktop, so that "More Apps" (or its translation) matches the App Center.

This PR also includes an update to the .pot file and to the relevant .po files, for which I got the translated strings straight from GNOME Shell, where they used to live until now.

https://phabricator.endlessm.com/T18933