### PR TITLE
appstream: Add "GnomeSoftware::popular" kudo to com.endless. apps

### DIFF
--- a/plugins/core/gs-appstream.c
+++ b/plugins/core/gs-appstream.c
@@ -771,6 +771,11 @@ gs_appstream_refine_app (GsPlugin *plugin,
 	if (as_app_has_category (item, "featured"))
 		gs_app_add_kudo (app, GS_APP_KUDO_FEATURED_RECOMMENDED);
 
+	/* Mark com.endlessm. apps with featured kudo. See discussion on T23152 */
+	if (!gs_app_has_kudo (app, GS_APP_KUDO_FEATURED_RECOMMENDED) &&
+	     g_str_has_prefix (gs_app_get_id (app), "com.endlessm."))
+		gs_app_add_kudo (app, GS_APP_KUDO_FEATURED_RECOMMENDED);
+
 	/* add new-style kudos */
 	kudos = as_app_get_kudos (item);
 	for (i = 0; i < kudos->len; i++) {


### PR DESCRIPTION
"GnomeSoftware::popular" kudo has been removed from the build
process[1] due to recent version of appstream-validate started
rejecting that kudo. In order to still keep the logic for getting
"Featured" apps and search-provider relevant, we add this kudo at
runtime while reading the appstream.

[1] https://github.com/endlessm/eos-build/commit/05977432eb2a624a436caedbcb92f9acd41581de

https://phabricator.endlessm.com/T23152