### PR TITLE
flatpak: Fix EknServices-picking logic

### DIFF
--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -2761,12 +2761,11 @@ gs_flatpak_get_services_app_for_runtime (GsFlatpak *self, GsApp *runtime,
 		services_id = g_strdup ("com.endlessm.EknServices");
 		services_branch = "eos3";
 	} else if (g_strcmp0 (runtime_id, "com.endlessm.apps.Platform") == 0) {
+		services_id = g_strdup ("com.endlessm.EknServices2");
 		if (g_strcmp0 (runtime_branch, "master") == 0)
-			services_id = g_strdup ("com.endlessm.EknServices2");
+			services_branch = "master";
 		else
-			services_id = g_strdup_printf ("com.endlessm.EknServices%s",
-			                               runtime_branch);
-		services_branch = "stable";
+			services_branch = "stable";
 	} else {
 		/* Runtime doesn't require an EknServices app */
 		return NULL;


### PR DESCRIPTION
The previous code would start looking for com.endlessm.EknServices3 when
installing an SDK3 app. That is incorrect, it should keep using
com.endlessm.EknServices2 until we bump the version number of that
service due to some backwards-incompatibility.

https://phabricator.endlessm.com/T20846