### PR TITLE
fixup! eos: Add EknServicesMultiplexer as a related app for EKN apps

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -594,9 +594,9 @@ gs_flatpak_get_services_app_if_needed (GsPlugin *plugin,
 
 	/* Construct a GsApp for EknServicesMultiplexer */
 	services_app = gs_app_new (services_id);
-	gs_app_set_kind (app, AS_APP_KIND_DESKTOP);
-	gs_app_set_branch (app, services_branch);
-	gs_app_add_quirk (app, GS_APP_QUIRK_IS_WILDCARD);
+	gs_app_set_kind (services_app, AS_APP_KIND_DESKTOP);
+	gs_app_set_branch (services_app, services_branch);
+	gs_app_add_quirk (services_app, GS_APP_QUIRK_IS_WILDCARD);
 
 	return g_steal_pointer (&services_app);
 }


### PR DESCRIPTION
eos: Set services apps GsApp information correctly

The bug was discovered when testing out the search functionality
for the new gnome-software-3.32. There was something inherently
wrong with searching knowledge apps with queries like:
* com.endlessm.
* health
* animals
* teeth
and so on...

After some digging and looking at the --verbose log, it was found
that the appropriate search results where added to the GsAppList
(in the --verbose log) but could not be seen on the search page.

A few more steps in exploration, it was found that the endlessm
apps specifically where getting refined using gs_plugin_refine_wildcard
while other apps, mainly from flathub and gnome-apps-nightly
where getting refined using gs_plugin_refine during the search.
Hence, next step was to found out where these endlessm apps
were getting marked with GS_APP_QUIRK_IS_WILDCARD kudo.

It was then simply evident from the eos-plugin where, instead of
setting the services_app as wildcard, the base app itself
was marked as wildcard and hence gs_plugin_refine_wildcard was
being fired during every search. Nevertheless, it fixed the
bug in the search and the appropriate search results start
to show up in the search-page.

https://phabricator.endlessm.com/T27491