### PR TITLE
Revert "Add an app menu toggle for turning auto updates on/off"

### DIFF
--- a/src/gs-application.c
+++ b/src/gs-application.c
@@ -933,7 +933,6 @@ gs_application_startup (GApplication *application)
 {
 	GSettings *settings;
 	GsApplication *app = GS_APPLICATION (application);
-	g_autoptr(GAction) action = NULL;
 	G_APPLICATION_CLASS (gs_application_parent_class)->startup (application);
 
 	gs_application_add_wrapper_actions (application);
@@ -952,9 +951,6 @@ gs_application_startup (GApplication *application)
 	g_signal_connect_swapped (settings, "changed",
 				  G_CALLBACK (gs_application_settings_changed_cb),
 				  application);
-
-	action = g_settings_create_action (app->settings, "download-updates");
-	g_action_map_add_action (G_ACTION_MAP (app), action);
 
 	gs_application_initialize_ui (app);
 

--- a/src/gs-menus.ui
+++ b/src/gs-menus.ui
@@ -11,12 +11,6 @@
     </section>
     <section>
       <item>
-        <attribute name="label" translatable="yes">Automatic _updates</attribute>
-        <attribute name="action">app.download-updates</attribute>
-      </item>
-    </section>
-    <section>
-      <item>
         <attribute name="label" translatable="yes">_About</attribute>
         <attribute name="action">app.about</attribute>
       </item>


### PR DESCRIPTION
This reverts commit 7625028ed8140e4ea53c1919e05402bef6da508f as the
auto-updates related UI is now part of GNOME Control Center.

https://phabricator.endlessm.com/T22341