### PR TITLE
eos: Don't make apps "compulsory" if their scope is unknown

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -896,7 +896,8 @@ gs_plugin_adopt_app (GsPlugin *plugin, GsApp *app)
 static void
 gs_plugin_eos_refine_core_app (GsApp *app)
 {
-	if (app_is_flatpak (app))
+	if (app_is_flatpak (app) ||
+	    (gs_app_get_scope (app) == AS_APP_SCOPE_UNKNOWN))
 		return;
 
 	/* we only allow to remove flatpak apps */


### PR DESCRIPTION
When processing apps, we should only add the "compulsory" quirk if their
scope is system, otherwise we risk setting it to apps that still have
some wildcards in their unique IDs (pending being fully refined by a
plugin) which can end up blacklisting the app: apps that are not of the
desktop kind (it can be unknown/wildcard) but are set the compulsory
quirk in order to avoid showing fonts, addons, etc.

In future rebases, this patch should be squashed with
910c9572c9bbb4cd0a26fc475d574810c4f58b10.

https://phabricator.endlessm.com/T20108