### PR TITLE
flatpak: Use correct error domain G_IO_ERROR

### DIFF
--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -3389,7 +3389,7 @@ gs_flatpak_create_app_from_repo_dir (GsFlatpak *self,
 
 	if (!dir_has_repo) {
 		g_autofree gchar *file_uri = g_file_get_uri (file);
-		g_set_error (error, G_IO_ERROR_FAILED, G_IO_ERROR_NOT_FOUND,
+		g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
 			     "No remotes from the given directory: %s", file_uri);
 		return NULL;
 	}


### PR DESCRIPTION
In gs_flatpak_create_app_from_repo_dir() we're returning an error with
the domain G_IO_ERROR_FAILED but that's an enum value. The correct
domain is G_IO_ERROR. This change is important because it allows the
caller gs_plugin_flatpak_file_to_app_repo() to properly check for the
G_IO_ERROR_NOT_FOUND error and ignore it. The impact of this bug is that
when a USB created with `flatpak create-usb` is inserted, gnome-software
prints an error after failing to find a matching remote in one
installation, rather than searching the other installations as well (and
similar for other uses of this code path).

https://phabricator.endlessm.com/T23419