### PR TITLE
Fix displaying Flathub apps on Featured tab

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -2360,6 +2360,9 @@ gs_plugin_add_popular (GsPlugin *plugin,
 		if (!g_strcmp0 (origin, "eos-apps") &&
 		    g_str_has_prefix (app_id, "com.endlessm."))
 			add = TRUE;
+		/* all com.endlessnetwork. apps */
+		else if (g_str_has_prefix (app_id, "com.endlessnetwork."))
+			add = TRUE;
 
 		if (add)
 			gs_app_list_add (new_list, app);

--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -2293,27 +2293,42 @@ gs_plugin_add_popular (GsPlugin *plugin,
 {
 	g_autoptr(AsProfileTask) ptask = NULL;
 	GsAppList *new_list = NULL;
+	/* These IDs must match the <component><id> element in the app's
+	 * appdata. Note in particular that some apps have a .desktop suffix
+	 * there, and some do not.
+	 */
 	const gchar *popular_apps[] = {
 		"com.calibre_ebook.calibre.desktop",
 		"com.google.Chrome.desktop",
 		"com.spotify.Client.desktop",
-		"com.transmissionbt.Transmission.desktop",
+		"com.transmissionbt.Transmission",
 		"com.valvesoftware.Steam.desktop",
 		"io.github.mmstick.FontFinder.desktop",
-		"net.minetest.Minetest.desktop",
-		"net.scribus.Scribus.desktop",
-		"org.audacityteam.Audacity.desktop",
-		"org.gimp.GIMP.desktop",
-		"org.gnome.chess.desktop",
-		"org.gnome.SwellFoop.desktop",
-		"org.inkscape.Inkscape.desktop",
+		"net.minetest.Minetest",
+		"net.scribus.Scribus",
+		"org.audacityteam.Audacity",
+		"org.gimp.GIMP",
+		"org.gnome.Chess",
+		"org.gnome.SwellFoop",
+		"org.inkscape.Inkscape",
 		"org.kde.gcompris.desktop",
-		"org.kde.krita.desktop",
+		"org.kde.krita",
 		"org.libreoffice.LibreOffice.desktop",
 		"org.mozilla.Firefox.desktop",
 		"org.telegram.desktop.desktop",
 		"org.tuxpaint.Tuxpaint.desktop",
 		"org.videolan.VLC.desktop",
+		/* TODO: this doesn't end up in the list of apps used by the
+		 * overview. Relevant log output:
+		 *
+		 *   As  run 0x562bb3977e30~GsPlugin::appstream(gs_plugin_add_popular;gs_plugin_refine_wildcard)
+		 *   Gs  not using simple-scan.desktop for wildcard as no bundle or pkgname
+		 *
+		 * This app is built into the ostree. Its ID is, without spaces:
+		 *
+		 *   system / * / * / desktop / simple-scan.desktop / *
+		 *            ^   ^ these are probably bundle and pkgname?
+		 */
 		"simple-scan.desktop",
 		NULL
 	};

--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -2299,6 +2299,7 @@ gs_plugin_add_popular (GsPlugin *plugin,
 	 */
 	const gchar *popular_apps[] = {
 		"com.calibre_ebook.calibre.desktop",
+		"com.endlessm.photos.desktop",
 		"com.google.Chrome.desktop",
 		"com.spotify.Client.desktop",
 		"com.transmissionbt.Transmission",
@@ -2348,7 +2349,19 @@ gs_plugin_add_popular (GsPlugin *plugin,
 	/* get all the popular apps that are Endless' ones */
 	for (guint i = 0; i < gs_app_list_length (list); ++i) {
 	        GsApp *app = gs_app_list_index (list, i);
-		if (g_str_has_prefix (gs_app_get_id (app), "com.endlessm."))
+		const gchar *app_id = gs_app_get_id (app);
+		const gchar *origin = gs_app_get_origin (app);
+		gboolean add = FALSE;
+
+		if (!app_id || !origin)
+			continue;
+
+		/* com.endlessm. apps from eos-apps */
+		if (!g_strcmp0 (origin, "eos-apps") &&
+		    g_str_has_prefix (app_id, "com.endlessm."))
+			add = TRUE;
+
+		if (add)
 			gs_app_list_add (new_list, app);
 	}
 

--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -592,9 +592,10 @@ gs_flatpak_add_apps_from_xremote (GsFlatpak *self,
 		as_app_set_origin (app, flatpak_remote_get_name (xremote));
 		as_app_add_keyword (app, NULL, "flatpak");
 
-		/* Mark com.endlessm. apps with GnomeSoftware::popular kudo. See discussion on T23152 */
+		/* Mark Endless apps with GnomeSoftware::popular kudo. See discussion on T23152 */
 		if (!as_app_has_kudo (app, "GnomeSoftware::popular") &&
-		     g_str_has_prefix (as_app_get_id (app), "com.endlessm."))
+		    (g_str_has_prefix (as_app_get_id (app), "com.endlessm.") ||
+		     g_str_has_prefix (as_app_get_id (app), "com.endlessnetwork.")))
 			as_app_add_kudo (app, "GnomeSoftware::popular");
 
 		if (collection_id != NULL)

--- a/src/gs-overview-page.c
+++ b/src/gs-overview-page.c
@@ -130,32 +130,9 @@ filter_category (GsApp *app, gpointer user_data)
 }
 
 static gint
-sort_with_popular_background (GsApp *a, GsApp *b, gpointer user_data)
-{
-	gint cmp = 0;
-	const char *image_a = gs_app_get_metadata_item (a,
-					"GnomeSoftware::popular-background");
-	const char *image_b = gs_app_get_metadata_item (b,
-					"GnomeSoftware::popular-background");
-
-	if (image_a && image_a[0] != '\0')
-		cmp -= 1;
-
-	if (image_b && image_b[0] != '\0')
-		cmp += 1;
-
-	return cmp;
-}
-
-static gint
 sort_by_alphabetical_order (GsApp *a, GsApp *b, gpointer user_data)
 {
-	gint cmp = sort_with_popular_background (a, b, user_data);
-
-	if (cmp == 0)
-		return g_strcmp0 (gs_app_get_name (a), gs_app_get_name (b));
-
-	return cmp;
+	return g_strcmp0 (gs_app_get_name (a), gs_app_get_name (b));
 }
 
 static void
@@ -220,13 +197,10 @@ gs_overview_page_get_popular_cb (GObject *source_object,
 	gs_app_list_filter (list, filter_category, priv->category_of_day);
 	gs_app_list_randomize (list);
 
+	/* On some images, we want these apps to be sorted alphabetically. */
 	sort_alphabetically = g_settings_get_boolean (priv->settings,
 						      "sort-overview-alphabetically");
-	/* In any case always sort the randomized list based on the presence of the popular
-	 * background so it gives precedence to apps that have that asset */
-	if (!sort_alphabetically)
-		gs_app_list_sort (list, sort_with_popular_background, NULL);
-	else
+	if (sort_alphabetically)
 		gs_app_list_sort (list, sort_by_alphabetical_order, NULL);
 
 	gs_container_remove_all (GTK_CONTAINER (priv->box_popular));


### PR DESCRIPTION
Since we moved various applications to Flathub, they fell out of our Featured tab, even though we attempted to update the hard-coded list.

There turned out to be two bugs here:

* The app IDs in the hard-coded list are neither Flatpak app IDs, nor .desktop file IDs: they are the <id> element from the appdata, which may be one or the other.
* We effectively filtered out any app which does not have a tile background image, which (since this is Endless-specific) effectively filtered out any Flathub apps.

Fixing the second point causes Hatch Previewer, a development tool we have published with a com.endlessm.* app ID to Flathub, to appear in the popular app rotation; I addressed this with a nasty special-case. Alternative suggestions welcome!

https://phabricator.endlessm.com/T23953