### PR TITLE
translations: Fix Translation for USB with Ostree Repo

### DIFF
--- a/data/org.gnome.Software.mime.xml
+++ b/data/org.gnome.Software.mime.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
   <mime-type type="x-content/ostree-software">
-    <comment>Endless Apps Repository</comment>
-    <comment xml:lang="es">Repositorio de Aplicaciones para Endless</comment>
-    <comment xml:lang="id_ID">Repository Aplikasi Endless</comment>
-    <comment xml:lang="pt_BR">Repositório de Aplicativos Endless</comment>
+    <comment>Software Updates</comment>
+    <comment xml:lang="es">Actualizaciones de Software</comment>
+    <comment xml:lang="id_ID">Pembaruan Software</comment>
+    <comment xml:lang="pt_BR">Atualizações de Software</comment>
     <sub-class-of type="x-content/software"/>
     <treemagic>
       <treematch type="directory" path=".ostree" non-empty="true"/>


### PR DESCRIPTION
Fix the phrase identifier for a USB with a ostree repo on it to a
more human-readable and upstreamable way.

https://phabricator.endlessm.com/T23777