### PR TITLE
Do not update apps when manually refreshing

### DIFF
--- a/src/gs-updates-page.c
+++ b/src/gs-updates-page.c
@@ -1308,8 +1308,6 @@ gs_updates_page_get_new_updates (GsUpdatesPage *self)
 
 	refresh_flags |= GS_PLUGIN_REFRESH_FLAGS_INTERACTIVE;
 	refresh_flags |= GS_PLUGIN_REFRESH_FLAGS_METADATA;
-	if (g_settings_get_boolean (self->settings, "download-updates"))
-		refresh_flags |= GS_PLUGIN_REFRESH_FLAGS_PAYLOAD;
 	plugin_job = gs_plugin_job_newv (GS_PLUGIN_ACTION_REFRESH,
 					 "failure-flags", GS_PLUGIN_FAILURE_FLAGS_USE_EVENTS,
 					 "refresh-flags", refresh_flags,


### PR DESCRIPTION
When manually refreshing GNOME Software (using the refresh button in the
updates page), updates were being downloaded or performed during the
refresh, while the updates page was shown as empty.
This UX is confusing since suddenly users see that updates disappear and
the refresh may take a long time to finish.
Besides, if users can already update all apps by clicking the "Update
All" button, then there's no real advantage in updating apps during a
manual refresh.

This patch stops the the manual refresh from performing app updates, so
it will simply refresh the metadata.

https://phabricator.endlessm.com/T20874