### PR TITLE
eos: fix asking shell to add/remove "[Invalid UTF-8]"

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -1734,16 +1734,13 @@ remove_app_from_shell (GsPlugin		*plugin,
 	GError *error = NULL;
 	GsPluginData *priv = gs_plugin_get_data (plugin);
 	g_autofree char *desktop_file_id = get_desktop_file_id (app);
-	g_autoptr(GDesktopAppInfo) app_info =
-		gs_utils_get_desktop_app_info (desktop_file_id);
-	const char *shortcut_id = g_app_info_get_id (G_APP_INFO (app_info));
 
 	g_dbus_connection_call_sync (priv->session_bus,
 				     "org.gnome.Shell",
 				     "/org/gnome/Shell",
 				     "org.gnome.Shell.AppStore",
 				     "RemoveApplication",
-				     g_variant_new ("(s)", shortcut_id),
+				     g_variant_new ("(s)", desktop_file_id),
 				     NULL,
 				     G_DBUS_CALL_FLAGS_NONE,
 				     -1,
@@ -1809,12 +1806,9 @@ add_app_to_shell (GsPlugin	*plugin,
 	GError *error = NULL;
 	GsPluginData *priv = gs_plugin_get_data (plugin);
 	g_autofree char *desktop_file_id = get_desktop_file_id (app);
-	g_autoptr(GDesktopAppInfo) app_info =
-		gs_utils_get_desktop_app_info (desktop_file_id);
-	const char *shortcut_id = g_app_info_get_id (G_APP_INFO (app_info));
 
 	/* Look up the app in our replacement list to see if we
-	 * can replace and existing shortcut, and if so, do that
+	 * can replace an existing shortcut, and if so, do that
 	 * instead */
 	const char *shortcut_id_to_replace = g_hash_table_lookup (priv->replacement_app_lookup,
 								  desktop_file_id);
@@ -1823,12 +1817,12 @@ add_app_to_shell (GsPlugin	*plugin,
 	if (shortcut_id_to_replace)
 		shell_replace_app (priv->session_bus,
 				   shortcut_id_to_replace,
-				   shortcut_id,
+				   desktop_file_id,
 				   cancellable,
 				   &error);
 	else
 		shell_add_app_if_not_visible (priv->session_bus,
-					      shortcut_id,
+					      desktop_file_id,
 					      cancellable,
 					      &error);
 


### PR DESCRIPTION
According to our statistics, "[Invalid UTF-8]" is the 3rd most popular
installed app. I also found it in my icon-grid-layout this morning.

Within g_variant_new(), if g_variant_new_string() returns NULL, the
result of g_variant_new_string("[Invalid UTF-8]") is used instead. (This
is the only place in the GLib codebase that this string appears.)

g_variant_new_string() returns NULL only if its argument is NULL, or its
argument fails g_utf8_validate(). Looking in the journal on my system
which has this value in the icon-grid-layout, I see the following:

    gnome-software[1569]: g_app_info_get_id: assertion 'G_IS_APP_INFO (appinfo)' failed
    gnome-software[1569]: g_variant_new_string: assertion 'string != NULL' failed

and no instances of the g_utf8_validate() assertion failing.

In my case, what happened is that I removed an application behind
gnome-software's back (using the command line), then tried to add it to
the desktop. Since the app is not installed,
gs_utils_get_desktop_app_info() returns NULL; g-s then tries to call
g_app_info_get_id() on that NULL, which criticals and returns NULL; it
then passes that NULL to g_variant_new("(s)", shortcut_id), and sends
that to the shell.

I have not managed to reproduce sending this string to
AddAppIfNotVisible() or ReplaceApplication() in other scenarios. I was
suspicious that it was the "replace get-foo.desktop with foo.desktop"
case that caused it, but I tried every get-* app and it seems to work.

In the remove_app_from_shell(), it is 100% reproducible that
gnome-software calls RemoveApplication("[Invalid UTF-8]") every time you
uninstall an app which is on the desktop. This is because the eos plugin
has:

    gs_plugin_add_rule (plugin, GS_PLUGIN_RULE_RUN_AFTER, "flatpak");

which guarantees that it will only be run after the Flatpak plugin has
done the work of actually removing the app. By that point, its .desktop
file is no longer on disk, so gs_utils_get_desktop_app_info() is
guaranteed to return NULL.

g_app_info_get_id (gs_utils_get_desktop_app_info (id)) == id in almost
all cases, because gs_utils_get_desktop_app_info (id) is mostly a wrapper
around g_desktop_app_info_new (id). The exceptions are:

* When id does not end with '.desktop', gs_utils_get_desktop_app_info()
  appends it. But the ID in these cases come from get_desktop_file_id(),
  which already ensures there is a '.desktop' on the end of the ID
* If g_desktop_app_info_new() returns NULL,
  gs_utils_get_desktop_app_info() prepends "kde4-" and tries again. We
  are migrating all our kde4-prefixed apps to non-prefixed Flathub
  equivalents, and Flatpak 1.0.3 will forbid exporting prefixed .desktop
  files.
* If after all this, there is no .desktop file installed matching id,
  gs_utils_get_desktop_app_info() returns NULL. This is always the case
  when an app has just been uninstalled. But we already knew the app id!

So, at best this pair of calls is a no-op; at worst it loses information
and sends junk to the shell. Remove it.

(The funny thing is that, strictly speaking, there's no guarantee that a
Flatpak app com.example.Foo actually exports com.example.Foo.desktop; in
theory it might only export com.example.Foo.Bar.desktop and
com.example.Foo-baz.desktop. In the case of LibreOffice, we already have
one Flatpak with >1 icon on the desktop, and we already rely on our
shell's behaviour of hiding icons from the grid when the .desktop file
is missing to make the icons go away if you uninstall it.)

https://phabricator.endlessm.com/T23920