### PR TITLE
updates: Open the WiFi panel when clicking the Network Settings button

### DIFF
--- a/src/gs-updates-page.c
+++ b/src/gs-updates-page.c
@@ -1335,7 +1335,7 @@ static void
 gs_updates_page_show_network_settings (GsUpdatesPage *self)
 {
 	g_autoptr(GError) error = NULL;
-	if (!g_spawn_command_line_async ("gnome-control-center network", &error))
+	if (!g_spawn_command_line_async ("gnome-control-center wifi", &error))
 		g_warning ("Failed to open the control center: %s", error->message);
 }
 


### PR DESCRIPTION
When the updates page is offline, a "Network Settings" button is shown
and it opens the Network panel in GNOME Control Center. While this is
fine for users that have wired connections, it's not very useful for
WiFi users. Thus, taking into account that most users connect to WiFi
networks, we're changing the button to open the WiFi settings panel
instead.

https://phabricator.endlessm.com/T21963