### PR TITLE
Mark com.endless apps as popular at appstream level

### DIFF
--- a/plugins/core/gs-appstream.c
+++ b/plugins/core/gs-appstream.c
@@ -765,15 +765,15 @@ gs_appstream_refine_app (GsPlugin *plugin,
 	    as_app_get_language (item, tmp) > 50)
 		gs_app_add_kudo (app, GS_APP_KUDO_MY_LANGUAGE);
 
+	/* Mark com.endlessm. apps with GnomeSoftware::popular kudo. See discussion on T23152 */
+	if (!as_app_has_kudo (item, "GnomeSoftware::popular") &&
+	     g_str_has_prefix (gs_app_get_id (app), "com.endlessm."))
+		as_app_add_kudo (item, "GnomeSoftware::popular");
+
 	/* add a kudo to featured and popular apps */
 	if (as_app_has_kudo (item, "GnomeSoftware::popular"))
 		gs_app_add_kudo (app, GS_APP_KUDO_FEATURED_RECOMMENDED);
 	if (as_app_has_category (item, "featured"))
-		gs_app_add_kudo (app, GS_APP_KUDO_FEATURED_RECOMMENDED);
-
-	/* Mark com.endlessm. apps with featured kudo. See discussion on T23152 */
-	if (!gs_app_has_kudo (app, GS_APP_KUDO_FEATURED_RECOMMENDED) &&
-	     g_str_has_prefix (gs_app_get_id (app), "com.endlessm."))
 		gs_app_add_kudo (app, GS_APP_KUDO_FEATURED_RECOMMENDED);
 
 	/* add new-style kudos */


### PR DESCRIPTION
As pointed out in the ticket [1], we actually need to mark our
com.endless apps as GnomeSoftware::popular (at appstream level)
instead of FEATURED_RECOMMENDED (as in commit fc07cef). This is
because appstream's add_popular vfunc populates the popular list
based on GnomeSoftware::popular kudo.

[1] https://phabricator.endlessm.com/T23152