### PR TITLE
flatpak: add update_remote_sync call to appstream refresh

### DIFF
--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -559,18 +559,6 @@ gs_flatpak_add_apps_from_xremote (GsFlatpak *self,
 	if (g_settings_get_boolean (settings, "filter-default-branch"))
 		default_branch = flatpak_remote_get_default_branch (xremote);
 
-	/* on Endless we rely heavily on always having the default branch
-	 * defined for the 'eos-apps' repository, so we need a fallback value
-	 * to cover the case where GS is run without being connected to the
-	 * Internet before (otherwise it would have pulled it from the server).
-	 */
-	if (default_branch == NULL && self->scope == AS_APP_SCOPE_SYSTEM &&
-	    remote_is_eos_apps (xremote)) {
-		g_warning ("No default branch configured for Endless eos-apps remote! "
-			   "Using fallback value");
-		default_branch = g_strdup ("eos3");
-	}
-
 	collection_id = flatpak_remote_get_collection_id (xremote);
 
 	/* get all the apps and fix them up */

--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -846,6 +846,7 @@ gs_flatpak_refresh_appstream_remote (GsFlatpak *self,
 	g_autoptr(AsProfileTask) ptask = NULL;
 	g_autoptr(GsApp) app_dl = gs_app_new (gs_plugin_get_name (self->plugin));
 	g_autoptr(GsFlatpakProgressHelper) phelper = NULL;
+	g_autoptr(GError) local_error = NULL;
 
 	ptask = as_profile_start (gs_plugin_get_profile (self->plugin),
 				  "%s::refresh-appstream{%s}",
@@ -857,6 +858,18 @@ gs_flatpak_refresh_appstream_remote (GsFlatpak *self,
 	str = g_strdup_printf (_("Getting flatpak metadata for %s…"), remote_name);
 	gs_app_set_summary_missing (app_dl, str);
 	gs_plugin_status_update (self->plugin, app_dl, GS_PLUGIN_STATUS_DOWNLOADING);
+
+	if (!flatpak_installation_update_remote_sync (self->installation,
+						      remote_name,
+						      cancellable,
+						      &local_error)) {
+		g_debug ("Failed to update metadata for remote %s: %s\n",
+			 remote_name, local_error->message);
+		gs_flatpak_error_convert (&local_error);
+		g_propagate_error (error, g_steal_pointer (&local_error));
+		return FALSE;
+	}
+
 #if FLATPAK_CHECK_VERSION(0,9,4)
 	phelper = gs_flatpak_progress_helper_new (self->plugin, app_dl);
 	if (!flatpak_installation_update_appstream_full_sync (self->installation,


### PR DESCRIPTION
This applies changes to the flatpak remote which come from the summary file,
such as updated keys, titles or the URL. Adding it into the appstream refresh
function means it's behind the timestamp checks and skipping broken remotes,
which avoids adding network roundtrips to the refresh.  libflatpak caches the
summary file in the common case that the remote details have not changed.

https://phabricator.endlessm.com/T20328