### PR TITLE
gs-overview-page: Fix the USB category in the sidebar

### DIFF
--- a/src/gs-overview-page.c
+++ b/src/gs-overview-page.c
@@ -573,9 +573,23 @@ get_categories_cb (GObject *source_object,
 		gs_shell_side_filter_clear_categories (priv->shell);
 
 		for (guint i = 0; i < list->len; i++) {
+			gboolean usb_category_inserted = FALSE;
 			cat = GS_CATEGORY (g_ptr_array_index (list, i));
-			if (gs_category_get_size (cat) == 0)
+
+			if (g_strcmp0 (gs_category_get_id (cat), "usb") == 0) {
+				g_autoptr(GPtrArray) copy_dests = gs_plugin_loader_dup_copy_dests (plugin_loader);
+
+				if (copy_dests != NULL && copy_dests->len > 0)
+					usb_category_inserted = TRUE;
+			}
+
+			/* allow empty categories for USB since there are usable
+			 * actions (such as copy OS to USB) in the USB category
+			 * even when it has no apps available
+			 */
+			if (gs_category_get_size (cat) == 0 && !usb_category_inserted)
 				continue;
+
 			has_category = TRUE;
 			gs_shell_side_filter_add_category (priv->shell, cat);
 		}
@@ -593,6 +607,9 @@ get_categories_cb (GObject *source_object,
 		gs_shell_side_filter_set_visible (priv->shell, TRUE);
 
 	priv->loading_categories = FALSE;
+
+	if (list != NULL)
+		g_signal_emit (self, signals[SIGNAL_CATEGORIES_LOADED], 0);
 
 	gs_overview_page_decrement_action_cnt (self);
 }


### PR DESCRIPTION
This was a rebase failure caused by 6e8cd654d2 not deleting the old code
(so changes rebased into that code weren’t noticed as part of the
rebase due to not causing conflicts).

When this is next rebased, commit 6e8cd654d2 should be modified to drop
the unused code, and this commit squashed into subsequent commits.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T26770