### PR TITLE
eos: remove Minecraft from duplicated apps list

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -996,7 +996,6 @@ gs_plugin_eos_blacklist_app_for_remote_if_needed (GsPlugin *plugin,
 
 	static const char *duplicated_apps[] = {
 		"com.google.Chrome",
-		"com.mojang.Minecraft",
 		"com.sparklinlabs.Superpowers",
 		"com.stencyl.Game",
 		"de.billardgl.Billardgl",


### PR DESCRIPTION
Moving from eos-apps version to Flathub version.

https://phabricator.endlessm.com/T26588