### PR TITLE
flatpak: Remove Blacklisting from USB Apps

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -896,7 +896,8 @@ gs_plugin_update_locale_cache_app (GsPlugin *plugin,
 	if (is_same_app (cached_app, app))
 		return;
 
-	if (cached_app && !gs_app_is_installed (cached_app)) {
+	if (cached_app && !gs_app_is_installed (cached_app) && 
+	    !gs_app_has_category (cached_app, "USB")) {
 		const char *app_id = gs_app_get_unique_id (app);
 		const char *cached_app_id = gs_app_get_unique_id (cached_app);
 
@@ -934,7 +935,8 @@ gs_plugin_eos_blacklist_kapp_if_needed (GsPlugin *plugin, GsApp *app)
 	/* last token may be the locale */
 	last_token = tokens[num_tokens - 1];
 
-	if (!gs_plugin_locale_is_compatible (plugin, last_token)) {
+	if (!gs_plugin_locale_is_compatible (plugin, last_token) &&
+	    !gs_app_has_category (app, "USB")) {
 		if (gs_app_is_installed (app))
 			return FALSE;
 
@@ -953,7 +955,8 @@ gs_plugin_eos_blacklist_kapp_if_needed (GsPlugin *plugin, GsApp *app)
 
 	/* skip if the cached app is already our best */
 	if (cached_app &&
-	    gs_plugin_app_is_locale_best_match (plugin, cached_app)) {
+	    gs_plugin_app_is_locale_best_match (plugin, cached_app)  && 
+	    !gs_app_has_category (cached_app, "USB")) {
 		if (!gs_app_is_installed (app)) {
 			g_debug ("Blacklisting '%s': cached app '%s' is best "
 				 "match", gs_app_get_unique_id (app),
@@ -1339,6 +1342,18 @@ gs_plugin_eos_blacklist_app_for_remote_if_needed (GsPlugin *plugin,
 		gs_app_add_category (app, "Blacklisted");
 
 	return do_blacklist;
+}
+
+static void
+gs_plugin_eos_remove_blacklist_from_usb_if_needed (GsPlugin *plugin,
+						  GsApp *app)
+{
+	if (!gs_app_has_category (app, "Blacklisted") || 
+	    !gs_app_has_category (app, "USB"))
+		return;
+
+	g_debug ("Removing blacklisting from '%s': app is from USB", gs_app_get_unique_id (app));
+	gs_app_remove_category (app, "Blacklisted");
 }
 
 static gboolean
@@ -1728,6 +1743,8 @@ gs_plugin_refine (GsPlugin		*plugin,
 
 		if (gs_plugin_eos_blacklist_app_for_remote_if_needed (plugin, app))
 			continue;
+		
+		gs_plugin_eos_remove_blacklist_from_usb_if_needed (plugin, app);
 
 		gs_plugin_eos_refine_popular_app (plugin, app);
 	}
@@ -2024,6 +2041,22 @@ add_updates (GsPlugin *plugin,
 		gs_app_list_remove (list, app);
 	}
 	gs_app_list_add (list, updates_proxy_app);
+
+	return TRUE;
+}
+
+gboolean
+gs_plugin_add_category_apps (GsPlugin *plugin,
+			     GsCategory *category,
+			     GsAppList *list,
+			     GCancellable *cancellable,
+			     GError **error)
+{
+	for (guint i = 0; i < gs_app_list_length (list); ++i) {
+		GsApp *app = gs_app_list_index (list, i);
+		
+		gs_plugin_eos_remove_blacklist_from_usb_if_needed (plugin, app);
+	}
 
 	return TRUE;
 }


### PR DESCRIPTION
Apps that are not on the native language of the system will be blacklisted by
gnome-software. Removing this category when it reads from an USB media and
when it verifies if an app is valid fixes the issue.

https://phabricator.endlessm.com/T23409