### PR TITLE
flatpak: Avoid a seg fault when copying to USBs

### DIFF
--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -3511,8 +3511,6 @@ copy_process_watch_cb (GPid pid, gint status, gpointer user_data)
 	g_cancellable_disconnect (helper->cancellable, helper->cancelled_id);
 	g_spawn_close_pid (pid);
 
-	helper->finished = TRUE;
-
 	/* once the copy terminates (successfully or not), set plugin status to
 	 * update UI accordingly */
 	gs_plugin_status_update (helper->self->plugin, helper->app,
@@ -3526,6 +3524,8 @@ copy_process_watch_cb (GPid pid, gint status, gpointer user_data)
 	if (error != NULL)
 		g_warning ("failed to refresh flatpak metadata after copying "
 			   "app to USB: %s", error->message);
+
+	helper->finished = TRUE;
 }
 
 static void


### PR DESCRIPTION
Currently gnome-software seg faults nearly every time you use the "Copy
to USB" button, especially if the app has already been copied. The copy
happens in a subprocess that is orchestrated by gs_flatpak_app_copy()
which uses copy_process_watch_cb() as the callback function for when the
subprocess exits. However copy_process_watch_cb() sets `helper->finished
= TRUE;` before the end of the function, which causes
gs_flatpak_app_copy() to return and free the GsFlatpakCopyProcessHelper
object. Then copy_process_watch_cb() tries to continue to use the freed
helper object, leading to a segfault in gs_flatpak_refresh(),
specifically in g_hash_table_remove_all().

So this commit fixes the issue by setting helper->finished to TRUE only
at the end of the callback function. An alternative solution would be to
have copy_process_watch_cb() add a reference to the GsFlatpak and
GsPlugin objects it needs, but I think this is cleaner.

https://phabricator.endlessm.com/T23636