### PR TITLE
Remove the suggested-action style from the Update button

### DIFF
--- a/src/gs-details-page.c
+++ b/src/gs-details-page.c
@@ -303,6 +303,7 @@ gs_details_page_switch_to (GsPage *page, gboolean scroll_up)
 		gtk_widget_set_visible (self->button_install, FALSE);
 		break;
 	case AS_APP_STATE_UPDATABLE_LIVE:
+		gtk_style_context_remove_class (gtk_widget_get_style_context (self->button_install), "suggested-action");
 		gtk_widget_set_visible (self->button_install, TRUE);
 		if (gs_app_get_kind (self->app) == AS_APP_KIND_FIRMWARE) {
 			/* TRANSLATORS: button text in the header when firmware


### PR DESCRIPTION
Only the Install and Add-to-desktop button should have the suggested
action, not the Update button. By mistake this change has not been
included in the patch that modifies this for other occasions. So this
patch should be squashed with f52e8f7a4aada021145c54f4fa2b5b3c6a048a2f
in the next rebase.

https://phabricator.endlessm.com/T19764