### PR TITLE
Revert "Use the global cache when creating popular apps by appstream"

### DIFF
--- a/plugins/core/gs-appstream.c
+++ b/plugins/core/gs-appstream.c
@@ -1253,19 +1253,12 @@ gs_appstream_add_popular (GsPlugin *plugin,
 	}
 	for (guint i = 0; i < array->len; i++) {
 		g_autoptr(GsApp) app = NULL;
-		g_autoptr(GError) local_error = NULL;
 		XbNode *component = g_ptr_array_index (array, i);
 		const gchar *component_id = xb_node_query_text (component, "id", NULL);
 		if (component_id == NULL)
 			continue;
-		app = gs_appstream_create_app (plugin, silo, component, &local_error);
-		if (app == NULL) {
-			g_debug ("Failed to get/create popular app %s: %s; creating as new app",
-				 component_id,
-				 local_error->message);
-			app = gs_app_new (component_id);
-			gs_app_add_quirk (app, GS_APP_QUIRK_IS_WILDCARD);
-		}
+		app = gs_app_new (component_id);
+		gs_app_add_quirk (app, GS_APP_QUIRK_IS_WILDCARD);
 		gs_app_list_add (list, app);
 	}
 	return TRUE;


### PR DESCRIPTION
This reverts commit 7af0a22975b972f5e5b2ee94c219bb62ab0b5ccc.

Drop this patch as it wasn't a systematic fix for the problem.
Also, the upstream has introduced a way to subsume metadata from
the wildcard to a real concrete GsApp [1], and the UI is rendered
with the real app + wildcard's extra-metadata (for e.g. marked popular,
extra categories). Hence, the problem of two objects out-of-sync
for a single app doesn't seem to be a case any longer.

The revert has been tested with gnome-3.32 rebase and there was
no issue of two objects having different app state were observed
during the test.

This patch all the more made hard to mark apps popular via external
appstream (T26507), as the apps created by gs_appstream_add_popular
were not necessarily marked as wildcards. It was only marked as
wildcard only if it wasn't found in the cache. Hence, we revert this
patch, but bring us closer to the upstream gnome-3.32 version
of the function.

[1]: https://gitlab.gnome.org/GNOME/gnome-software/commit/c4c3b62dd0

This patch can be dropped in the next rebase cycle.

https:/phabricator.endlessm.com/T26507