### PR TITLE
flatpak: Undo 2x factor in success/failure update heuristics

### DIFF
--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -3805,7 +3805,7 @@ gs_flatpak_has_space_to_update (GsFlatpak *self, GsApp *app, GsAppList *list, gb
 		g_warning ("Error getting min-free-space config value of OSTree repo at %s:%s", path, error->message);
 		g_clear_error (&error);
 	}
-	space_required = (space_required * 2) + min_free_space;
+	space_required = space_required + min_free_space;
 	if (!get_installation_dir_free_space (self, &free_space, &error)) {
 		g_warning ("Error getting the free space available for updating %s: %s",
 			   gs_app_get_unique_id (app), error->message);


### PR DESCRIPTION
Flatpak(v1.3.3) now has a solution to temporary usage of double disk
space for app installs or updates. Therefore, we can undo our 2x free
disk-space factor for updates introduced in [1]. The check for free
disk space against (app's size + min-free-space) needs to be kept
intact.

[1]: https://github.com/endlessm/gnome-software/pull/399

https://phabricator.endlessm.com/T26084