### PR TITLE
eos: Do not blacklist apps from upstream if they are installed

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -744,7 +744,8 @@ gs_plugin_eos_blacklist_upstream_app_if_needed (GsPlugin *plugin, GsApp *app)
 
 	const char *hostname = NULL;
 
-	if (gs_app_get_scope (app) != AS_APP_SCOPE_SYSTEM)
+	if (gs_app_get_scope (app) != AS_APP_SCOPE_SYSTEM ||
+	    gs_app_is_installed (app))
 		return FALSE;
 
 	hostname = gs_app_get_origin_hostname (app);


### PR DESCRIPTION
We blacklist some apps from upstream remotes if they are known not to
work well in EOS, and for ARM we use a whitelist instead. However, if an
app is already installed (by e.g. using Flatpak CLI), then it should
never get blacklisted.

https://phabricator.endlessm.com/T21185