### PR TITLE
flatpak: Check if a related app is installed even when dealing with u…

### DIFF
--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -2915,7 +2915,8 @@ gs_flatpak_get_list_for_install_or_update (GsFlatpak *self,
 				   error_local->message);
 			continue;
 		}
-		if (is_update && !gs_app_is_updatable (app_tmp)) {
+		if (gs_app_is_installed (app_tmp) && is_update &&
+		    !gs_app_is_updatable (app_tmp)) {
 			g_debug ("not adding related %s as it's not updatable", ref_display);
 			continue;
 		}


### PR DESCRIPTION
…pdates

When dealing with updates, gs-flatpak gets the list of related apps
(usually runtime extensions) that should be updated together with the
main app. However, if one of those related apps is not installed, the
gs_app_is_updatable call will return FALSE and the app will not be
installed.
This is a problem when e.g. a runtime extension has been mistakenly
removed, or when an app is updated and needs a new runtime extension.

This patch simply adds a further test for whether the app is installed,
together with the logic mentioned above.
In a future rebase, this patch should be squashed with
9b64959a09ef96eb215b1cc278354242573cc22e.

https://phabricator.endlessm.com/T20418