### PR TITLE
gs-updates-section: Avoid crash when switching modes

### DIFF
--- a/src/gs-updates-section.c
+++ b/src/gs-updates-section.c
@@ -521,9 +521,6 @@ _list_header_func (GtkListBoxRow *row, GtkListBoxRow *before, gpointer user_data
 
 	/* section changed */
 	if (before == NULL) {
-		GtkWidget *parent;
-		if ((parent = gtk_widget_get_parent (GTK_WIDGET (self->section_header))) != NULL)
-			gtk_container_remove (GTK_CONTAINER (parent), GTK_WIDGET (self->section_header));
 		header = self->section_header;
 	} else {
 		header = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);


### PR DESCRIPTION
When an app is in the middle of its installation phase of doing an
update, and you click its row in the updates page to switch to its
details, then click the ‘back’ button to return from the details page to
the updates page, gnome-software will crash with the following assertion
failure:
```
gtk_widget_realize: assertion 'widget->priv->anchored || GTK_IS_INVISIBLE (widget)' failed
**
Gtk:ERROR:../../../../gtk/gtkwidget.c:12348:gtk_widget_real_map: assertion failed: (_gtk_widget_get_realized (widget))
```

The widget in question is the GsUpdatesSection.section_header, which had
somehow ended up with no parent widget, but still being iterated over in
the realize loop for the GsUpdatesSection.

The code in `_list_header_func()` to remove it from the
`GsUpdatesSection` may have caused this; `gtk_list_box_update_header()`
in GTK already has code to handle removing the old header widget from
its container when updating headers. Removing it manually may confuse
that.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T27333