### PR TITLE
eos: Fix launching system apps

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -1284,8 +1284,10 @@ gs_plugin_launch (GsPlugin *plugin,
 		  GCancellable *cancellable,
 		  GError **error)
 {
-	if (g_strcmp0 (gs_app_get_management_plugin (app),
-		       gs_plugin_get_name (plugin)) == 0) {
+	/* if the app is one of the system ones, we simply launch it through the
+	 * plugin's app launcher */
+	if (gs_app_has_quirk (app, AS_APP_QUIRK_COMPULSORY) &&
+	    !app_is_flatpak (app)) {
 		return gs_plugin_app_launch (plugin, app, error);
 	}
 


### PR DESCRIPTION
In ab8ffb62f39198785fe730fd13f7f70b7cfc6f0e we started assigning the
plugin that calls for the creation of an app as its management plugin.
This broke launching system apps on EOS because our EOS plugin was
launching only apps that had it as their management plugin (which it
was setting to compulsory apps that had yet none assigned), and those
apps are now getting 'appstream' as their management plugin instead.

To fix this, instead of changing the management plugin, I have replaced
the check for the management plugin with a check for whether the app
being launched is a compulsory, non-flatpak app (just checking for
compulsory should be fine, but this way it is more future proof).

https://phabricator.endlessm.com/T19983