### PR TITLE
flatpak: Only try to get EknServices if an app has a runtime

### DIFF
--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -2948,11 +2948,14 @@ gs_flatpak_get_list_for_install_or_update (GsFlatpak *self,
 			return FALSE;
 		runtime = gs_app_get_update_runtime (app);
 	}
-	if (runtime != NULL)
+	if (runtime != NULL) {
 		gs_flatpak_add_app_to_list_if_not_installed (runtime, list, hash_installed, FALSE);
 
-	/* add services flatpak */
-	services_app = gs_flatpak_get_services_app_if_needed (self, app, runtime, cancellable);
+		/* add services flatpak */
+		services_app = gs_flatpak_get_services_app_if_needed (self, app, runtime,
+								      cancellable);
+	}
+
 	if (g_cancellable_set_error_if_cancelled (cancellable, error))
 		return FALSE;
 	if (services_app != NULL) {


### PR DESCRIPTION
When a runtime was attempted to be installed directly (i.e. not just
because an app was being installed as well), it crashed when getting the
EknServices app for it. The reason is that this function assumed that a
runtime and an app were passed to it, but when installing a runtime, it
is the "app" and its runtime will be NULL.

This patch fixes the mentioned issue by only attempting to get the
EknServices app if a runtime is available.

https://phabricator.endlessm.com/T22523