### PR TITLE
Never show the first run dialog

### DIFF
--- a/src/gs-application.c
+++ b/src/gs-application.c
@@ -235,15 +235,11 @@ gs_application_dbus_unregister (GApplication    *application,
 static void
 gs_application_show_first_run_dialog (GsApplication *app)
 {
-	GtkWidget *dialog;
-
-	if (g_settings_get_boolean (app->settings, "first-run") == TRUE) {
-		dialog = gs_first_run_dialog_new ();
-		gs_shell_modal_dialog_present (app->shell, GTK_DIALOG (dialog));
+	/* XXX: Never show the first run dialog, since it's not useful and it
+	 * delays the loading of the app tiles; we keep the setting toggling as
+	 * it can be interesting for other purposes in the future */
+	if (g_settings_get_boolean (app->settings, "first-run"))
 		g_settings_set_boolean (app->settings, "first-run", FALSE);
-		g_signal_connect_swapped (dialog, "response",
-					  G_CALLBACK (gtk_widget_destroy), dialog);
-	}
 }
 
 static void


### PR DESCRIPTION
We're completely removing the first run dialog for the moment, to avoid
situations where the dialog is shown more than once. This shouldn't of
course happen, but we need a quick fix and the dialog was not useful in
any case: it adds little value and and delays the loading of the app
tiles.

In the future we may need to revisit this in order to show some useful
information on the first run, and thus this patch keeps toggling the
"first-run" setting, so we have this information in the future.

https://phabricator.endlessm.com/T21725