### PR TITLE
eos: Ensure both QUIRK_PARENTAL_* quirks can be set simultaneously

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -1471,12 +1471,14 @@ app_is_parentally_blacklisted (GsApp *app, EpcAppFilter *app_filter)
 static gboolean
 gs_plugin_eos_parental_filter_if_needed (GsPlugin *plugin, GsApp *app, EpcAppFilter *app_filter)
 {
+	gboolean filtered = FALSE;
+
 	/* Check the OARS ratings to see if this app should be installable. */
 	if (!app_is_content_rating_appropriate (app, app_filter)) {
 		g_debug ("Filtering ‘%s’: app OARS rating is too extreme for this user",
 		         gs_app_get_unique_id (app));
 		gs_app_add_quirk (app, GS_APP_QUIRK_PARENTAL_FILTER);
-		return TRUE;
+		filtered = TRUE;
 	}
 
 	/* Check the app blacklist to see if this app should be launchable. */
@@ -1484,10 +1486,10 @@ gs_plugin_eos_parental_filter_if_needed (GsPlugin *plugin, GsApp *app, EpcAppFil
 		g_debug ("Filtering ‘%s’: app is blacklisted for this user",
 		         gs_app_get_unique_id (app));
 		gs_app_add_quirk (app, GS_APP_QUIRK_PARENTAL_NOT_LAUNCHABLE);
-		return TRUE;
+		filtered = TRUE;
 	}
 
-	return FALSE;
+	return filtered;
 }
 
 static gboolean


### PR DESCRIPTION
If an app is:
 • Installed
 • Blacklisted by the parental controls app filter
 • Blacklisted by the parental controls OARS filter
it would only have the QUIRK_PARENTAL_FILTER set on it (from the OARS
filter), but not QUIRK_PARENTAL_NOT_LAUNCHABLE (from the app filter).
This would be fine, but because it’s already installed,
QUIRK_PARENTAL_FILTER is ignored in a few places (correctly); which
makes the lack of QUIRK_PARENTAL_NOT_LAUNCHABLE relevant.

Specifically, it means that the app can be listed in search results, and
on its details page its ‘Launch’ and ‘Add to Desktop’ buttons are
visible and sensitive. They’re supposed to be hidden.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T24017