### PR TITLE
T26936 spark app filtering

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -1359,6 +1359,12 @@ app_is_banned_for_personality (GsPlugin *plugin, GsApp *app)
 	GsPluginData *priv = gs_plugin_get_data (plugin);
 	const char *app_name = gs_flatpak_app_get_ref_name (app);
 
+	static const char *adult_apps[] = {
+		"com.katawa_shoujo.KatawaShoujo",
+		"com.scoutshonour.dtipbijays",
+		NULL
+	};
+
 	static const char *violent_apps[] = {
 		"com.grangerhub.Tremulous",
 		"com.moddb.TotalChaos",
@@ -1392,7 +1398,8 @@ app_is_banned_for_personality (GsPlugin *plugin, GsApp *app)
 	        (g_strv_contains (google_apps, app_name) ||
 	         g_str_has_prefix (app_name, "com.endlessm.encyclopedia"))) ||
 	       (g_str_has_prefix (priv->personality, "spark") &&
-	        g_strv_contains (violent_apps, app_name));
+	        (g_strv_contains (adult_apps, app_name) ||
+	         g_strv_contains (violent_apps, app_name)));
 }
 
 static gboolean

--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -1390,7 +1390,9 @@ app_is_banned_for_personality (GsPlugin *plugin, GsApp *app)
 	        g_strv_contains (violent_apps, app_name)) ||
 	       ((g_strcmp0 (priv->personality, "zh_CN") == 0) &&
 	        (g_strv_contains (google_apps, app_name) ||
-	         g_str_has_prefix (app_name, "com.endlessm.encyclopedia")));
+	         g_str_has_prefix (app_name, "com.endlessm.encyclopedia"))) ||
+	       (g_str_has_prefix (priv->personality, "spark") &&
+	        g_strv_contains (violent_apps, app_name));
 }
 
 static gboolean

--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -1360,6 +1360,9 @@ app_is_banned_for_personality (GsPlugin *plugin, GsApp *app)
 	const char *app_name = gs_flatpak_app_get_ref_name (app);
 
 	static const char *violent_apps[] = {
+		"com.grangerhub.Tremulous",
+		"com.moddb.TotalChaos",
+		"com.realm667.WolfenDoom_Blade_of_Agony",
 		"io.github.FreeDM",
 		"io.github.Freedoom-Phase-1",
 		"io.github.Freedoom-Phase-2",


### PR DESCRIPTION
This hard-codes filtering of a number of violent and adult-content apps for the Spark personalities.

As a side effect, it bans a few additional violent games for the `gt_GT` personality but I assume that's OK.

I have not tested this myself other than ensuring it builds given a pretty serious time crunch. If it looks good enough, we can merge, build a new Spark image, then test in that