### PR TITLE
trivial: Fix a small memory leak in gs_app_set_metadata()

### DIFF
--- a/lib/gs-app.c
+++ b/lib/gs-app.c
@@ -3112,10 +3112,12 @@ emit_metadata_signal_idle (gpointer data)
 void
 gs_app_set_metadata (GsApp *app, const gchar *key, const gchar *value)
 {
+	g_autoptr(GVariant) tmp = NULL;
 	g_return_if_fail (GS_IS_APP (app));
 	g_return_if_fail (key != NULL);
-	gs_app_set_metadata_variant (app, key,
-				     value != NULL ? g_variant_new_string (value) : NULL);
+	if (value != NULL)
+		tmp = g_variant_new_string (value);
+	gs_app_set_metadata_variant (app, key, tmp);
 }
 
 /**


### PR DESCRIPTION
@rshuler , I haven't opened a task for this since there's a patch upstream for it already.