### PR TITLE
flatpak: Use system installation for create-usb

### DIFF
--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -3524,8 +3524,8 @@ gs_flatpak_app_copy (GsFlatpak *self,
 								       app);
 
 	gboolean spawn_retval;
-	const gchar *argv[] = {"/usr/bin/flatpak", "create-usb", copy_dest,
-			       app_ref, NULL};
+	const gchar *argv[] = {"/usr/bin/flatpak", "--system", "create-usb",
+			       copy_dest, app_ref, NULL};
 	GPid child_pid;
 	gulong cancelled_id;
 


### PR DESCRIPTION
By default the flatpak create-usb command will search both the user and
system installations for the given refs, and error out if there's
ambiguity and no opportunity for user input (such as when it's being run
in a subprocess of gnome-software). But gnome-software currently only
interacts with the system-wide flatpak installation, so we can use the
--system option when calling flatpak create-usb to prevent ambiguity.

This ensures that the "Copy to USB" feature will work even when remotes
and refs are present in the user flatpak installation (such as happens
when GNOME Builder is run).

https://phabricator.endlessm.com/T20146