### PR TITLE
Fix binding the enabled property of the wrapper and real actions

### DIFF
--- a/src/gs-application.c
+++ b/src/gs-application.c
@@ -802,7 +802,6 @@ static GActionEntry actions_after_loading[] = {
 static void
 gs_application_update_software_sources_presence (GApplication *self)
 {
-	GsApplication *app = GS_APPLICATION (self);
 	GSimpleAction *action;
 	gboolean enable_sources;
 
@@ -884,8 +883,8 @@ gs_application_add_wrapper_actions (GApplication *application)
 		g_signal_connect (simple_action, "activate",
 				  G_CALLBACK (wrapper_action_activated_cb),
 				  application);
-		g_object_bind_property (simple_action, "notify::enabled", action,
-					"notify::enabled", G_BINDING_DEFAULT);
+		g_object_bind_property (simple_action, "enabled", action,
+					"enabled", G_BINDING_DEFAULT);
 		g_action_map_add_action (G_ACTION_MAP (application),
 					 G_ACTION (simple_action));
 	}


### PR DESCRIPTION
The patch that fixes enabling/disabling the sources action used
the action name incorrectly when binding the wrapper and real actions'
"enabled" property (it included the "notify::" prefix).

This patch removes that wrong prefix and also a left over declaration
that was producing a warning.

https://phabricator.endlessm.com/T20236