### PR TITLE
flatpak: Fix checking installed apps when adding updates

### DIFF
--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -1532,6 +1532,11 @@ gs_flatpak_add_updates (GsFlatpak *self, GsAppList *list,
 		}
 
 		app = gs_flatpak_create_installed (self, xref, &error_local);
+		if (app == NULL) {
+			g_warning ("failed to add flatpak: %s", error_local->message);
+			continue;
+		}
+
 		/* if we don't have a runtime set yet, then refine the metadata */
 		if (gs_app_get_runtime (app) == NULL &&
 		    !gs_plugin_refine_item_metadata (self,
@@ -1541,10 +1546,6 @@ gs_flatpak_add_updates (GsFlatpak *self, GsAppList *list,
 			g_debug ("Failed to refine state for app %s: %s",
 				 gs_app_get_unique_id (app),
 				 error_local->message);
-			continue;
-		}
-		if (app == NULL) {
-			g_warning ("failed to add flatpak: %s", error_local->message);
 			continue;
 		}
 


### PR DESCRIPTION
When getting the installed apps from Flatpak refs for adding updates,
the code was using the returned GsApp object without checking whether
it's valid. Thus, if that pointer was NULL, it'd not only still keep
using it but also end up reusing an already set GError.

https://phabricator.endlessm.com/T25495