### PR TITLE
Don't show the fallback screenshot placeholder when offline

### DIFF
--- a/src/gs-details-page.c
+++ b/src/gs-details-page.c
@@ -679,7 +679,7 @@ gs_details_page_refresh_screenshots (GsDetailsPage *self)
 			gtk_widget_set_visible (ssimg, TRUE);
 		}
 		gtk_widget_set_visible (self->box_details_screenshot_fallback,
-		                        screenshots->len == 0);
+		                        screenshots->len == 0 && !is_offline);
 		return;
 	}
 
@@ -699,16 +699,13 @@ gs_details_page_refresh_screenshots (GsDetailsPage *self)
 		break;
 	default:
 		gtk_widget_set_visible (self->box_details_screenshot_fallback,
-					screenshots->len == 0);
+					screenshots->len == 0 && !is_offline);
 		break;
 	}
 
 	/* reset screenshots */
 	gs_container_remove_all (GTK_CONTAINER (self->box_details_screenshot_main));
 	gs_container_remove_all (GTK_CONTAINER (self->box_details_screenshot_thumbnails));
-
-	if (screenshots->len == 0)
-		return;
 
 	list = gtk_list_box_new ();
 	gtk_style_context_add_class (gtk_widget_get_style_context (list), "image-list");
@@ -733,6 +730,7 @@ gs_details_page_refresh_screenshots (GsDetailsPage *self)
 			/* when we're offline, the load will be immediate, so we
 			 * can check if it succeeded, and just skip it and its
 			 * thumbnails otherwise */
+
 			if (is_offline &&
 			    !gs_screenshot_image_is_showing (GS_SCREENSHOT_IMAGE (ssmain)))
 				continue;


### PR DESCRIPTION
The fallback screenshot placeholder is used when apps don't provide any
screenshots, and should not be shown if the user is offline (because
they will never get an updated AppStream data and thus would always see
the placeholder).
    
This is in line with the rest of the changes for T19887 that just hide the
screenshots when they fail to load and the user is offline.
    
https://phabricator.endlessm.com/T19887
