### PR TITLE
Remove the big shopping bag icon from the loading page

### DIFF
--- a/src/gs-loading-page.ui
+++ b/src/gs-loading-page.ui
@@ -24,10 +24,20 @@
             <property name="spacing">12</property>
             <child>
               <object class="GtkImage" id="image">
-                <property name="visible">True</property>
+                <property name="visible">False</property>
                 <property name="can_focus">False</property>
                 <property name="pixel_size">256</property>
                 <property name="icon_name">org.gnome.Software-symbolic</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Starting up…</property>
+                <attributes>
+                  <attribute name="scale" value="1.4"/>
+                </attributes>
               </object>
             </child>
             <child>
@@ -45,16 +55,6 @@
                 <property name="expand">False</property>
                 <property name="fill">True</property>
               </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Starting up…</property>
-                <attributes>
-                  <attribute name="scale" value="1.4"/>
-                </attributes>
-              </object>
             </child>
           </object>
         </child>


### PR DESCRIPTION
The big shopping bag icon in the loading page looks very similar to a
lockpad and this can be confusing for some users. Since we will also
replace the shopping bag icons in the app tiles, the big icon in the
loading page should also be replaced or removed. So for now, we are
removing it.

https://phabricator.endlessm.com/T21925