### PR TITLE
Make sure the shortcut buttons is hidden when an app has a pending task

### DIFF
--- a/src/gs-details-page.c
+++ b/src/gs-details-page.c
@@ -198,6 +198,11 @@ gs_details_page_update_shortcut_button (GsDetailsPage *self)
 	if (gs_app_get_kind (self->app) != AS_APP_KIND_DESKTOP)
 		return;
 
+	/* leave the button hidden if there's a pending action because the
+	 * progress bar will be visible */
+	if (gs_app_get_pending_action (self->app) != GS_PLUGIN_ACTION_UNKNOWN)
+		return;
+
 	/* only consider the shortcut button if the app is installed */
 	switch (gs_app_get_state (self->app)) {
 	case AS_APP_STATE_INSTALLED:


### PR DESCRIPTION
Recently we added a change where the progress bar is shown empty if the
app has a pending task. The problem is that the visibility of the
shortcut button has not been updated to account for this special
condition, so the result is that apps that are pending an update will
show the shortcut button + the progress bar, making the UI too large and
clunky.

This patch fixes that by simply checking for the pending task in the
logic that toggles the visibility of the shortcut button.

https://phabricator.endlessm.com/T21095