### PR TITLE
trivial: Fix a critical warning if XDG_CURRENT_DESKTOP is unset

### DIFF
--- a/plugins/core/gs-appstream.c
+++ b/plugins/core/gs-appstream.c
@@ -716,20 +716,22 @@ gs_appstream_refine_app (GsPlugin *plugin,
 	 */
 	array = as_app_get_compulsory_for_desktops (item);
 	current_desktop = g_getenv ("XDG_CURRENT_DESKTOP");
-	xdg_current_desktops = g_strsplit (current_desktop, ":", 0);
-	for (i = 0; i < array->len; i++) {
-		tmp = g_ptr_array_index (array, i);
-		/* if the value has a :, check the whole string */
-		if (g_strstr_len (tmp, -1, ":")) {
-			if (g_strcmp0 (current_desktop, tmp) == 0) {
+	if (current_desktop != NULL) {
+		xdg_current_desktops = g_strsplit (current_desktop, ":", 0);
+		for (i = 0; i < array->len; i++) {
+			tmp = g_ptr_array_index (array, i);
+			/* if the value has a :, check the whole string */
+			if (g_strstr_len (tmp, -1, ":")) {
+				if (g_strcmp0 (current_desktop, tmp) == 0) {
+					gs_app_add_quirk (app, AS_APP_QUIRK_COMPULSORY);
+					break;
+				}
+			/* otherwise check if any element matches this one */
+			} else if (g_strv_contains ((const gchar * const *) xdg_current_desktops,
+				   tmp)) {
 				gs_app_add_quirk (app, AS_APP_QUIRK_COMPULSORY);
 				break;
 			}
-		/* otherwise check if any element matches this one */
-		} else if (g_strv_contains ((const gchar * const *) xdg_current_desktops,
-			   tmp)) {
-			gs_app_add_quirk (app, AS_APP_QUIRK_COMPULSORY);
-			break;
 		}
 	}
 


### PR DESCRIPTION
Trivial backport of the upstream commit [ccc2ca31d7c18bdce140b7b0be48ff3ad577aded](https://git.gnome.org/browse/gnome-software/commit/?id=ccc2ca31d7c18bdce140b7b0be48ff3ad577aded).