### PR TITLE
eos: Add a comment clarifying the state change of proxy apps

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -1818,6 +1818,9 @@ gs_plugin_refine_proxy_app (GsPlugin	*plugin,
 		gs_app_add_related (app, related_app);
 	}
 
+	/* mark the state as unknown so 1) we're always allowed to change the state below
+	 * if needed; and 2) the app will not be shown at all (unless the state is changed
+	 * below), thus avoiding eventually showing a proxy app without updates */
 	gs_app_set_state (app, AS_APP_STATE_UNKNOWN);
 
 	/* only let the proxy app show in the updates list if it has anything to update */


### PR DESCRIPTION
This state change happens in the function that refines proxy apps, and
ensures that the proxy apps' state is set according to whether it has
apps to be processed; however, especially for developers not very
experienced with GNOME Software, it's good to document why that change
is done the way it is.

https://phabricator.endlessm.com/T25495