### PR TITLE
Misc post-rebase fixes

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -971,7 +971,8 @@ process_proxy_updates (GsPlugin *plugin,
 		/* remove any app matching the updatable one we're about to add as
 		 * this makes sure that we're getting the right app (updatable) in
 		 * the proxy app's related list */
-		gs_app_list_remove (proxied_updates, added_app);
+		if (added_app != NULL)
+			gs_app_list_remove (proxied_updates, added_app);
 
 		/* ensure the app we're about to add really is updatable; this
 		 * is mostly a safeguard, since in this plugin's refine of proxy

--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -177,6 +177,7 @@ gs_flatpak_set_update_permissions (GsFlatpak *self, GsApp *app, FlatpakInstalled
 	g_autoptr(GBytes) bytes = NULL;
 	g_autoptr(GKeyFile) keyfile = NULL;
 	GsAppPermissions permissions;
+	g_autoptr(GError) error_local = NULL;
 
 	old_bytes = flatpak_installed_ref_load_metadata (FLATPAK_INSTALLED_REF (xref), NULL, NULL);
 	old_keyfile = g_key_file_new ();
@@ -189,14 +190,21 @@ gs_flatpak_set_update_permissions (GsFlatpak *self, GsApp *app, FlatpakInstalled
 	                                                         gs_app_get_origin (app),
 	                                                         FLATPAK_REF (xref),
 	                                                         NULL,
-	                                                         NULL);
-	keyfile = g_key_file_new ();
-	g_key_file_load_from_data (keyfile,
-	                           g_bytes_get_data (bytes, NULL),
-	                           g_bytes_get_size (bytes),
-	                           0, NULL);
+	                                                         &error_local);
+	if (bytes == NULL) {
+		g_debug ("Failed to get metadata for remote ‘%s’: %s",
+			 gs_app_get_origin (app), error_local->message);
+		g_clear_error (&error_local);
+		permissions = GS_APP_PERMISSIONS_UNKNOWN;
+	} else {
+		keyfile = g_key_file_new ();
+		g_key_file_load_from_data (keyfile,
+			                   g_bytes_get_data (bytes, NULL),
+			                   g_bytes_get_size (bytes),
+			                   0, NULL);
 
-	permissions = perms_from_metadata (keyfile) & ~perms_from_metadata (old_keyfile);
+		permissions = perms_from_metadata (keyfile) & ~perms_from_metadata (old_keyfile);
+	}
 
 	/* no new permissions set */
 	if (permissions == GS_APP_PERMISSIONS_UNKNOWN)

--- a/plugins/flatpak/gs-plugin-flatpak.c
+++ b/plugins/flatpak/gs-plugin-flatpak.c
@@ -60,6 +60,7 @@ gs_plugin_initialize (GsPlugin *plugin)
 	permission = gs_utils_get_permission (action_id, NULL, &error_local);
 	if (permission == NULL) {
 		g_debug ("no permission for %s: %s", action_id, error_local->message);
+		g_clear_error (&error_local);
 	} else {
 		priv->has_system_helper = g_permission_get_allowed (permission) ||
 					  g_permission_get_can_acquire (permission);
@@ -406,12 +407,13 @@ gs_plugin_flatpak_find_app_by_ref (GsPlugin *plugin, const gchar *ref,
 				   GCancellable *cancellable, GError **error)
 {
 	GsPluginData *priv = gs_plugin_get_data (plugin);
-	g_autoptr(GError) error_local = NULL;
 
 	g_debug ("finding ref %s", ref);
 	for (guint i = 0; i < priv->flatpaks->len; i++) {
 		GsFlatpak *flatpak_tmp = g_ptr_array_index (priv->flatpaks, i);
 		g_autoptr(GsApp) app = NULL;
+		g_autoptr(GError) error_local = NULL;
+
 		app = gs_flatpak_ref_to_app (flatpak_tmp, ref, cancellable, &error_local);
 		if (app == NULL) {
 			g_debug ("%s", error_local->message);

--- a/src/gs-background-tile.c
+++ b/src/gs-background-tile.c
@@ -157,7 +157,7 @@ update_tile_info (GsBackgroundTile *tile)
 	if (gs_app_is_installed (tile->app)) {
 		/* TRANSLATORS: This is the name and state of an app for the ATK object */
 		name = g_strdup_printf (_("%s (Installed)"), gs_app_get_name (tile->app));
-	} else if (gs_app_get_state (tile->app) == AS_APP_STATE_AVAILABLE) {
+	} else {
 		name = g_strdup (gs_app_get_name (tile->app));
 	}
 

--- a/src/gs-updates-section.c
+++ b/src/gs-updates-section.c
@@ -589,7 +589,7 @@ gs_updates_section_class_init (GsUpdatesSectionClass *klass)
 	signals [SIGNAL_APP_STATE_CHANGED] =
 		g_signal_new ("app-state-changed",
 			      G_TYPE_FROM_CLASS (object_class), G_SIGNAL_RUN_LAST,
-			      0, NULL, NULL, g_cclosure_marshal_VOID__VOID,
+			      0, NULL, NULL, NULL,
 			      G_TYPE_NONE, 1, GS_TYPE_APP);
 }
 


### PR DESCRIPTION
Some fixes for various critical warnings I’ve seen while playing around with gnome-software now the rebase has landed.

No associated Phab task.

Includes two commits cherry-picked from upstream:
 * https://gitlab.gnome.org/GNOME/gnome-software/commit/bc855b242ceedebc224a2e44a47512728cbd31cf
 * https://gitlab.gnome.org/GNOME/gnome-software/commit/ad93551b8661429895b448a1e3766c877c2eac4c