### PR TITLE
Fix NULL pointer dereference in flatpak gs_plugin_download()

### DIFF
--- a/plugins/flatpak/gs-plugin-flatpak.c
+++ b/plugins/flatpak/gs-plugin-flatpak.c
@@ -507,51 +507,55 @@ gboolean
 gs_plugin_download (GsPlugin *plugin, GsAppList *list,
 		    GCancellable *cancellable, GError **error)
 {
-	GsFlatpak *flatpak = NULL;
-	g_autoptr(FlatpakTransaction) transaction = NULL;
-	g_autoptr(GsAppList) list_tmp = gs_app_list_new ();
+	g_autoptr(GHashTable) applist_by_flatpaks = NULL;
+	GHashTableIter iter;
+	gpointer key, value;
 
-	/* not supported */
-	for (guint i = 0; i < gs_app_list_length (list); i++) {
-		GsApp *app = gs_app_list_index (list, i);
-		flatpak = gs_plugin_flatpak_get_handler (plugin, app);
-		if (flatpak != NULL)
-			gs_app_list_add (list_tmp, app);
-	}
-	if (gs_app_list_length (list_tmp) == 0)
-		return TRUE;
+	/* build and run transaction for each flatpak installation */
+	applist_by_flatpaks = _flatpak_group_apps_by_installation (plugin, list);
+	g_hash_table_iter_init (&iter, applist_by_flatpaks);
+	while (g_hash_table_iter_next (&iter, &key, &value)) {
+		GsFlatpak *flatpak = GS_FLATPAK (key);
+		GsAppList *list_tmp = GS_APP_LIST (value);
+		g_autoptr(FlatpakTransaction) transaction = NULL;
 
-	if (!gs_plugin_has_flags (plugin, GS_PLUGIN_FLAGS_INTERACTIVE)) {
-		g_autoptr(GError) error_local = NULL;
+		g_assert (GS_IS_FLATPAK (flatpak));
+		g_assert (list_tmp != NULL);
+		g_assert (gs_app_list_length (list_tmp) > 0);
 
-		if (!gs_metered_block_app_list_on_download_scheduler (list_tmp, cancellable, &error_local)) {
-			g_warning ("Failed to block on download scheduler: %s",
-				   error_local->message);
-			g_clear_error (&error_local);
+		if (!gs_plugin_has_flags (plugin, GS_PLUGIN_FLAGS_INTERACTIVE)) {
+			g_autoptr(GError) error_local = NULL;
+
+			if (!gs_metered_block_app_list_on_download_scheduler (list_tmp, cancellable, &error_local)) {
+				g_warning ("Failed to block on download scheduler: %s",
+					   error_local->message);
+				g_clear_error (&error_local);
+			}
 		}
-	}
 
-	/* build and run non-deployed transaction */
-	transaction = _build_transaction (plugin, flatpak, cancellable, error);
-	if (transaction == NULL) {
-		gs_flatpak_error_convert (error);
-		return FALSE;
-	}
-	flatpak_transaction_set_no_deploy (transaction, TRUE);
-	for (guint i = 0; i < gs_app_list_length (list_tmp); i++) {
-		GsApp *app = gs_app_list_index (list_tmp, i);
-		g_autofree gchar *ref = NULL;
-
-		ref = gs_flatpak_app_get_ref_display (app);
-		if (!flatpak_transaction_add_update (transaction, ref, NULL, NULL, error)) {
+		/* build and run non-deployed transaction */
+		transaction = _build_transaction (plugin, flatpak, cancellable, error);
+		if (transaction == NULL) {
+			gs_flatpak_error_convert (error);
+			return FALSE;
+		}
+		flatpak_transaction_set_no_deploy (transaction, TRUE);
+		for (guint i = 0; i < gs_app_list_length (list_tmp); i++) {
+			GsApp *app = gs_app_list_index (list_tmp, i);
+			g_autofree gchar *ref = NULL;
+	
+			ref = gs_flatpak_app_get_ref_display (app);
+			if (!flatpak_transaction_add_update (transaction, ref, NULL, NULL, error)) {
+				gs_flatpak_error_convert (error);
+				return FALSE;
+			}
+		}
+		if (!gs_flatpak_transaction_run (transaction, cancellable, error)) {
 			gs_flatpak_error_convert (error);
 			return FALSE;
 		}
 	}
-	if (!gs_flatpak_transaction_run (transaction, cancellable, error)) {
-		gs_flatpak_error_convert (error);
-		return FALSE;
-	}
+
 	return TRUE;
 }
 

--- a/plugins/flatpak/gs-plugin-flatpak.c
+++ b/plugins/flatpak/gs-plugin-flatpak.c
@@ -437,6 +437,41 @@ _ref_to_app (FlatpakTransaction *transaction, const gchar *ref, GsPlugin *plugin
 	return gs_plugin_flatpak_find_app_by_ref (plugin, ref, NULL, NULL);
 }
 
+/*
+ * Returns: (transfer full) (element-type GsFlatpak GsAppList):
+ *  a map from GsFlatpak to non-empty lists of apps from @list associated
+ *  with that installation.
+ */
+static GHashTable *
+_flatpak_group_apps_by_installation (GsPlugin *plugin,
+                                              GsAppList *list)
+{
+	g_autoptr(GHashTable) applist_by_flatpaks = NULL;
+
+	/* list of apps to be handled by each flatpak installation */
+	applist_by_flatpaks = g_hash_table_new_full (g_direct_hash, g_direct_equal,
+						     (GDestroyNotify) g_object_unref,
+						     (GDestroyNotify) g_object_unref);
+
+	/* put each app into the correct per-GsFlatpak list */
+	for (guint i = 0; i < gs_app_list_length (list); i++) {
+		GsApp *app = gs_app_list_index (list, i);
+		GsFlatpak *flatpak = gs_plugin_flatpak_get_handler (plugin, app);
+		if (flatpak != NULL) {
+			GsAppList *list_tmp = g_hash_table_lookup (applist_by_flatpaks, flatpak);
+			if (list_tmp == NULL) {
+				list_tmp = gs_app_list_new ();
+				g_hash_table_insert (applist_by_flatpaks,
+						     g_object_ref (flatpak),
+						     list_tmp);
+			}
+			gs_app_list_add (list_tmp, app);
+		}
+	}
+
+	return g_steal_pointer (&applist_by_flatpaks);
+}
+
 static FlatpakTransaction *
 _build_transaction (GsPlugin *plugin, GsFlatpak *flatpak,
 		    GCancellable *cancellable, GError **error)
@@ -815,34 +850,21 @@ gs_plugin_update (GsPlugin *plugin,
                   GCancellable *cancellable,
                   GError **error)
 {
-	GsPluginData *priv = gs_plugin_get_data (plugin);
 	g_autoptr(GHashTable) applist_by_flatpaks = NULL;
-
-	/* list of apps to be handled by each flatpak installation */
-	applist_by_flatpaks = g_hash_table_new_full (g_direct_hash, g_direct_equal,
-						     NULL, (GDestroyNotify) g_object_unref);
-	for (guint i = 0; i < priv->flatpaks->len; i++) {
-		g_hash_table_insert (applist_by_flatpaks,
-				     g_ptr_array_index (priv->flatpaks, i),
-				     gs_app_list_new ());
-	}
-
-	/* put each app into the correct per-GsFlatpak list */
-	for (guint i = 0; i < gs_app_list_length (list); i++) {
-		GsApp *app = gs_app_list_index (list, i);
-		GsFlatpak *flatpak = gs_plugin_flatpak_get_handler (plugin, app);
-		if (flatpak != NULL) {
-			GsAppList *list_tmp = g_hash_table_lookup (applist_by_flatpaks, flatpak);
-			gs_app_list_add (list_tmp, app);
-		}
-	}
+	GHashTableIter iter;
+	gpointer key, value;
 
 	/* build and run transaction for each flatpak installation */
-	for (guint j = 0; j < priv->flatpaks->len; j++) {
-		GsFlatpak *flatpak = g_ptr_array_index (priv->flatpaks, j);
-		GsAppList *list_tmp = GS_APP_LIST (g_hash_table_lookup (applist_by_flatpaks, flatpak));
-		if (gs_app_list_length (list_tmp) == 0)
-			continue;
+	applist_by_flatpaks = _flatpak_group_apps_by_installation (plugin, list);
+	g_hash_table_iter_init (&iter, applist_by_flatpaks);
+	while (g_hash_table_iter_next (&iter, &key, &value)) {
+		GsFlatpak *flatpak = GS_FLATPAK (key);
+		GsAppList *list_tmp = GS_APP_LIST (value);
+
+		g_assert (GS_IS_FLATPAK (flatpak));
+		g_assert (list_tmp != NULL);
+		g_assert (gs_app_list_length (list_tmp) > 0);
+
 		if (!gs_plugin_flatpak_update (plugin, flatpak, list_tmp, cancellable, error))
 			return FALSE;
 	}

--- a/plugins/flatpak/gs-plugin-flatpak.c
+++ b/plugins/flatpak/gs-plugin-flatpak.c
@@ -503,10 +503,107 @@ _build_transaction (GsPlugin *plugin, GsFlatpak *flatpak,
 	return g_steal_pointer (&transaction);
 }
 
+static gboolean
+get_installation_dir_free_space (GsFlatpak *flatpak, guint64 *free_space, GError **error)
+{
+	FlatpakInstallation *installation;
+	g_autoptr (GFile) installation_dir = NULL;
+	g_autoptr (GFileInfo) info = NULL;
+
+	installation = gs_flatpak_get_installation (flatpak);
+	installation_dir = flatpak_installation_get_path (installation);
+
+	info = g_file_query_filesystem_info (installation_dir,
+					     G_FILE_ATTRIBUTE_FILESYSTEM_FREE,
+					     NULL,
+					     error);
+	if (info == NULL)
+		return FALSE;
+
+	*free_space = g_file_info_get_attribute_uint64 (info, G_FILE_ATTRIBUTE_FILESYSTEM_FREE);
+	return TRUE;
+}
+
+static gboolean
+gs_flatpak_has_space_to_install (GsFlatpak *flatpak, GsApp *app)
+{
+	g_autoptr(GError) error = NULL;
+	guint64 free_space = 0;
+	guint64 min_free_space = 0;
+	guint64 space_required = 0;
+	FlatpakInstallation *installation;
+
+	space_required = gs_app_get_size_download (app);
+	if (space_required == GS_APP_SIZE_UNKNOWABLE) {
+		g_warning ("Failed to query download size: %s", gs_app_get_unique_id (app));
+		space_required = 0;
+	}
+
+	installation = gs_flatpak_get_installation (flatpak);
+
+	if (!flatpak_installation_get_min_free_space_bytes (installation, &min_free_space, &error)) {
+		g_autoptr(GFile) installation_file = flatpak_installation_get_path (installation);
+		g_autofree gchar *path = g_file_get_path (installation_file);
+		g_warning ("Error getting min-free-space config value of OSTree repo at %s:%s", path, error->message);
+		g_clear_error (&error);
+	}
+	space_required = space_required + min_free_space;
+
+	if (!get_installation_dir_free_space (flatpak, &free_space, &error)) {
+		g_warning ("Error getting the free space available for installing %s: %s",
+			   gs_app_get_unique_id (app), error->message);
+		g_clear_error (&error);
+		/* Even if we fail to get free space, we don't want to block this user-intiated
+		 * install action. It might happen that there is enough space to install but
+		 * an error happened during querying the filesystem info. */
+		return TRUE;
+	}
+
+	return free_space >= space_required;
+}
+
+static gboolean
+gs_flatpak_has_space_to_update (GsFlatpak *flatpak, GsAppList *list, gboolean is_auto_update)
+{
+	g_autoptr(GError) error = NULL;
+	guint64 free_space = 0;
+	guint64 min_free_space = 0;
+	guint64 space_required = 0;
+	FlatpakInstallation *installation;
+
+	if (is_auto_update) {
+		for (guint i = 0; i < gs_app_list_length (list); i++) {
+			GsApp *app_temp = gs_app_list_index (list, i);
+			space_required += gs_app_get_size_installed (app_temp);
+		}
+	}
+
+	installation = gs_flatpak_get_installation (flatpak);
+
+	if (!flatpak_installation_get_min_free_space_bytes (installation, &min_free_space, &error)) {
+		g_autoptr(GFile) installation_file = flatpak_installation_get_path (installation);
+		g_autofree gchar *path = g_file_get_path (installation_file);
+		g_warning ("Error getting min-free-space config value of OSTree repo at %s:%s", path, error->message);
+		g_clear_error (&error);
+	}
+	space_required = space_required + min_free_space;
+	if (!get_installation_dir_free_space (flatpak, &free_space, &error)) {
+		g_warning ("Error getting the free space available for updating an app list: %s",
+			   error->message);
+		g_clear_error (&error);
+		/* Only fail autoupdates if we cannot query the filesystem info.
+		 * Manual updates follow the pattern similar to install's case. */
+		return is_auto_update ? FALSE : TRUE;
+	}
+
+	return free_space >= space_required;
+}
+
 gboolean
 gs_plugin_download (GsPlugin *plugin, GsAppList *list,
 		    GCancellable *cancellable, GError **error)
 {
+	gboolean is_auto_update = !gs_plugin_has_flags (plugin, GS_PLUGIN_FLAGS_INTERACTIVE);
 	g_autoptr(GHashTable) applist_by_flatpaks = NULL;
 	GHashTableIter iter;
 	gpointer key, value;
@@ -531,6 +628,27 @@ gs_plugin_download (GsPlugin *plugin, GsAppList *list,
 					   error_local->message);
 				g_clear_error (&error_local);
 			}
+		}
+
+		/* Is there enough disk space to download updates in this
+		 * installation?
+		 */
+		if (!gs_flatpak_has_space_to_update (flatpak, list_tmp, is_auto_update)) {
+			g_debug ("Skipping %s for %s: not enough space on disk",
+				 (is_auto_update ? "automatic update" : "update"),
+				 gs_flatpak_get_id (flatpak));
+			if (is_auto_update) {
+				/* If we're performing automatic updates in the
+				 * background, don't return an error: we don't
+				 * want an error banner showing up out of the
+				 * blue. Continue to the next installation (if
+				 * any).
+				 */
+				continue;
+			}
+			g_set_error (error, GS_PLUGIN_ERROR, GS_PLUGIN_ERROR_NO_SPACE,
+				     _("You don’t have enough space to update these apps. Please remove apps or documents to create more space."));
+			return FALSE;
 		}
 
 		/* build and run non-deployed transaction */
@@ -684,6 +802,17 @@ gs_plugin_app_install (GsPlugin *plugin,
 		return FALSE;
 	}
 
+	/* Is there enough disk space free to install? */
+	if (!gs_flatpak_has_space_to_install (flatpak, app)) {
+		g_debug ("Skipping installation for %s: not enough space on disk",
+			 gs_app_get_unique_id (app));
+		gs_app_set_state_recover (app);
+		g_set_error (error, GS_PLUGIN_ERROR, GS_PLUGIN_ERROR_NO_SPACE,
+			     _("You don’t have enough space to install %s. Please remove apps or documents to create more space."),
+			     gs_app_get_unique_id (app));
+		return FALSE;
+	}
+
 	/* add to the transaction cache for quick look up -- other unrelated
 	 * refs will be matched using gs_plugin_flatpak_find_app_by_ref() */
 	gs_flatpak_transaction_add_app (transaction, app);
@@ -793,6 +922,28 @@ gs_plugin_flatpak_update (GsPlugin *plugin,
 			  GError **error)
 {
 	g_autoptr(FlatpakTransaction) transaction = NULL;
+	gboolean is_auto_update;
+
+	/* Is there enough disk space to download updates in this
+	 * installation?
+	 */
+	is_auto_update = !gs_plugin_has_flags (plugin, GS_PLUGIN_FLAGS_INTERACTIVE);
+	if (!gs_flatpak_has_space_to_update (flatpak, list_tmp, is_auto_update)) {
+		g_debug ("Skipping %s for %s: not enough space on disk",
+			 (is_auto_update ? "automatic update" : "update"),
+			 gs_flatpak_get_id (flatpak));
+		if (is_auto_update) {
+			/* If we're performing automatic updates in the
+			 * background, don't return an error: we don't want an
+			 * error banner showing up out of the blue. Continue to
+			 * the next installation (if any).
+			 */
+			return TRUE;
+		}
+		g_set_error (error, GS_PLUGIN_ERROR, GS_PLUGIN_ERROR_NO_SPACE,
+			     _("You don’t have enough space to update these apps. Please remove apps or documents to create more space."));
+		return FALSE;
+	}
 
 	/* build and run transaction */
 	transaction = _build_transaction (plugin, flatpak, cancellable, error);

--- a/plugins/flatpak/gs-plugin-flatpak.c
+++ b/plugins/flatpak/gs-plugin-flatpak.c
@@ -468,102 +468,6 @@ _build_transaction (GsPlugin *plugin, GsFlatpak *flatpak,
 	return g_steal_pointer (&transaction);
 }
 
-static gboolean
-get_installation_dir_free_space (GsFlatpak *flatpak, guint64 *free_space, GError **error)
-{
-	FlatpakInstallation *installation;
-	g_autoptr (GFile) installation_dir = NULL;
-	g_autoptr (GFileInfo) info = NULL;
-
-	installation = gs_flatpak_get_installation (flatpak);
-	installation_dir = flatpak_installation_get_path (installation);
-
-	info = g_file_query_filesystem_info (installation_dir,
-					     G_FILE_ATTRIBUTE_FILESYSTEM_FREE,
-					     NULL,
-					     error);
-	if (info == NULL)
-		return FALSE;
-
-	*free_space = g_file_info_get_attribute_uint64 (info, G_FILE_ATTRIBUTE_FILESYSTEM_FREE);
-	return TRUE;
-}
-
-static gboolean
-gs_flatpak_has_space_to_install (GsFlatpak *flatpak, GsApp *app)
-{
-	g_autoptr(GError) error = NULL;
-	guint64 free_space = 0;
-	guint64 min_free_space = 0;
-	guint64 space_required = 0;
-	FlatpakInstallation *installation;
-
-	space_required = gs_app_get_size_download (app);
-	if (space_required == GS_APP_SIZE_UNKNOWABLE) {
-		g_warning ("Failed to query download size: %s", gs_app_get_unique_id (app));
-		space_required = 0;
-	}
-
-	installation = gs_flatpak_get_installation (flatpak);
-
-	if (!flatpak_installation_get_min_free_space_bytes (installation, &min_free_space, &error)) {
-		g_autoptr(GFile) installation_file = flatpak_installation_get_path (installation);
-		g_autofree gchar *path = g_file_get_path (installation_file);
-		g_warning ("Error getting min-free-space config value of OSTree repo at %s:%s", path, error->message);
-		g_clear_error (&error);
-	}
-	space_required = space_required + min_free_space;
-
-	if (!get_installation_dir_free_space (flatpak, &free_space, &error)) {
-		g_warning ("Error getting the free space available for installing %s: %s",
-			   gs_app_get_unique_id (app), error->message);
-		g_clear_error (&error);
-		/* Even if we fail to get free space, we don't want to block this user-intiated
-		 * install action. It might happen that there is enough space to install but
-		 * an error happened during querying the filesystem info. */
-		return TRUE;
-	}
-
-	return free_space >= space_required;
-}
-
-static gboolean
-gs_flatpak_has_space_to_update (GsFlatpak *flatpak, GsAppList *list, gboolean is_auto_update)
-{
-	g_autoptr(GError) error = NULL;
-	guint64 free_space = 0;
-	guint64 min_free_space = 0;
-	guint64 space_required = 0;
-	FlatpakInstallation *installation;
-
-	if (is_auto_update) {
-		for (guint i = 0; i < gs_app_list_length (list); i++) {
-			GsApp *app_temp = gs_app_list_index (list, i);
-			space_required += gs_app_get_size_installed (app_temp);
-		}
-	}
-
-	installation = gs_flatpak_get_installation (flatpak);
-
-	if (!flatpak_installation_get_min_free_space_bytes (installation, &min_free_space, &error)) {
-		g_autoptr(GFile) installation_file = flatpak_installation_get_path (installation);
-		g_autofree gchar *path = g_file_get_path (installation_file);
-		g_warning ("Error getting min-free-space config value of OSTree repo at %s:%s", path, error->message);
-		g_clear_error (&error);
-	}
-	space_required = space_required + min_free_space;
-	if (!get_installation_dir_free_space (flatpak, &free_space, &error)) {
-		g_warning ("Error getting the free space available for updating an app list: %s",
-			   error->message);
-		g_clear_error (&error);
-		/* Only fail autoupdates if we cannot query the filesystem info.
-		 * Manual updates follow the pattern similar to install's case. */
-		return is_auto_update ? FALSE : TRUE;
-	}
-
-	return free_space >= space_required;
-}
-
 gboolean
 gs_plugin_download (GsPlugin *plugin, GsAppList *list,
 		    GCancellable *cancellable, GError **error)
@@ -571,7 +475,6 @@ gs_plugin_download (GsPlugin *plugin, GsAppList *list,
 	GsFlatpak *flatpak = NULL;
 	g_autoptr(FlatpakTransaction) transaction = NULL;
 	g_autoptr(GsAppList) list_tmp = gs_app_list_new ();
-	gboolean is_auto_update;
 
 	/* not supported */
 	for (guint i = 0; i < gs_app_list_length (list); i++) {
@@ -591,21 +494,6 @@ gs_plugin_download (GsPlugin *plugin, GsAppList *list,
 				   error_local->message);
 			g_clear_error (&error_local);
 		}
-	}
-
-	/* Is there enough disk space to download? */
-	is_auto_update = !gs_plugin_has_flags (plugin, GS_PLUGIN_FLAGS_INTERACTIVE);
-	if (!gs_flatpak_has_space_to_update (flatpak, list_tmp, is_auto_update)) {
-		g_debug ("Skipping %s: not enough space on disk",
-			 (is_auto_update ? "automatic update" : "update"));
-		if (is_auto_update) {
-			/* Do not return an error because we don't want to see a banner
-			 * showing up out of the blue for possibly multiple update failures */
-			return TRUE;
-		}
-		g_set_error (error, GS_PLUGIN_ERROR, GS_PLUGIN_ERROR_NO_SPACE,
-			     _("You don’t have enough space to update these apps. Please remove apps or documents to create more space."));
-		return FALSE;
 	}
 
 	/* build and run non-deployed transaction */
@@ -757,17 +645,6 @@ gs_plugin_app_install (GsPlugin *plugin,
 		return FALSE;
 	}
 
-	/* Is there enough disk space free to install? */
-	if (!gs_flatpak_has_space_to_install (flatpak, app)) {
-		g_debug ("Skipping installation for %s: not enough space on disk",
-			 gs_app_get_unique_id (app));
-		gs_app_set_state_recover (app);
-		g_set_error (error, GS_PLUGIN_ERROR, GS_PLUGIN_ERROR_NO_SPACE,
-			     _("You don’t have enough space to install %s. Please remove apps or documents to create more space."),
-			     gs_app_get_unique_id (app));
-		return FALSE;
-	}
-
 	/* add to the transaction cache for quick look up -- other unrelated
 	 * refs will be matched using gs_plugin_flatpak_find_app_by_ref() */
 	gs_flatpak_transaction_add_app (transaction, app);
@@ -877,22 +754,6 @@ gs_plugin_flatpak_update (GsPlugin *plugin,
 			  GError **error)
 {
 	g_autoptr(FlatpakTransaction) transaction = NULL;
-	gboolean is_auto_update;
-
-	/* Is there enough disk space to download? */
-	is_auto_update = !gs_plugin_has_flags (plugin, GS_PLUGIN_FLAGS_INTERACTIVE);
-	if (!gs_flatpak_has_space_to_update (flatpak, list_tmp, is_auto_update)) {
-		g_debug ("Skipping %s: not enough space on disk",
-			 (is_auto_update ? "automatic update" : "update"));
-		if (is_auto_update) {
-			/* Do not return an error because we don't want to see a banner
-			 * showing up out of the blue for possibly multiple update failures */
-			return TRUE;
-		}
-		g_set_error (error, GS_PLUGIN_ERROR, GS_PLUGIN_ERROR_NO_SPACE,
-			     _("You don’t have enough space to update these apps. Please remove apps or documents to create more space."));
-		return FALSE;
-	}
 
 	/* build and run transaction */
 	transaction = _build_transaction (plugin, flatpak, cancellable, error);


### PR DESCRIPTION
Unfortunately 68110bf345e38b69f7b4ddf09990be3b53074766 meant that an incorrect early return was replaced by a `NULL` pointer dereference since later in the function, `flatpak` is assumed to be non-`NULL`. This manifested itself in gnome-software segfaulting in the cases where it would previously have silently failed to install any Flatpaks:

```
(gdb) bt 
#0  gs_flatpak_get_installation (self=self@entry=0x0) at ../plugins/flatpak/gs-flatpak.c:3521
#1  0x00007fffdf23d49f in gs_flatpak_has_space_to_update (flatpak=flatpak@entry=0x0, list=list@entry=0x555557120180, 
    is_auto_update=is_auto_update@entry=1) at ../plugins/flatpak/gs-plugin-flatpak.c:546
#2  0x00007fffdf23e306 in gs_plugin_download (plugin=plugin@entry=0x55555592bb20, list=list@entry=0x7fffcc093980, 
    cancellable=cancellable@entry=0x5555570d7720, error=error@entry=0x7fffcae7c9d8) at ../plugins/flatpak/gs-plugin-flatpak.c:598
[…]
(gdb) frame 0
#0  gs_flatpak_get_installation (self=self@entry=0x0) at ../plugins/flatpak/gs-flatpak.c:3521
3521		return self->installation;
(gdb) p self
$11 = (GsFlatpak *) 0x0
(gdb) frame 2
#2  0x00007fffdf23e306 in gs_plugin_download (plugin=plugin@entry=0x55555592bb20, list=list@entry=0x7fffcc093980, 
    cancellable=cancellable@entry=0x5555570d7720, error=error@entry=0x7fffcae7c9d8) at ../plugins/flatpak/gs-plugin-flatpak.c:598
598		if (!gs_flatpak_has_space_to_update (flatpak, list_tmp, is_auto_update)) {
(gdb) p gs_app_get_id (gs_app_list_index (list, gs_app_list_length (list) - 1))
$12 = (const gchar *) 0x7fffcc004c50 "com.endlessm.proxy.EOSUpdatesProxy"
```

Fix this by grouping the elements of the `GsAppList` by the `GsFlatpak` (if any) that they apply to, and processing each group as a separate batch. This is the same fix applied to `gs_plugin_update` by 12c3f6464c9e9ecd0111b35facf931fc28ad91a9.

We have a downstream patch to this function which conflicted with this change, so in this branch I have reverted it, applied the two patches that I submitted upstream, and then un-reverted it, fixing the conflicts. Assuming the upstream patches are accepted in this form, this means that the next rebase can simply drop the old patch + revert old patch pair, and apply the refreshed downstream patch (if it is still needed).

TODO:

- [x] Ensure that `gs_plugin_update` still works after this refactoring. 30 queued updates are currently downloading on my system; I guess we'll see once they're done.

https://gitlab.gnome.org/GNOME/gnome-software/merge_requests/318
https://phabricator.endlessm.com/T27438