### PR TITLE
T23939: additional couple of fixes

### DIFF
--- a/src/gs-application.c
+++ b/src/gs-application.c
@@ -260,7 +260,7 @@ theme_changed (GtkSettings *settings, GParamSpec *pspec, GsApplication *app)
 static void
 gs_application_shell_loaded_cb (GsShell *shell, GsApplication *app)
 {
-	gs_shell_set_mode (app->shell, GS_SHELL_MODE_OVERVIEW);
+	g_signal_handler_disconnect (app->shell, app->shell_loaded_handler_id);
 	app->shell_loaded_handler_id = 0;
 }
 

--- a/src/gs-overview-page.c
+++ b/src/gs-overview-page.c
@@ -510,8 +510,10 @@ out:
 	priv->empty = !has_category;
 
 	/* We always show the side filter in the overview page because it
-	 * has the "Featured" row */
-	gs_shell_side_filter_set_visible (priv->shell, TRUE);
+	 * has the "Featured" row. Re-check the mode because it's possible
+	 * to switch mode before the categories have loaded. */
+	if (gs_shell_get_mode (priv->shell) == GS_SHELL_MODE_OVERVIEW)
+		gs_shell_side_filter_set_visible (priv->shell, TRUE);
 
 	priv->loading_categories = FALSE;
 

--- a/src/gs-shell.c
+++ b/src/gs-shell.c
@@ -586,6 +586,10 @@ initial_overview_load_done (GsOverviewPage *overview_page, gpointer data)
 	gs_page_reload (page);
 
 	g_signal_emit (shell, signals[SIGNAL_LOADED], 0);
+
+	/* go to OVERVIEW, unless the "loading" callbacks changed mode already */
+	if (priv->mode == GS_SHELL_MODE_LOADING)
+		gs_shell_change_mode (shell, GS_SHELL_MODE_OVERVIEW, NULL, TRUE);
 }
 
 static void


### PR DESCRIPTION
The patch c4579fb dropped from https://github.com/endlessm/gnome-software/pull/423 is actually needed because it prevents the shell from needlessly going to the overview mode before the set_mode GAction is handled - we unconditionally keep the shell_loaded_handler_id as an indicator of whether loading has completed, and the shell decides whether the loading->overview transition is needed or not.

This in turn exposed another bug where if you go from overview to another mode before the categories have loaded, the side filters get shown on the other mode.

https://phabricator.endlessm.com/T23939