### PR TITLE
Mark com.endlessm. apps as popular when adding to store

### DIFF
--- a/plugins/core/gs-appstream.c
+++ b/plugins/core/gs-appstream.c
@@ -765,11 +765,6 @@ gs_appstream_refine_app (GsPlugin *plugin,
 	    as_app_get_language (item, tmp) > 50)
 		gs_app_add_kudo (app, GS_APP_KUDO_MY_LANGUAGE);
 
-	/* Mark com.endlessm. apps with GnomeSoftware::popular kudo. See discussion on T23152 */
-	if (!as_app_has_kudo (item, "GnomeSoftware::popular") &&
-	     g_str_has_prefix (gs_app_get_id (app), "com.endlessm."))
-		as_app_add_kudo (item, "GnomeSoftware::popular");
-
 	/* add a kudo to featured and popular apps */
 	if (as_app_has_kudo (item, "GnomeSoftware::popular"))
 		gs_app_add_kudo (app, GS_APP_KUDO_FEATURED_RECOMMENDED);

--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -577,6 +577,11 @@ gs_flatpak_add_apps_from_xremote (GsFlatpak *self,
 		as_app_set_origin (app, flatpak_remote_get_name (xremote));
 		as_app_add_keyword (app, NULL, "flatpak");
 
+		/* Mark com.endlessm. apps with GnomeSoftware::popular kudo. See discussion on T23152 */
+		if (!as_app_has_kudo (app, "GnomeSoftware::popular") &&
+		     g_str_has_prefix (as_app_get_id (app), "com.endlessm."))
+			as_app_add_kudo (app, "GnomeSoftware::popular");
+
 		if (collection_id != NULL)
 			as_app_add_metadata (app, "flatpak::CollectionId",
 					     collection_id);


### PR DESCRIPTION
"GnomeSoftware::popular" kudo has been removed from the build
process[1] due to the recent version of appstream-validate started
to reject that kudo. Now that com.endlessm. apps are not marked
as popular anymore, they are out of the "Featured" list/category
too. In order to still keep the logic for getting "Featured" apps
and search-provider relevant, we explicitly mark com.endlessm. apps
with GnomeSoftware::popular.

[1] endlessm/eos-build@0597743

https://phabricator.endlessm.com/T23152