### PR TITLE
Revert "flatpak: Stop refreshing the updates page after every update"

### DIFF
--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -4199,6 +4199,9 @@ gs_flatpak_update_app (GsFlatpak *self,
 		return FALSE;
 	}
 
+	/* update UI */
+	gs_plugin_updates_changed (self->plugin);
+
 	/* state is known */
 	gs_app_set_state (app, AS_APP_STATE_INSTALLED);
 	gs_app_set_update_version (app, NULL);


### PR DESCRIPTION
The updates page needs the signal for refreshing its layout when it has
both PackageKit apps that require reboot, and online updatable flatpak
apps.

This reverts commit 2e7ca21eb2e97468370e6406a47b507d6d7083d1.
This reverts commit 484de32a2843f4e6653d9a1701dac31911a200b1.

(cherry picked from commit befabac6cb5e390022bbeb3deaf852a78a20d2de)
Signed-off-by: Robert McQueen <rob@endlessm.com>

https://phabricator.endlessm.com/T22234