### PR TITLE
Ensure refining the metadata of apps is not skipped incorrectly

### DIFF
--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -2229,8 +2229,6 @@ gs_flatpak_set_app_metadata (GsFlatpak *self,
 	}
 	g_debug ("runtime for %s is %s", name, runtime);
 
-	/* we always get this, but it's a low bar... */
-	gs_app_add_kudo (app, GS_APP_KUDO_SANDBOXED);
 	shared = g_key_file_get_string_list (kf, "Context", "shared", NULL, NULL);
 	if (shared != NULL) {
 		/* SHM isn't secure enough */
@@ -2263,6 +2261,8 @@ gs_flatpak_set_app_metadata (GsFlatpak *self,
 		}
 	}
 
+	/* we always get this, but it's a low bar... */
+	gs_app_add_kudo (app, GS_APP_KUDO_SANDBOXED);
 	return TRUE;
 }
 


### PR DESCRIPTION
When refining the metadata of apps, it was using the SANDBOXED quirk in
order to skip having to refine it a second time (since it involves IO).
However, that quirk was being set earlier in the function that also sets
the runtime for the app; as a result, when refining updatable apps'
metadata in order to ensure that their runtime is set, if there was a
previous call to the refine which wasn't yet finished, it could end up
skipping the second call before the runtime was set.

This caused a noticeable problem in the Updates page, where the number
updates would vary on every start up (but this is likely not the only
problem).

This patch simply sets the SANDBOXED quirk after everything is done in
the refine, thus allowing it to be correctly used as flag for skipping
further calls to the function.

https://phabricator.endlessm.com/T22749