### PR TITLE
flatpak: Fix heap-use-after-free of a GError

### DIFF
--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -3611,7 +3611,7 @@ gs_flatpak_app_copy (GsFlatpak *self,
 		g_main_context_iteration (NULL, FALSE);
 
 	if (helper->error) {
-		g_propagate_error (error, helper->error);
+		g_propagate_error (error, g_steal_pointer (&helper->error));
 		return FALSE;
 	}
 


### PR DESCRIPTION
This patch fixes a heap-use-after-free of a GError and subsequent seg
fault in the case that you use the "Copy to USB" button and the `flatpak
create-usb` command fails, such as because the `ostree-metadata` ref
isn't available for one of the remotes relevant to the app being copied.
This happens for example if you reflash a computer and never go online
before using the "Copy to USB" feature.

https://phabricator.endlessm.com/T23754