### PR TITLE
eos: update list of proxied apps for the HackComponents

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -2230,6 +2230,7 @@ add_updates (GsPlugin *plugin,
 					   "com.endlessm.Hackdex_chapter_two.desktop",
 					   "com.endlessm.LightSpeed.desktop",
 					   "com.endlessm.OperatingSystemApp.desktop",
+					   "com.endlessm.Sidetrack.desktop",
 					   NULL};
 
 	GsPluginData *priv = gs_plugin_get_data (plugin);


### PR DESCRIPTION
Add the new toy app com.endlessm.Sidetrack

https://phabricator.endlessm.com/T26622