### PR TITLE
Remove the refresh-when-metered setting

### DIFF
--- a/src/gs-update-monitor.c
+++ b/src/gs-update-monitor.c
@@ -806,8 +806,6 @@ static void
 check_updates (GsUpdateMonitor *monitor)
 {
 	gint64 tmp;
-	gboolean refresh_on_metered;
-	gboolean connection_is_metered;
 	g_autoptr(GDateTime) last_refreshed = NULL;
 	g_autoptr(GDateTime) now = NULL;
 	g_autoptr(GsPluginJob) plugin_job = NULL;
@@ -815,13 +813,6 @@ check_updates (GsUpdateMonitor *monitor)
 
 	/* never check for updates when offline */
 	if (!gs_plugin_loader_get_network_available (monitor->plugin_loader))
-		return;
-
-	refresh_on_metered = g_settings_get_boolean (monitor->settings,
-						     "refresh-when-metered");
-	connection_is_metered = gs_plugin_loader_get_network_metered (monitor->plugin_loader);
-
-	if (!refresh_on_metered && connection_is_metered)
 		return;
 
 	/* never refresh when the battery is low */
@@ -864,7 +855,6 @@ check_updates (GsUpdateMonitor *monitor)
 			g_date_time_to_unix (now));
 
 	if (gs_plugin_loader_get_allow_updates (monitor->plugin_loader) &&
-	    !connection_is_metered &&
 	    g_settings_get_boolean (monitor->settings, "download-updates")) {
 		g_debug ("Refreshing for metadata and payload");
 		refresh_flags |= GS_PLUGIN_REFRESH_FLAGS_PAYLOAD;


### PR DESCRIPTION
This gsetting was used to control whether a refresh should happen on
metered connection, but we're now always allowing metadata refreshes
even on metered connections, since they are important and we're limiting
them to once every 24 hours. For that reason, this patch removes that
setting and its use altogether.

https://phabricator.endlessm.com/T22389