### PR TITLE
eos: Blacklist freedoom games for es_GT personality

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -738,7 +738,9 @@ app_is_banned_for_personality (GsPlugin *plugin, GsApp *app)
 		return FALSE;
 
 	return ((g_strcmp0 (priv->personality, "es_GT") == 0) &&
-	        (g_strcmp0 (id, "org.openarena.Openarena.desktop") == 0)) ||
+	        ((g_strcmp0 (id, "io.github.Freedoom-Phase-1.desktop") == 0) ||
+		 (g_strcmp0 (id, "io.github.Freedoom-Phase-2.desktop") == 0) ||
+		 (g_strcmp0 (id, "org.openarena.Openarena.desktop") == 0))) ||
 	       ((g_strcmp0 (priv->personality, "zh_CN") == 0) &&
 	        ((g_strcmp0 (id, "com.google.Chrome.desktop") == 0) ||
 	         (g_strcmp0 (id, "com.endlessm.translation.desktop") == 0) ||


### PR DESCRIPTION
Just like we do for Open Arena, due to the cultural sensitivity
around violent content.

https://phabricator.endlessm.com/T19954