### PR TITLE
eos: Blacklist gnome-system-monitor-kde

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -1454,6 +1454,16 @@ gs_plugin_eos_refine_core_app (GsApp *app)
 	if (gs_app_get_kind (app) == AS_APP_KIND_OS_UPGRADE)
 		return;
 
+	/* blacklist the KDE desktop file of the GNOME System Monitor since
+	 * it's a core app but should not be shown */
+	if (g_strcmp0 (gs_app_get_id (app), "gnome-system-monitor-kde.desktop") == 0) {
+		g_debug ("Blacklisting %s because it will show as a duplicate "
+			 "of the real gnome-system-monitor one.",
+			 gs_app_get_unique_id (app));
+		gs_app_add_category (app, "Blacklisted");
+		return;
+	}
+
 	/* we only allow to remove flatpak apps */
 	gs_app_add_quirk (app, AS_APP_QUIRK_COMPULSORY);
 


### PR DESCRIPTION
There is a desktop file for providing details about the GNOME System
Monitor app in KDE environments, which was showing up in GNOME Software.

This app should eventually be blocked by checking its project group (set
by the OnlyShowIn key in the desktop file), but this value is being
incorrectly set to GNOME (see [1]) and thus there's no generic way of
hiding the mentioned app. So this patch just blacklists it instead of
setting it as installed, as it does to the rest of the core apps.

[1] https://github.com/hughsie/appstream-glib/issues/236

https://phabricator.endlessm.com/T21451