### PR TITLE
T19479: Search by Endless::HasDiscoveryFeedContent tag

### DIFF
--- a/plugins/core/gs-appstream.c
+++ b/plugins/core/gs-appstream.c
@@ -829,6 +829,34 @@ gs_appstream_refine_app (GsPlugin *plugin,
 }
 
 static gboolean
+matches_all_on_metadata (AsApp  *item,
+			 gchar **values)
+{
+	GHashTable *metadata = as_app_get_metadata (item);
+	gchar **value_iter = values;
+
+	for (; *value_iter != NULL; ++value_iter) {
+		GHashTableIter iter;
+		gboolean matched_value = FALSE;
+		gpointer key, value;
+
+		g_hash_table_iter_init (&iter, metadata);
+
+		while (g_hash_table_iter_next (&iter, &key, &value)) {
+			if (g_ascii_strcasecmp ((gchar *) key, *value_iter) == 0) {
+				matched_value = TRUE;
+				break;
+			}
+		}
+
+		if (!matched_value)
+			return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
 gs_appstream_store_search_item (GsPlugin *plugin,
 				AsApp *item,
 				gchar **values,
@@ -844,10 +872,12 @@ gs_appstream_store_search_item (GsPlugin *plugin,
 
 	/* match against the app or any of the addons */
 	match_value = as_app_search_matches_all (item, values);
+	match_value |= matches_all_on_metadata (item, values);
 	addons = as_app_get_addons (item);
 	for (i = 0; i < addons->len; i++) {
 		item_tmp = g_ptr_array_index (addons, i);
 		match_value |= as_app_search_matches_all (item_tmp, values);
+		match_value |= matches_all_on_metadata (item_tmp, values);
 	}
 
 	/* no match */

--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -104,10 +104,6 @@ filter_for_discovery_feed_apps (GsApp *app, gpointer user_data)
 	if (!app_thumbnail_filename)
 		return FALSE;
 
-	/* App must also be tagged as having discovery feed content */
-	if (!gs_app_get_metadata_item (app, "Endless::HasDiscoveryFeedContent"))
-		return FALSE;
-
 	return TRUE;
 }
 

--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -201,7 +201,7 @@ handle_get_discovery_feed_apps (GsDiscoveryFeedInstallableApps *skeleton,
 	self->cancellable = g_cancellable_new ();
 
 	plugin_job = gs_plugin_job_newv (GS_PLUGIN_ACTION_SEARCH,
-					 "search", "com.endlessm",
+					 "search", "Endless::HasDiscoveryFeedContent",
 					 "failure-flags", GS_PLUGIN_FAILURE_FLAGS_NONE,
 					 "refine-flags", GS_PLUGIN_REFINE_FLAGS_REQUIRE_ICON |
 							 GS_PLUGIN_REFINE_FLAGS_REQUIRE_ORIGIN_HOSTNAME,

--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -162,13 +162,13 @@ search_done_cb (GObject *source,
 	guint i;
 	GVariantBuilder builder;
 	guint app_list_length;
+	g_autoptr(GError) error = NULL;
 	g_autoptr(GsAppList) list = NULL;
 
-	list = gs_plugin_loader_job_process_finish (self->plugin_loader, res, NULL);
+	list = gs_plugin_loader_job_process_finish (self->plugin_loader, res, &error);
 	if (list == NULL) {
-		gs_discovery_feed_installable_apps_complete_get_installable_apps (self->skeleton,
-										  search->invocation,
-										  NULL);
+		g_warning ("Error searching for Discovery Feed Apps: %s", error->message);
+		g_dbus_method_invocation_take_error (search->invocation, g_steal_pointer (&error));
 		pending_search_free (search);
 		g_application_release (g_application_get_default ());
 		return;

--- a/src/gs-discovery-feed-content-provider.c
+++ b/src/gs-discovery-feed-content-provider.c
@@ -59,47 +59,6 @@ pending_search_free (PendingSearch *search)
 	g_slice_free (PendingSearch, search);
 }
 
-typedef struct {
-	GsAppKudo kudo;
-	guint weight;
-} DiscoveryFeedKudoWeight ;
-
-
-static const DiscoveryFeedKudoWeight discovery_feed_app_kudos[] =
-{
-	{ GS_APP_KUDO_MY_LANGUAGE, 10 },
-	{ GS_APP_KUDO_FEATURED_RECOMMENDED, 5 },
-	{ GS_APP_KUDO_POPULAR, 3 }
-};
-static const guint discovery_feed_app_kudos_len = G_N_ELEMENTS (discovery_feed_app_kudos);
-
-static guint
-get_discovery_feed_app_kudo_score (GsApp *app)
-{
-	guint i = 0;
-	guint score = 0;
-	guint64 kudos = gs_app_get_kudos (app);
-
-	for (; i < discovery_feed_app_kudos_len; ++i)
-		if ((kudos & discovery_feed_app_kudos[i].kudo) != 0)
-			score += discovery_feed_app_kudos[i].weight;
-
-	return score;
-}
-
-static gint
-search_sort_by_kudo_cb (GsApp *app1, GsApp *app2, gpointer user_data)
-{
-	guint pa, pb;
-	pa = get_discovery_feed_app_kudo_score (app1);
-	pb = get_discovery_feed_app_kudo_score (app2);
-	if (pa < pb)
-		return 1;
-	else if (pa > pb)
-		return -1;
-	return 0;
-}
-
 static gchar *
 get_app_thumbnail_cached_filename (GsApp *app)
 {
@@ -182,7 +141,6 @@ search_done_cb (GObject *source,
 	 * internally randomized order. */
 	gs_app_list_filter (list, filter_for_discovery_feed_apps, NULL);
 	gs_app_list_randomize (list);
-	gs_app_list_sort (list, search_sort_by_kudo_cb, NULL);
 
 	app_list_length = gs_app_list_length (list);
 


### PR DESCRIPTION
Adjust the search handler in `gs-appstream` to allow searching by metadata keys and do the entire search by `Endless::HasDiscoveryFeedContent`. This allows us to remove a previous hack which assumed that all discovery-feed capable apps started with the ID `com.endlessm` and then had to filter for the right ones later.

It might be the case that we are doing the search of the metadata in the wrong place. I took a look at appstream-glib and there doesn't seem to be a particularly obivous process for adding new search fields without hardcoding new ones.

https://phabricator.endlessm.com/T19479