### PR TITLE
Use the global cache when creating popular apps by appstream

### DIFF
--- a/plugins/core/gs-appstream.c
+++ b/plugins/core/gs-appstream.c
@@ -1041,6 +1041,7 @@ gs_appstream_add_popular (GsPlugin *plugin,
 	GPtrArray *array;
 	guint i;
 	g_autoptr(AsProfileTask) ptask = NULL;
+	g_autoptr(GError) local_error = NULL;
 
 	/* find out how many packages are in each category */
 	ptask = as_profile_start_literal (gs_plugin_get_profile (plugin),
@@ -1054,8 +1055,14 @@ gs_appstream_add_popular (GsPlugin *plugin,
 			continue;
 		if (!as_app_has_kudo (item, "GnomeSoftware::popular"))
 			continue;
-		app = gs_app_new (as_app_get_id (item));
-		gs_app_add_quirk (app, AS_APP_QUIRK_MATCH_ANY_PREFIX);
+		app = gs_appstream_get_or_create_app (plugin, item, &local_error);
+		if (app == NULL) {
+			g_debug ("Failed to get/create popular app %s: %s; creating as new app",
+				 as_app_get_unique_id (item),
+				 local_error->message);
+			app = gs_app_new (as_app_get_id (item));
+			gs_app_add_quirk (app, AS_APP_QUIRK_MATCH_ANY_PREFIX);
+		}
 		gs_app_list_add (list, app);
 	}
 	return TRUE;


### PR DESCRIPTION
This avoids a current problem where the objects in the featured page
will be different than the objects representing the same apps in other
views. As a result, the states of what appears to be the same app will
differ: e.g. if a popular app is installed, the same app in the category
view may still show up as not installed.

https://phabricator.endlessm.com/T21218