### PR TITLE
eos: Make getting an app's desktop ID more robust

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -88,6 +88,7 @@ static const gchar *eos_updater_state_str[] = {"None",
 
 static void setup_os_upgrade (GsPlugin *plugin);
 static EosUpdaterState sync_state_from_updater (GsPlugin *plugin);
+static gboolean app_is_flatpak (GsApp *app);
 
 struct GsPluginData
 {
@@ -1388,17 +1389,27 @@ gs_plugin_eos_blacklist_if_needed (GsPlugin *plugin, GsApp *app)
 	return blacklist_app;
 }
 
-static const char*
+static char *
 get_desktop_file_id (GsApp *app)
 {
 	const char *desktop_file_id =
 		gs_app_get_metadata_item (app, METADATA_SYS_DESKTOP_FILE);
 
-	if (!desktop_file_id)
+	if (!desktop_file_id) {
+		if (app_is_flatpak (app)) {
+			/* ensure we add the .desktop suffix to the app's ref name
+			 * since in Flatpak the app ID can have that suffix already
+			 * or not, depending on how the appdata has been generated */
+			const char *ref_name = gs_flatpak_app_get_ref_name (app);
+			return g_strconcat (ref_name, ".desktop", NULL);
+		}
+
+		/* just use the app ID if this is not a Flatpak app */
 		desktop_file_id = gs_app_get_id (app);
+	}
 
 	g_assert (desktop_file_id != NULL);
-	return desktop_file_id;
+	return g_strdup (desktop_file_id);
 }
 
 static void
@@ -1406,7 +1417,7 @@ gs_plugin_eos_update_app_shortcuts_info (GsPlugin *plugin,
 					 GsApp *app)
 {
 	GsPluginData *priv = NULL;
-	const char *desktop_file_id = NULL;
+	g_autofree char *desktop_file_id = NULL;
 	g_autofree char *kde_desktop_file_id = NULL;
 
 	if (!gs_app_is_installed (app)) {
@@ -1657,7 +1668,7 @@ remove_app_from_shell (GsPlugin		*plugin,
 {
 	GError *error = NULL;
 	GsPluginData *priv = gs_plugin_get_data (plugin);
-	const char *desktop_file_id = get_desktop_file_id (app);
+	g_autofree char *desktop_file_id = get_desktop_file_id (app);
 	g_autoptr(GDesktopAppInfo) app_info =
 		gs_utils_get_desktop_app_info (desktop_file_id);
 	const char *shortcut_id = g_app_info_get_id (G_APP_INFO (app_info));
@@ -1732,7 +1743,7 @@ add_app_to_shell (GsPlugin	*plugin,
 {
 	GError *error = NULL;
 	GsPluginData *priv = gs_plugin_get_data (plugin);
-	const char *desktop_file_id = get_desktop_file_id (app);
+	g_autofree char *desktop_file_id = get_desktop_file_id (app);
 	g_autoptr(GDesktopAppInfo) app_info =
 		gs_utils_get_desktop_app_info (desktop_file_id);
 	const char *shortcut_id = g_app_info_get_id (G_APP_INFO (app_info));
@@ -1813,7 +1824,7 @@ launch_with_sys_desktop_file (GsApp *app,
 {
 	GdkDisplay *display;
 	g_autoptr(GAppLaunchContext) context = NULL;
-	const char *desktop_file_id = get_desktop_file_id (app);
+	g_autofree char *desktop_file_id = get_desktop_file_id (app);
 	g_autoptr(GDesktopAppInfo) app_info =
 		gs_utils_get_desktop_app_info (desktop_file_id);
 	g_autoptr(GError) local_error = NULL;


### PR DESCRIPTION
The apps' desktop ID was ending up just passing the GsApps' ID since the
utils function to get the AppInfo file already adds the .desktop suffix
when it's not yet present. However, some apps may have a .desktop not as
a desktop ID suffix but as part of their own ID, in which case the
mentioned utils function will not append the suffix again and this ends
up in a failure when trying to add an app to the desktop.

This patch solves that by always appending the .desktop suffix to the
app's ref name (if the app is a Flatpak one) when getting the app's
desktop file ID.

Note that this can still allow shortcuts to fail if a core app
(non-Flatpak) has .desktop as the suffix of their app ID, but that's not
the case with any app currently and we can easily control that. This is
kept like this so the logic stays fairly simple.

https://phabricator.endlessm.com/T22453