### PR TITLE
Only show "Copy to OS to USB" button if it might work

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -136,9 +136,7 @@ if get_option('enable-polkit')
   conf.set('HAVE_POLKIT', 1)
 endif
 
-if get_option('enable-ostree')
-  ostree = dependency('ostree-1')
-endif
+ostree = dependency('ostree-1')
 
 if get_option('enable-packagekit')
   packagekit = dependency('packagekit-glib2', version : '>= 1.1.0')

--- a/src/meson.build
+++ b/src/meson.build
@@ -90,6 +90,7 @@ gnome_software_dependencies = [
   libsecret,
   libsoup,
   mogwai_schedule_client,
+  ostree,
 ]
 
 if get_option('enable-packagekit')


### PR DESCRIPTION
Currently gnome-software will only show the "Copy to USB" button on an
app's details page if some conditions are met that mean it has a chance
of working: there's a collection ID configured on the relevant remote(s)
and it's not an extra-data app. But the "Copy OS to USB" button is shown
unconditionally. This commit makes gnome-software only show the "Copy OS
to USB" button if there's a collection ID configured on the OS remote
(eos in the case of Endless) which is a prerequisite for the copy to
succeed.

Currently the only Endless users who have that collection ID set are
ones that reflash with a development image so most won't have the button
appear yet. After the next release it should be deployed to more users
(specifically, ones who update to 3.4.8, reboot at least once, and then
update to the following release).

https://phabricator.endlessm.com/T23944