### PR TITLE
add Learn to Code category

### DIFF
--- a/plugins/core/gs-desktop-common.c
+++ b/plugins/core/gs-desktop-common.c
@@ -169,6 +169,13 @@ static const GsDesktopMap map_games[] = {
 	{ NULL }
 };
 
+static const GsDesktopMap map_learn_to_code[] = {
+	{ "all",		NC_("Menu of Learn to Code", "All"),
+					{ "LearnToCode",
+					  NULL } },
+	{ NULL }
+};
+
 /* Office */
 static const GsDesktopMap map_productivity[] = {
 	{ "all",		NC_("Menu of Productivity", "All"),
@@ -326,6 +333,10 @@ static const GsDesktopData msdata[] = {
 	/* TRANSLATORS: this is the menu spec main category for Game */
 	{ "games",		map_games,		N_("Games"),
 				"applications-games-symbolic", "#5cae4b", 70 },
+	/* TRANSLATORS: this is the menu spec main category for Endless
+	 * Studios' "learn to code" category */
+	{ "learn-to-code",	map_learn_to_code,		N_("Learn to Code"),
+				"applications-games-symbolic", "#af07af", 65 },
 	/* TRANSLATORS: this is the menu spec main category for Multimedia */
 	{ "multimedia",		map_multimedia,		N_("Multimedia"),
 				"applications-multimedia-symbolic", "#07afa7", 60 },


### PR DESCRIPTION
This category will be used for games developed by Endless Interactive to
highlight them separately from other games.

As of this writing, there are no apps available in this category so it
will not be displayed. However, I've confirmed that the category does
get populated when apps for the associated category are available.

For apps to appear in this category, they will need to include "Endless
Games" in their AppStream <categories>. See the AppStream documentation
for more details:

https://www.freedesktop.org/software/appstream/docs/chap-CollectionData.html

This, of course, is an invented category not among the FreeDesktop Menu
Specification's Registered Categories (but it's also not among the
Reserved Categories):

https://specifications.freedesktop.org/menu-spec/latest/apa.html

https://phabricator.endlessm.com/T25518