### PR TITLE
Remove the "generic-updates" plugin

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -63,6 +63,7 @@ override_dh_install-arch:
 	rm -f debian/tmp/usr/lib/*/gs-plugins-*/libgs_plugin_dummy*
 	rm -f debian/tmp/usr/lib/*/gs-plugins-*/libgs_plugin_epiphany*
 	rm -f debian/tmp/usr/lib/*/gs-plugins-*/libgs_plugin_repos*
+	rm -f debian/tmp/usr/lib/*/gs-plugins-*/libgs_plugin_generic-updates*
 	dh_install
 
 override_dh_missing:


### PR DESCRIPTION
This plugin is not only not needed by us but is also creating a problem
by converting any packages that are of the kind "generic" into
OS updates, and this is happening with some of our apps.

https://phabricator.endlessm.com/T20135