### PR TITLE
Revert "gs-updates-section: Avoid crash when switching modes"

### DIFF
--- a/src/gs-updates-section.c
+++ b/src/gs-updates-section.c
@@ -521,6 +521,9 @@ _list_header_func (GtkListBoxRow *row, GtkListBoxRow *before, gpointer user_data
 
 	/* section changed */
 	if (before == NULL) {
+		GtkWidget *parent;
+		if ((parent = gtk_widget_get_parent (GTK_WIDGET (self->section_header))) != NULL)
+			gtk_container_remove (GTK_CONTAINER (parent), GTK_WIDGET (self->section_header));
 		header = self->section_header;
 	} else {
 		header = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);


### PR DESCRIPTION
This reverts commit 12e48ce81af4bce099cd09d2b535404d04cfd41c.

It doesn’t solve the bug and crashes still occur — it is obviously not
the right fix, and has not been accepted upstream.

https://phabricator.endlessm.com/T27333