### PR TITLE
updates section: Be more defensive before triggering reboots

### DIFF
--- a/src/gs-updates-page.c
+++ b/src/gs-updates-page.c
@@ -827,7 +827,7 @@ _update_all (GsUpdatesPage *self, GsAppList *apps)
 	/* look at each app in turn */
 	for (guint i = 0; apps != NULL && i < gs_app_list_length (apps); i++) {
 		GsApp *app = gs_app_list_index (apps, i);
-		if (gs_app_get_state (app) != AS_APP_STATE_UPDATABLE_LIVE)
+		if (gs_app_get_state (app) == AS_APP_STATE_UPDATABLE)
 			helper->do_reboot = TRUE;
 		if (gs_app_has_quirk (app, AS_APP_QUIRK_NEEDS_REBOOT))
 			helper->do_reboot_notification = TRUE;


### PR DESCRIPTION
Instead of checking that app state != UPDATABLE_LIVE, check that it is
UPDATABLE. This ensures that we don't do a reboot in case of an
unexpected state, such as INSTALLING.

https://gitlab.gnome.org/GNOME/gnome-software/issues/483
(cherry picked from commit c85432c779d76f566eb3e303a1cdaa577ccb3af0)
Signed-off-by: Robert McQueen <rob@endlessm.com>

Moved equivalent code back to to src/gs-updates-page.c where it used to be in
our version.

https://phabricator.endlessm.com/T19785