### PR TITLE
eos: Drop popular apps support

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -2079,65 +2079,6 @@ gs_plugin_add_updates (GsPlugin *plugin,
 	return add_updates (plugin, list, cancellable, error);
 }
 
-gboolean
-gs_plugin_add_popular (GsPlugin *plugin,
-		       GsAppList *list,
-		       GCancellable *cancellable,
-		       GError **error)
-{
-	g_autoptr(AsProfileTask) ptask = NULL;
-	GsAppList *new_list = NULL;
-	const gchar *popular_apps[] = {
-		"com.calibre_ebook.calibre.desktop",
-		"com.google.Chrome.desktop",
-		"com.spotify.Client.desktop",
-		"com.transmissionbt.Transmission.desktop",
-		"com.valvesoftware.Steam.desktop",
-		"io.github.mmstick.FontFinder.desktop",
-		"net.minetest.Minetest.desktop",
-		"net.scribus.Scribus.desktop",
-		"org.audacityteam.Audacity.desktop",
-		"org.gimp.GIMP.desktop",
-		"org.gnome.chess.desktop",
-		"org.gnome.SwellFoop.desktop",
-		"org.inkscape.Inkscape.desktop",
-		"org.kde.gcompris.desktop",
-		"org.kde.krita.desktop",
-		"org.libreoffice.LibreOffice.desktop",
-		"org.mozilla.Firefox.desktop",
-		"org.telegram.desktop.desktop",
-		"org.tuxpaint.Tuxpaint.desktop",
-		"org.videolan.VLC.desktop",
-		"simple-scan.desktop",
-		NULL
-	};
-
-	ptask = as_profile_start_literal (gs_plugin_get_profile (plugin),
-					  "eos::add-popular");
-
-	new_list = gs_app_list_new ();
-
-	/* add the hardcoded list of popular apps */
-	for (guint i = 0; popular_apps[i] != NULL; ++i) {
-		g_autoptr(GsApp) app = gs_app_new (popular_apps[i]);
-		gs_app_add_quirk (app, AS_APP_QUIRK_MATCH_ANY_PREFIX);
-		gs_app_list_add (new_list, app);
-	}
-
-	/* get all the popular apps that are Endless' ones */
-	for (guint i = 0; i < gs_app_list_length (list); ++i) {
-	        GsApp *app = gs_app_list_index (list, i);
-		if (g_str_has_prefix (gs_app_get_id (app), "com.endlessm."))
-			gs_app_list_add (new_list, app);
-	}
-
-	/* replace the list of popular apps so far by ours */
-	gs_app_list_remove_all (list);
-	gs_app_list_add_list (list, new_list);
-
-	return TRUE;
-}
-
 static void
 setup_os_upgrade (GsPlugin *plugin)
 {


### PR DESCRIPTION
It’s now implemented by adding the relevant kudos to the eos-extra.xml
appstream file, which can be updated independently from gnome-software.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T26507