### PR TITLE
debian: Drop Debian-specific dependencies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+gnome-software (3.32.0-1endless1) UNRELEASED; urgency=medium
+
+  * Drop Debian-specific dependencies (T25367)
+    - libgtk3-perl: Needed for debconf
+    - software-properties-gtk: Debian-specific apt repository configuration tool
+  * Drop fwupd `recommends` line (T25367)
+    - We already dropped the build dependency, so keeping the `recommends` is
+      just confusing.
+  * Drop `apt-config-icons` dependency (T25367)
+    - Our apt repositories don’t support it, and the majority of our apps are
+      packaged in flatpak.
+
+ -- Philip Withnall <withnall@endlessm.com>  Mon, 22 Jul 2019 10:09:00 +0000
+
 gnome-software (3.32.0-1endless0) UNRELEASED; urgency=medium
 
   * Rebase on GNOME 3.32 (T25367)

--- a/debian/control
+++ b/debian/control
@@ -42,20 +42,15 @@ Homepage: https://wiki.gnome.org/Apps/Software
 Package: gnome-software
 Architecture: any
 Depends: appstream,
-         apt-config-icons,
          gnome-software-common (= ${source:Version}),
          gsettings-desktop-schemas (>= 3.18),
-         libgtk3-perl,
-         software-properties-gtk,
          ${misc:Depends},
          ${shlibs:Depends}
 Replaces: gnome-packagekit-session (<< 3.16.0-2~)
 Breaks: gnome-packagekit-session (<< 3.16.0-2~)
 Conflicts: sessioninstaller
 Recommends: ${plugin:Recommends},
-            fwupd [linux-any]
-Suggests: apt-config-icons-hidpi,
-          gnome-software-plugin-flatpak [amd64 arm64 armel armhf i386 mips mipsel mips64el ppc64el s390x hppa powerpc powerpcspe ppc64],
+Suggests: gnome-software-plugin-flatpak [amd64 arm64 armel armhf i386 mips mipsel mips64el ppc64el s390x hppa powerpc powerpcspe ppc64],
           ${plugin:Suggests}
 Description: Software Center for GNOME
  Software lets you install and update applications and system extensions.

--- a/debian/control.in
+++ b/debian/control.in
@@ -38,20 +38,15 @@ Homepage: https://wiki.gnome.org/Apps/Software
 Package: gnome-software
 Architecture: any
 Depends: appstream,
-         apt-config-icons,
          gnome-software-common (= ${source:Version}),
          gsettings-desktop-schemas (>= 3.18),
-         libgtk3-perl,
-         software-properties-gtk,
          ${misc:Depends},
          ${shlibs:Depends}
 Replaces: gnome-packagekit-session (<< 3.16.0-2~)
 Breaks: gnome-packagekit-session (<< 3.16.0-2~)
 Conflicts: sessioninstaller
 Recommends: ${plugin:Recommends},
-            fwupd [linux-any]
-Suggests: apt-config-icons-hidpi,
-          gnome-software-plugin-flatpak [amd64 arm64 armel armhf i386 mips mipsel mips64el ppc64el s390x hppa powerpc powerpcspe ppc64],
+Suggests: gnome-software-plugin-flatpak [amd64 arm64 armel armhf i386 mips mipsel mips64el ppc64el s390x hppa powerpc powerpcspe ppc64],
           ${plugin:Suggests}
 Description: Software Center for GNOME
  Software lets you install and update applications and system extensions.


### PR DESCRIPTION
  * Drop Debian-specific dependencies (T25367)
    - libgtk3-perl: Needed for debconf
    - software-properties-gtk: Debian-specific apt repository configuration tool
  * Drop fwupd `recommends` line (T25367)
    - We already dropped the build dependency, so keeping the `recommends` is
      just confusing.
  * Drop `apt-config-icons` dependency (T25367)
    - Our apt repositories don’t support it, and the majority of our apps are
      packaged in flatpak.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T25367