### PR TITLE
gs-updates-page: Don’t crash if mogwai-scheduled stops

### DIFF
--- a/src/gs-updates-page.c
+++ b/src/gs-updates-page.c
@@ -1799,9 +1799,11 @@ gs_updates_page_upgrade_cancel_cb (GsUpgradeBanner *upgrade_banner,
 static void
 scheduler_invalidated_cb (GsUpdatesPage *self)
 {
-	g_warning ("The Mogwai Scheduler has just been invalidated when "
-		   "it should still be held!");
-	g_assert_not_reached ();
+	/* The scheduler shouldn’t normally be invalidated, since we Hold() it
+	 * until we’re done with it. However, if the scheduler is stopped by
+	 * systemd (`systemctl stop mogwai-scheduled`) this signal will be
+	 * emitted. */
+	g_clear_object (&self->scheduler);
 }
 
 static void
@@ -1825,9 +1827,6 @@ scheduler_hold_cb (GObject *source_object,
 		return;
 	}
 
-	/* we connect to the invalidated signal just for sanity check, as it
-	 * should not be reached (we disconnect it before releasing the Mogwai
-	 * Scheduler daemon) */
 	self->scheduler_invalidated_handler =
 		g_signal_connect_swapped (scheduler, "invalidated",
 					  (GCallback) scheduler_invalidated_cb,


### PR DESCRIPTION
The updates page holds a reference to the Mogwai scheduler, which should
normally stop it being invalidated while the page needs it. However, if
some feckless developer runs `systemctl stop mogwai-scheduled`, the hold
on the scheduler will be ignored, and it will disappear from the bus.

Previously, this would cause gnome-software to emit a critical warning
and abort. We probably want it to gracefully drop its scheduler instance
and carry on without scheduling support instead.

Spotted while working on T24117.

Signed-off-by: Philip Withnall <withnall@endlessm.com>