### PR TITLE
fixup! trivial: Never show cancelled error messages to the user

### DIFF
--- a/lib/gs-plugin-loader.c
+++ b/lib/gs-plugin-loader.c
@@ -458,7 +458,8 @@ gs_plugin_error_handle_failure (GsPluginLoaderHelper *helper,
 	}
 
         /* this is only ever informational */
-        if (g_error_matches (error_local, GS_PLUGIN_ERROR, GS_PLUGIN_ERROR_CANCELLED)) {
+        if (g_error_matches (error_local, GS_PLUGIN_ERROR, GS_PLUGIN_ERROR_CANCELLED) ||
+            g_error_matches (error_local, G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
                 g_debug ("ignoring error cancelled: %s", error_local->message);
                 return TRUE;
         }


### PR DESCRIPTION
Restrict G_IO_ERROR_CANCELLED from showing up in the error banner.
Ideally this should not happen as the G_IO_ERROR is converted
to G_PLUGIN_ERROR domain via gs_flatpak_error_convert. Additionally,
this is not reproducable on the upstream gnome-software master as of
now (commit : 5531a7d1).

We should revisit this after gnome-software rebase over 3.32

https://phabricator.endlessm.com/T23928