### PR TITLE
Fix enabling/disabling software sources

### DIFF
--- a/src/gs-application.c
+++ b/src/gs-application.c
@@ -806,7 +806,7 @@ gs_application_update_software_sources_presence (GApplication *self)
 	GSimpleAction *action;
 	gboolean enable_sources;
 
-	action = G_SIMPLE_ACTION (g_action_map_lookup_action (G_ACTION_MAP (app->action_map),
+	action = G_SIMPLE_ACTION (g_action_map_lookup_action (G_ACTION_MAP (self),
 							      "sources"));
 	enable_sources = g_settings_get_boolean (GS_APPLICATION (self)->settings,
 						 ENABLE_SOFTWARE_SOURCES_CONF_KEY);
@@ -884,6 +884,8 @@ gs_application_add_wrapper_actions (GApplication *application)
 		g_signal_connect (simple_action, "activate",
 				  G_CALLBACK (wrapper_action_activated_cb),
 				  application);
+		g_object_bind_property (simple_action, "notify::enabled", action,
+					"notify::enabled", G_BINDING_DEFAULT);
 		g_action_map_add_action (G_ACTION_MAP (application),
 					 G_ACTION (simple_action));
 	}


### PR DESCRIPTION
Enabling and disabling the software sources was broken since we started
calling certain actions after the loading state is finished (by using a
wrapper action that is added to the application's map, which calls the
real action from a secondary map). The problem was that the right action
was being disabled/enabled (so the software sources dialog was not
shown), but the wrapper action's wasn't being affected (and this is the
one that is associated with the menu item).

This patch fixes that by enabling or disabling the wrapper action
instead, since this is the one that belongs to the application's map,
and by binding the "notify::enabled" property of the real app with it.

This way, if in the future we have to disable other actions, this
problem will no longer happen.

https://phabricator.endlessm.com/T20236