### PR TITLE
Fix adding the pending updates

### DIFF
--- a/lib/gs-plugin-loader.c
+++ b/lib/gs-plugin-loader.c
@@ -3135,9 +3135,11 @@ gs_plugin_loader_process_thread_cb (GTask *task,
 			g_task_return_error (task, error);
 			return;
 		}
+	}
 
-		/* append pending updates this way, until we find a consensus to deal
-		 * with updates (e.g. only one updates plugin function...) */
+	/* append pending updates this way, until we find a consensus to deal
+	 * with updates (e.g. only one updates plugin function...) */
+	if (action == GS_PLUGIN_ACTION_GET_UPDATES) {
 		helper->function_name = "gs_plugin_add_updates_pending";
 		if (!gs_plugin_loader_run_results (helper, cancellable, &error)) {
 			gs_utils_error_convert_gio (&error);


### PR DESCRIPTION
They were mistakenly being added when the plugin loader's action was the
"UPDATE" one, not the "GET_UPDATES" one...

As a result, the updates that were not downloaded were never being
shown, which, in most cases (because as of recently the Flaptka plugin
no longer pre-downloads updates) meant there were no updates whatsoever.

This patch corrects the mentioned mistake and should be squashed
together with 0ba1d4ab2d4b61d4e98dfe0e131bf77ace073688 in a future
rebase.

https://phabricator.endlessm.com/T20874