### PR TITLE
Lower the minimum number of popular apps required to be shown

### DIFF
--- a/src/gs-overview-page.c
+++ b/src/gs-overview-page.c
@@ -35,6 +35,7 @@
 #include "gs-common.h"
 
 #define N_TILES 35
+#define MIN_POPULAR_TILES 2
 
 typedef struct
 {
@@ -207,7 +208,7 @@ gs_overview_page_get_popular_cb (GObject *source_object,
 	}
 
 	/* not enough to show */
-	if (gs_app_list_length (list) < N_TILES) {
+	if (gs_app_list_length (list) < MIN_POPULAR_TILES) {
 		g_warning ("Only %u apps for popular list, hiding",
 		           gs_app_list_length (list));
 		gtk_widget_set_visible (priv->box_popular, FALSE);


### PR DESCRIPTION
The minimum number of popular apps to be shown was being set to the
maximum allowed, as a result, if an image overrode the popular apps
(using the popular-overrides gsetting) then those weren't being shown.

This patch separates the maximum number of popular apps allowed from
the minimum required.

https://phabricator.endlessm.com/T22925