### PR TITLE
Do not invalidate OS upgrades in the Updates page

### DIFF
--- a/src/gs-updates-page.c
+++ b/src/gs-updates-page.c
@@ -1736,27 +1736,9 @@ gs_updates_page_upgrade_help_cb (GsUpgradeBanner *upgrade_banner,
 }
 
 static void
-gs_updates_page_invalidate_downloaded_upgrade (GsUpdatesPage *self)
-{
-	GsApp *app;
-	app = gs_upgrade_banner_get_app (GS_UPGRADE_BANNER (self->upgrade_banner));
-	if (app == NULL)
-		return;
-	if (gs_app_get_state (app) != AS_APP_STATE_UPDATABLE)
-		return;
-	gs_app_set_state (app, AS_APP_STATE_AVAILABLE);
-	g_debug ("resetting %s to AVAILABLE as the updates have changed",
-		 gs_app_get_id (app));
-}
-
-static void
 gs_updates_page_changed_cb (GsPluginLoader *plugin_loader,
                             GsUpdatesPage *self)
 {
-	/* if we do a live update and the upgrade is waiting to be deployed
-	 * then make sure all new packages are downloaded */
-	gs_updates_page_invalidate_downloaded_upgrade (self);
-
 	/* check to see if any apps in the app list are in a processing state */
 	if (gs_shell_update_are_updates_in_progress (self)) {
 		g_debug ("ignoring updates-changed as updates in progress");
@@ -1773,20 +1755,6 @@ gs_updates_page_status_changed_cb (GsPluginLoader *plugin_loader,
                                    GsPluginStatus status,
                                    GsUpdatesPage *self)
 {
-	switch (status) {
-	case GS_PLUGIN_STATUS_INSTALLING:
-	case GS_PLUGIN_STATUS_REMOVING:
-		if (gs_app_get_kind (app) != AS_APP_KIND_OS_UPGRADE &&
-		    gs_app_get_id (app) != NULL) {
-			/* if we do a install or remove then make sure all new
-			 * packages are downloaded */
-			gs_updates_page_invalidate_downloaded_upgrade (self);
-		}
-		break;
-	default:
-		break;
-	}
-
 	self->last_status = status;
 	gs_updates_page_update_ui_state (self);
 }


### PR DESCRIPTION
The Updates page resets the OS upgrades state to be available again if
there's a change to the updates, or an app removal, etc.. The reason for
this is that package-based systems need to make sure they have all the
packages downloaded, so this would force the user to download any
missing packages.

As a result, if the user has a downloaded OS upgrade in an ostree system,
and restarts GNOME Software, or removes an app, in this state, the OS
upgrade will show the Download button again, even if offline.

Any OS upgrade invalidation should be done by the plugins related to it
and not by the Updates page, so this patch removes the mentioned code.

https://phabricator.endlessm.com/T22503