### PR TITLE
Fix blacklisting apps when searching for them

### DIFF
--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -239,7 +239,8 @@ handle_get_discovery_feed_apps (GsDiscoveryFeedInstallableApps *skeleton,
 	plugin_job = gs_plugin_job_newv (GS_PLUGIN_ACTION_SEARCH,
 					 "search", "com.endlessm",
 					 "failure-flags", GS_PLUGIN_FAILURE_FLAGS_NONE,
-					 "refine-flags", GS_PLUGIN_REFINE_FLAGS_REQUIRE_ICON,
+					 "refine-flags", GS_PLUGIN_REFINE_FLAGS_REQUIRE_ICON |
+							 GS_PLUGIN_REFINE_FLAGS_REQUIRE_ORIGIN_HOSTNAME,
 					 "max-results", MAX_RESULTS,
 					 NULL);
 	gs_plugin_loader_job_process_async (self->plugin_loader, plugin_job,

--- a/src/gs-shell-search-provider.c
+++ b/src/gs-shell-search-provider.c
@@ -180,7 +180,8 @@ execute_search (GsShellSearchProvider  *self,
 	plugin_job = gs_plugin_job_newv (GS_PLUGIN_ACTION_SEARCH,
 					 "search", value,
 					 "failure-flags", GS_PLUGIN_FAILURE_FLAGS_NONE,
-					 "refine-flags", GS_PLUGIN_REFINE_FLAGS_REQUIRE_ICON,
+					 "refine-flags", GS_PLUGIN_REFINE_FLAGS_REQUIRE_ICON |
+							 GS_PLUGIN_REFINE_FLAGS_REQUIRE_ORIGIN_HOSTNAME,
 					 "max-results", GS_SHELL_SEARCH_PROVIDER_MAX_RESULTS,
 					 NULL);
 	gs_plugin_job_set_sort_func (plugin_job, gs_shell_search_provider_sort_cb);


### PR DESCRIPTION
When searching for apps in the shell, some apps were incorrectly not
being blacklisted (i.e. shown in the search results). This happened to
apps that needed to be blacklisted because they exist both in Endless'
repos and Flathub, and the cause was that the blacklisting logic uses
needs the origin's hostname to be set in those apps, and such flag was
not passed by the search call.

To fix this issue, this patch simply adds the ORIGIN_HOSTNAME refine
flag to the search call in the shell search provider and the discovery
feed content provider.

https://phabricator.endlessm.com/T20268