### PR TITLE
T23939: fix state tracking/transition around LOADING state

### DIFF
--- a/lib/gs-plugin-loader.c
+++ b/lib/gs-plugin-loader.c
@@ -2620,7 +2620,7 @@ mount_added_cb (GVolumeMonitor *volume_monitor,
 	GsPluginLoaderPrivate *priv = gs_plugin_loader_get_instance_private (plugin_loader);
 	g_autoptr(GDrive) drive = g_mount_get_drive (mount);
 
-	if (!g_drive_is_removable (drive))
+	if (drive == NULL || !g_drive_is_removable (drive))
 		return;
 
 	/* remove this mount if it already exists in the list and add it to the

--- a/src/gs-application.c
+++ b/src/gs-application.c
@@ -883,9 +883,6 @@ wrapper_action_activated_cb (GSimpleAction *action,
 								       G_SIMPLE_ACTION (real_action),
 								       g_variant_ref (parameter));
 
-		g_signal_handler_disconnect (app->shell, app->shell_loaded_handler_id);
-		app->shell_loaded_handler_id = 0;
-
 		g_signal_connect_swapped (app->shell, "loaded",
 					  G_CALLBACK (activate_on_shell_loaded_cb), helper);
 		return;

--- a/src/gs-details-page.c
+++ b/src/gs-details-page.c
@@ -2448,6 +2448,11 @@ gs_details_page_plugin_status_changed_cb (GsPluginLoader *plugin_loader,
                                           GsPluginStatus status,
                                           GsDetailsPage *self)
 {
+	self->plugin_status = status;
+
+	if (app == NULL)
+		return;
+
 	if (status == GS_PLUGIN_STATUS_COPYING) {
 		/* prevent the app from being deleted, etc. while it's being copied */
 		gs_app_add_quirk (app, AS_APP_QUIRK_COMPULSORY);
@@ -2455,8 +2460,6 @@ gs_details_page_plugin_status_changed_cb (GsPluginLoader *plugin_loader,
 		/* allow removal once copying has completed */
 		gs_app_remove_quirk (app, AS_APP_QUIRK_COMPULSORY);
 	}
-
-	self->plugin_status = status;
 }
 
 static gboolean
@@ -2484,7 +2487,6 @@ gs_details_page_setup (GsPage *page,
 	g_signal_connect (plugin_loader, "notify::copy-dests",
 			  G_CALLBACK (gs_details_page_copy_dests_notify_cb),
 			  self);
-	gs_details_page_copy_dests_notify_cb (plugin_loader, NULL, self);
 
 	/* show review widgets if we have plugins that provide them */
 	self->enable_reviews =

--- a/src/gs-shell.c
+++ b/src/gs-shell.c
@@ -786,6 +786,12 @@ gs_shell_copy_dests_notify_cb (GsPluginLoader *plugin_loader,
 	GsShellPrivate *priv = gs_shell_get_instance_private (shell);
 	GsPage *page = GS_PAGE (g_hash_table_lookup (priv->pages, "overview"));
 
+	/* reloading the overview page before the initial refresh is completed
+	   means the categories and popular apps don't get initialised properly
+	   and the UI appears very broken */
+	if (priv->mode == GS_SHELL_MODE_LOADING)
+		return;
+
 	gs_page_reload (page);
 }
 
@@ -1808,7 +1814,6 @@ gs_shell_setup (GsShell *shell, GsPluginLoader *plugin_loader, GCancellable *can
 	g_signal_connect (priv->plugin_loader, "notify::copy-dests",
 			  G_CALLBACK (gs_shell_copy_dests_notify_cb),
 			  shell);
-	gs_shell_copy_dests_notify_cb (plugin_loader, NULL, shell);
 	g_signal_connect_object (priv->plugin_loader, "notify::events",
 				 G_CALLBACK (gs_shell_events_notify_cb),
 				 shell, 0);

--- a/src/gs-shell.c
+++ b/src/gs-shell.c
@@ -763,9 +763,6 @@ main_window_closed_cb (GtkWidget *dialog, GdkEvent *event, gpointer user_data)
 	g_application_withdraw_notification (g_application_get_default (),
 					     "install-resources");
 
-	/* When the window is closed, reset the initial mode to overview */
-	priv->mode = GS_SHELL_MODE_OVERVIEW;
-
 	gs_shell_clean_back_entry_stack (shell);
 	gtk_widget_hide (dialog);
 	return TRUE;

--- a/src/gs-shell.c
+++ b/src/gs-shell.c
@@ -2213,7 +2213,8 @@ gs_shell_side_filter_clear_categories (GsShell *shell)
 
 	/* select the overview mode to prevent removing a category row
 	 * that may be selected */
-	gs_shell_set_mode (shell, GS_SHELL_MODE_OVERVIEW);
+	if (priv->mode == GS_SHELL_MODE_CATEGORY)
+		gs_shell_set_mode (shell, GS_SHELL_MODE_OVERVIEW);
 
 	rows = gtk_container_get_children (GTK_CONTAINER (priv->side_filter));
 	for (GList *l = rows; l; l = l->next) {

--- a/src/gs-shell.c
+++ b/src/gs-shell.c
@@ -1967,18 +1967,7 @@ void
 gs_shell_set_mode (GsShell *shell, GsShellMode mode)
 {
 	GsShellPrivate *priv = gs_shell_get_instance_private (shell);
-	guint matched;
 
-	/* if we're loading a different mode at startup then don't wait for
-	 * the overview page to load before showing content */
-	if (mode != GS_SHELL_MODE_OVERVIEW) {
-		GsPage *page = g_hash_table_lookup (priv->pages, "overview");
-		matched = g_signal_handlers_disconnect_by_func (page,
-								initial_overview_load_done,
-								shell);
-		if (matched > 0)
-			g_signal_emit (shell, signals[SIGNAL_LOADED], 0);
-	}
 	gs_shell_change_mode (shell, mode, NULL, TRUE);
 }
 


### PR DESCRIPTION
There were a few different bugs where the shell and the application's idea of whether the shell had finished loading could be bypassed or get out of sync. This branch cleans the shell logic up so that the shell doesn't emit the "loading" signal or leave the LOADING mode until the initial refresh has been completed, and the shell and application can use these guarantees to prevent other actions being started too early.

The main "culprit" here was the USB app installation code reloading the overview page as new mount points appeared, which happens asynchronously during the application startup. This was starting the loading of categories and popular apps before the initial refresh had completed, which was causing live locks between the plugins, and the categories and popular apps staying empty for the lifespan of the app.

Also squash various other new warnings caused by the USB app export code, things being accessed before being initialised, or updated un-necessarily.

https://phabricator.endlessm.com/T23939