### PR TITLE
Add the .desktop suffix if needed in gs_utils_get_desktop_app_info

### DIFF
--- a/lib/gs-utils.c
+++ b/lib/gs-utils.c
@@ -343,6 +343,8 @@ gs_utils_strv_fnmatch (gchar **strv, const gchar *str)
  * @id: A desktop ID, e.g. "gimp.desktop"
  *
  * Gets a a #GDesktopAppInfo taking into account the kde4- prefix.
+ * If the given @id doesn not have a ".desktop" suffix, it will add one to it
+ * for convenience.
  *
  * Returns: a #GDesktopAppInfo for a specific ID, or %NULL
  */
@@ -350,6 +352,14 @@ GDesktopAppInfo *
 gs_utils_get_desktop_app_info (const gchar *id)
 {
 	GDesktopAppInfo *app_info;
+	g_autofree gchar *desktop_id = NULL;
+
+	/* for convenience, if the given id doesn't have the required .desktop
+	 * suffix, we add it here */
+	if (!g_str_has_suffix (id, ".desktop")) {
+		desktop_id = g_strconcat (id, ".desktop", NULL);
+		id = desktop_id;
+	}
 
 	/* try to get the standard app-id */
 	app_info = g_desktop_app_info_new (id);


### PR DESCRIPTION
The desktop ID given to g_desktop_app_info_new (called from
gs_utils_get_desktop_app_info) needs to have the .desktop suffix. So,
for convenience this patch ensures that the mentioned utils' function
adds the .desktop suffix when the given ID doesn't have it.

https://phabricator.endlessm.com/T22343