### PR TITLE
eos: Don't blacklist io.atom.Atom

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -532,7 +532,6 @@ gs_plugin_eos_blacklist_upstream_app_if_needed (GsPlugin *plugin, GsApp *app)
 		"com.valvesoftware.Steam.desktop",
 		"com.visualstudio.code.oss.desktop",
 		"de.billardgl.Billardgl.desktop",
-		"io.atom.Atom.desktop",
 		"io.github.Supertux.desktop",
 		"org.supertuxproject.SuperTux.desktop",
 		"net.blockout.Blockout2.desktop",


### PR DESCRIPTION
We are deprecating our build (based on freedesktop 1.4) and exposing
the version from flathub (based on freedesktop 1.6) instead.
Even though we don't have a clean transition for existing app users,
attempts to build our version against freedesktop 1.6 failed.

https://phabricator.endlessm.com/T20301