### PR TITLE
Revert "eos: Mark com.endless. app as GS_APP_KUDO_FEATURED_RECOMMENDED"

### DIFF
--- a/plugins/core/gs-appstream.c
+++ b/plugins/core/gs-appstream.c
@@ -906,12 +906,6 @@ gs_appstream_refine_app (GsPlugin *plugin,
 		if (xb_node_query_text (component, "categories/category[text()='featured']", NULL) != NULL)
 			gs_app_add_kudo (app, GS_APP_KUDO_FEATURED_RECOMMENDED);
 
-		/* Mark com.endlessm. apps with featured kudo. See discussion on T23152 */
-		if (!gs_app_has_kudo (app, GS_APP_KUDO_FEATURED_RECOMMENDED) &&
-		    (g_str_has_prefix (gs_app_get_id (app), "com.endlessm.") ||
-		     g_str_has_prefix (gs_app_get_id (app), "com.endlessnetwork.")))
-			gs_app_add_kudo (app, GS_APP_KUDO_FEATURED_RECOMMENDED);
-
 		/* add new-style kudos */
 		kudos = xb_node_query (component, "kudos/kudo", 0, NULL);
 		for (guint i = 0; kudos != NULL && i < kudos->len; i++) {


### PR DESCRIPTION
This reverts commit ed922ffc66ab1e400c415d40934d059bde9a408a.

Popular apps are now marked via external-appstream. We don't need to
hard code to mark Endless-specific apps as popular.

Any app from any remote can be marked as popular now, with the help
of external-appstream(i.e. eos-extra.xml)

See https://github.com/endlessm/gnome-software-data/pull/15/

https://phabricator.endlessm.com/T26507