### PR TITLE
Change the installation button's label to "Download"

### DIFF
--- a/src/gs-details-page.c
+++ b/src/gs-details-page.c
@@ -285,9 +285,20 @@ gs_details_page_switch_to (GsPage *page, gboolean scroll_up)
 	case AS_APP_STATE_AVAILABLE_LOCAL:
 		gtk_widget_set_visible (self->button_install, TRUE);
 		gtk_style_context_add_class (gtk_widget_get_style_context (self->button_install), "suggested-action");
-		/* TRANSLATORS: button text in the header when an application
-		 * can be installed */
-		gtk_button_set_label (GTK_BUTTON (self->button_install), _("_Install"));
+
+		/* we need to show more directly to users that apps needs to be downloaded,
+		 * so we're changing the installation button's label to "Download" but
+		 * only if the app is not coming from a removable drive (as in which
+		 * case they don't need to be downloaded, only installed) */
+		if (gs_app_has_category (self->app, "USB")) {
+			/* TRANSLATORS: button text in the header when an application
+			 * can be installed */
+			gtk_button_set_label (GTK_BUTTON (self->button_install), _("_Install"));
+		} else {
+			/* TRANSLATORS: button text in the header when an application
+			 * can be installed but needs to be downloaded first */
+			gtk_button_set_label (GTK_BUTTON (self->button_install), _("_Download"));
+		}
 		break;
 	case AS_APP_STATE_INSTALLING:
 		gtk_widget_set_visible (self->button_install, FALSE);


### PR DESCRIPTION
We need to show more directly to users that apps needs to be downloaded,
so we're changing the installation button's label to "Download" but only
if the app is not coming from a removable drive. Otherwise they don't
need to be downloaded, only installed.

https://phabricator.endlessm.com/T21227