### PR TITLE
flatpak: Choose correct installation for create-usb command

### DIFF
--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -3555,12 +3555,24 @@ gs_flatpak_app_copy (GsFlatpak *self,
 						     app_arch, app_branch);
 	const gchar* app_collection_id = gs_flatpak_get_collection_id (self,
 								       app);
-
+	g_autofree gchar* installation_arg = NULL;
 	gboolean spawn_retval;
-	const gchar *argv[] = {"/usr/bin/flatpak", "--system", "create-usb",
-			       copy_dest, app_ref, NULL};
+	const gchar *argv[] = {"/usr/bin/flatpak",
+			       NULL, /* installation arg */
+			       "create-usb",
+			       copy_dest,
+			       app_ref,
+			       NULL
+			      };
 	GPid child_pid;
 	gulong cancelled_id;
+
+	if (flatpak_installation_get_is_user (self->installation))
+		installation_arg = g_strdup ("--user");
+	else
+		installation_arg = g_strdup_printf ("--installation=%s", flatpak_installation_get_id (self->installation));
+
+	argv[1] = installation_arg;
 
 	g_debug ("Copying app %s with collection ID: %s", app_ref,
 		 app_collection_id);


### PR DESCRIPTION
At the moment gnome-software passes "--system" to the flatpak create-usb
command used to copy apps to USB drives. But this is not necessarily
correct because gnome-software also searches the user installation. So
this commit changes the subprocess call so that it passes the
appropriate option depending on whether the app in question is in a
per-user installation, the default system installation, or another
installation.

https://phabricator.endlessm.com/T23635