### PR TITLE
eos: remove Scratch from duplicated apps list

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -1006,7 +1006,6 @@ gs_plugin_eos_blacklist_app_for_remote_if_needed (GsPlugin *plugin,
 		"org.platformio.Ide",
 		"org.snap4arduino.App",
 		"org.squeakland.Etoys",
-		"org.squeakland.Scratch",
 		NULL
 	};
 


### PR DESCRIPTION
Moving from eos-apps version to Flathub version.

https://phabricator.endlessm.com/T26658