### PR TITLE
Set install-timestamp gsetting when we update or upgrade

### DIFF
--- a/lib/gs-plugin-loader.c
+++ b/lib/gs-plugin-loader.c
@@ -3112,6 +3112,8 @@ gs_plugin_loader_generic_update (GsPluginLoader *plugin_loader,
 		helper->anything_ran = TRUE;
 		gs_plugin_status_update (plugin, NULL, GS_PLUGIN_STATUS_FINISHED);
 	}
+
+	gs_utils_update_install_timestamp (priv->settings);
 	return TRUE;
 }
 
@@ -3175,6 +3177,11 @@ gs_plugin_loader_process_thread_cb (GTask *task,
 			g_task_return_error (task, error);
 			return;
 		}
+	}
+
+	if (action == GS_PLUGIN_ACTION_UPGRADE_TRIGGER) {
+		GsPluginLoaderPrivate *priv = gs_plugin_loader_get_instance_private (plugin_loader);
+		gs_utils_update_install_timestamp (priv->settings);
 	}
 
 	/* remove from pending list */

--- a/lib/gs-utils.c
+++ b/lib/gs-utils.c
@@ -1041,4 +1041,22 @@ gs_utils_get_memory_total (void)
 	return si.totalram / MB_IN_BYTES / si.mem_unit;
 }
 
+/**
+ * gs_utils_update_install_timestamp:
+ *
+ * Sets the value of install-timestamp to current epoch. "install-timestamp" represents
+ * the last time we had an update or upgrade.
+ *
+ **/
+void
+gs_utils_update_install_timestamp (GSettings *settings)
+{
+	g_autoptr(GDateTime) now = NULL;
+
+	g_return_if_fail (settings != NULL);
+
+	now = g_date_time_new_now_local ();
+	g_settings_set (settings, "install-timestamp", "x", g_date_time_to_unix (now));
+}
+
 /* vim: set noexpandtab: */

--- a/lib/gs-utils.h
+++ b/lib/gs-utils.h
@@ -91,6 +91,7 @@ void		 gs_utils_append_key_value	(GString	*str,
 						 const gchar	*key,
 						 const gchar	*value);
 guint		 gs_utils_get_memory_total	(void);
+void		 gs_utils_update_install_timestamp (GSettings *settings);
 
 G_END_DECLS
 


### PR DESCRIPTION
In order to adjust the frequency of our update related app-center
notifications, we need to leverage "install-timestamp" first.
Tried to cover these cases (might be missing more of these!):

* App was set to auto-update and it got updated
* An OS upgrade has been done (from updates Tab)
* While clicking on "update all"
* App has been updated from App-details page or  from the Updates
  tab's app-row (i.e. it's a user-initiated single app update)