### PR TITLE
plugins/flatpak: order before icons plugin so icons are loaded

### DIFF
--- a/plugins/flatpak/gs-plugin-flatpak.c
+++ b/plugins/flatpak/gs-plugin-flatpak.c
@@ -63,6 +63,9 @@ gs_plugin_initialize (GsPlugin *plugin)
 	/* getting app properties from appstream is quicker */
 	gs_plugin_add_rule (plugin, GS_PLUGIN_RULE_RUN_AFTER, "appstream");
 
+	/* like appstream, we need the icon plugin to load cached icons into pixbufs */
+	gs_plugin_add_rule (plugin, GS_PLUGIN_RULE_RUN_BEFORE, "icons");
+
 	/* prioritize over packages */
 	gs_plugin_add_rule (plugin, GS_PLUGIN_RULE_BETTER_THAN, "packagekit");
 


### PR DESCRIPTION
Because we re-use code from the appstream plugin, locally-installed Flatpaks
which are loaded from the local AppStream file don't get their pixbuf loaded
unless the icons plugin is run after Flatpak, which means they are considered
invalid and not reliably shown in the Installed tab.

(cherry picked from commit 1fca2bb9a014f3d67f7eeb410d3638e559ba8e43)
Signed-off-by: Robert McQueen <rob@endlessm.com>

https://phabricator.endlessm.com/T20108