### PR TITLE
Backport fixes for T27438 and T27668

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -146,7 +146,8 @@ if get_option('tests')
       gtk,
       json_glib,
       libm,
-      libsoup
+      libsoup,
+      libxmlb,
     ],
     link_with : [
       libgnomesoftware

--- a/plugins/core/gs-plugin-appstream.c
+++ b/plugins/core/gs-plugin-appstream.c
@@ -721,6 +721,7 @@ gs_plugin_refine_from_id (GsPlugin *plugin,
 	xb_string_append_union (xpath, "components/component/id[text()='%s']/../pkgname/..", id);
 	xb_string_append_union (xpath, "components/component[@type='webapp']/id[text()='%s']/..", id);
 	xb_string_append_union (xpath, "component/id[text()='%s']/../pkgname/..", id);
+	xb_string_append_union (xpath, "component/id[text()='%s']/../description/..", id);
 	components = xb_silo_query (priv->silo, xpath->str, 0, &error_local);
 	if (components == NULL) {
 		if (g_error_matches (error_local, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))

--- a/plugins/flatpak/gs-plugin-flatpak.c
+++ b/plugins/flatpak/gs-plugin-flatpak.c
@@ -580,7 +580,7 @@ gs_plugin_download (GsPlugin *plugin, GsAppList *list,
 		if (flatpak != NULL)
 			gs_app_list_add (list_tmp, app);
 	}
-	if (flatpak == NULL)
+	if (gs_app_list_length (list_tmp) == 0)
 		return TRUE;
 
 	if (!gs_plugin_has_flags (plugin, GS_PLUGIN_FLAGS_INTERACTIVE)) {


### PR DESCRIPTION
As discussed from the standup call, we start to backport fixes from upstream merge-requests which are blocked on current maintainer's review. These commits look safe and hence we decided to move forward with it.

* "appstream: Also query the real appdata files during refine …" - [upstream merge request](https://gitlab.gnome.org/GNOME/gnome-software/merge_requests/306)

* "flatpak: Fix logic error check of GsFlatpak in gs_plugin_download …" - Already [merged](https://gitlab.gnome.org/GNOME/gnome-software/commit/3e1fe203b40248f571be2a804027acd8e23dc54e) upstream
