### PR TITLE
eos-blacklist: Allow multiple locales for g-s apps

### DIFF
--- a/plugins/eos-blacklist/meson.build
+++ b/plugins/eos-blacklist/meson.build
@@ -13,6 +13,7 @@ shared_module(
   dependencies : [
     plugin_libs,
     flatpak,
+    gnome_desktop,
   ],
   link_with : [
     libgnomesoftware,


### PR DESCRIPTION
Make eos-blacklist avoid blacklisting apps that ends with a specific
set of locales dictated by the flatpak user's configuration file.

https://phabricator.endlessm.com/T24213

~** Only merge-able after https://github.com/flatpak/flatpak/pull/3058~
~** Only merge-able after the flatpak rebase~
~** Only merge-able after https://github.com/flatpak/flatpak/pull/3152~