### PR TITLE
lib/app: Set entire metadata GVariant in gs_app_subsume_metadata

### DIFF
--- a/lib/gs-app.c
+++ b/lib/gs-app.c
@@ -4650,10 +4650,10 @@ gs_app_subsume_metadata (GsApp *app, GsApp *donor)
 	g_autoptr(GList) keys = g_hash_table_get_keys (priv->metadata);
 	for (GList *l = keys; l != NULL; l = l->next) {
 		const gchar *key = l->data;
-		const gchar *value = gs_app_get_metadata_item (donor, key);
-		if (gs_app_get_metadata_item (app, key) != NULL)
+		GVariant *tmp = gs_app_get_metadata_variant (donor, key);
+		if (gs_app_get_metadata_variant (app, key) != NULL)
 			continue;
-		gs_app_set_metadata (app, key, value);
+		gs_app_set_metadata_variant (app, key, tmp);
 	}
 }
 


### PR DESCRIPTION
Set the entire metadata GVariant instead of setting each metadata
component as a string value. The reason is some metadata components
are not GVariant strings (e.g. "flatpak::RefKind"). Subsuming
such a component will throw a critical as:

```
07:02:57:0442 GLib g_variant_get_string:
assertion 'g_variant_is_of_type (value, G_VARIANT_TYPE_STRING) ||
g_variant_is_of_type (value, G_VARIANT_TYPE_OBJECT_PATH) ||
g_variant_is_of_type (value, G_VARIANT_TYPE_SIGNATURE)' failed
```

for gs_app_get_metadata_item.

 (Backported from e0bab44f941cb44f93d5309d7a5e336df46ce07b upstream)
