### PR TITLE
Display ongoing app-installation at top of the list

### DIFF
--- a/src/gs-installed-page.c
+++ b/src/gs-installed-page.c
@@ -378,9 +378,10 @@ gs_installed_page_switch_to (GsPage *page, gboolean scroll_up)
  * Get a sort key to achive this:
  *
  * 1. state:installing applications
- * 2. state:removing applications
- * 3. kind:normal applications
- * 4. kind:system applications
+ * 2. state: applications queued for installing
+ * 3. state:removing applications
+ * 4. kind:normal applications
+ * 5. kind:system applications
  *
  * Within each of these groups, they are sorted by the install date and then
  * by name.
@@ -396,14 +397,16 @@ gs_installed_page_get_app_sort_key (GsApp *app)
 	/* sort installed, removing, other */
 	switch (gs_app_get_state (app)) {
 	case AS_APP_STATE_INSTALLING:
-	case AS_APP_STATE_QUEUED_FOR_INSTALL:
 		g_string_append (key, "1:");
 		break;
-	case AS_APP_STATE_REMOVING:
+	case AS_APP_STATE_QUEUED_FOR_INSTALL:
 		g_string_append (key, "2:");
 		break;
-	default:
+	case AS_APP_STATE_REMOVING:
 		g_string_append (key, "3:");
+		break;
+	default:
+		g_string_append (key, "4:");
 		break;
 	}
 


### PR DESCRIPTION
Currently, in the "Installed" page, the app whose installation is
in progress and the apps which are queued for installation (marked
as "Pending") are given the same rank while sorting. In this patch,
we change the priority, giving a higher priority to the current
installing app so that it shows at the top, followed by the "Pending"
apps for installation.

This is a partial fix for:
https://phabricator.endlessm.com/T23263