### PR TITLE
gs-details-page: Possible fix for an assertion failure warning

### DIFF
--- a/src/gs-details-page.c
+++ b/src/gs-details-page.c
@@ -286,7 +286,7 @@ gs_details_page_update_copy_button (GsDetailsPage *self)
 		return;
 
 	copy_dest = removable_destination_dup (self);
-	if (gs_app_is_installed (self->app)) {
+	if (self->app != NULL && gs_app_is_installed (self->app)) {
 		if (copy_dest != NULL) {
 			gtk_button_set_label (GTK_BUTTON (self->button_copy), _("Copy to USB"));
 			gtk_widget_set_sensitive (self->button_copy, TRUE);


### PR DESCRIPTION
Spotted while looking at OpenQA logs for T24855. This is a potential fix
for the following warning:
  Jan 28 15:22:57 endless gnome-software[1717]: gs_app_is_installed: assertion 'GS_IS_APP (app)' failed

Spotted by reading the code, rather than any more precise debugging
technique. Other places in gs-details-page.c check (self->app != NULL)
before doing anything with the app, so it’s obviously possible for the
app to be NULL. Guard against that case when updating the ‘Copy to USB’
button too.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T24855