### PR TITLE
Fix how queued GTasks are processed in the Plugin Loader

### DIFF
--- a/lib/gs-plugin-loader.c
+++ b/lib/gs-plugin-loader.c
@@ -3381,13 +3381,17 @@ gs_plugin_loader_process_thread_cb (GTask *task,
 	g_task_return_pointer (task, g_object_ref (list), (GDestroyNotify) g_object_unref);
 }
 
-
 static void
 gs_plugin_loader_process_in_thread_pool_cb (gpointer data,
 					    gpointer user_data)
 {
 	GTask *task = data;
-	g_task_run_in_thread_sync (task, gs_plugin_loader_process_thread_cb);
+	gpointer source_object = g_task_get_source_object (task);
+	gpointer task_data = g_task_get_task_data (task);
+	GCancellable *cancellable = g_task_get_cancellable (task);
+
+	gs_plugin_loader_process_thread_cb (task, source_object, task_data, cancellable);
+	g_object_unref (task);
 }
 
 static gboolean


### PR DESCRIPTION
The Plugin Loader schedules the GTasks corresponding to some operations
like install/update/upgrade-download, but was running the GTasks using
g_task_run_in_thread_sync from a Thread Pool worker. This is a problem
because this version just runs the GTask's thread function but doesn't
run the callback afterwards. So it broke the use of GPluginLoader's
async calls for the mentioned ops.

For fixing this, turns out we simply have to call the GTask's thread
function directly, as it will end up running the callback.
It also has the advantage that we no longer spawn a thread (GTask's)
from within another thread (GThreadPool's).

https://phabricator.endlessm.com/T16318