### PR TITLE
eos: blacklist LibreOffice from Flathub

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -649,6 +649,7 @@ gs_plugin_eos_blacklist_upstream_app_if_needed (GsPlugin *plugin, GsApp *app)
 		"org.gnome.clocks.desktop",
 		"org.gnome.eog.desktop",
 		"org.gnome.gedit.desktop",
+		"org.libreoffice.LibreOffice",
 		NULL
 	};
 


### PR DESCRIPTION
We currently provide LibreOffice as a core app, and now that it is
available on Flathub we want to avoid duplication/confusion.

https://phabricator.endlessm.com/T20253