### PR TITLE
flatpak: Emit updates-changed when a USB remote is loaded

### DIFF
--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -3234,8 +3234,12 @@ gs_flatpak_create_app_from_repo_dir (GsFlatpak *self,
 	gs_app_set_name (app, GS_APP_QUALITY_NORMAL, "Removable Media Repo");
 	gs_app_set_management_plugin (app, gs_plugin_get_name (self->plugin));
 	gs_app_set_metadata (app, "EndlessOS::RemovableMediaCategory", "usb");
-	if (reload_overview)
+	if (reload_overview) {
 		gs_app_set_metadata (app, "EndlessOS::ReloadOverview", "true");
+		/* also make it load the updates again since there may be some
+		 * available USB remotes */
+		gs_plugin_updates_changed (self->plugin);
+	}
 
 	return app;
 }


### PR DESCRIPTION
Besides reloading the overview, we should also check if there are
updates coming from USB remotes. This is accomplished by calling
gs_plugin_updates_changed when a USB remote is loaded.

https://phabricator.endlessm.com/T22192