### PR TITLE
Refactor screenshots and hide those unavailable when offline

### DIFF
--- a/src/gs-screenshot-image.c
+++ b/src/gs-screenshot-image.c
@@ -582,6 +582,12 @@ gs_screenshot_image_load_async (GsScreenshotImage *ssimg,
 				    g_object_ref (ssimg));
 }
 
+gboolean
+gs_screenshot_image_is_showing (GsScreenshotImage *ssimg)
+{
+	return ssimg->showing_image;
+}
+
 static void
 gs_screenshot_image_destroy (GtkWidget *widget)
 {

--- a/src/gs-screenshot-image.h
+++ b/src/gs-screenshot-image.h
@@ -47,6 +47,7 @@ void		 gs_screenshot_image_set_use_desktop_background
 							 gboolean		 use_desktop_background);
 void		 gs_screenshot_image_load_async		(GsScreenshotImage	*ssimg,
 							 GCancellable		*cancellable);
+gboolean	 gs_screenshot_image_is_showing		(GsScreenshotImage	*ssimg);
 
 G_END_DECLS
 


### PR DESCRIPTION
The details page displays a number of screenshots for regular apps and
it works offline as long as the screenshots have been previously cached.
However, if the screenshots have not been cached, an error screenshot
placeholder is shown instead. This is a problem for many users who are
constantly offline, as most of their apps will display the error
screenshot and thus affect the UX negatively as every app appears to
have an issue.

To help provide a cleaner UX, this patch hides screenshots if they
cannot be loaded when the user is offline. In the process these changes
also refactor the logic around showing the screenshots.

https://phabricator.endlessm.com/T19887