### PR TITLE
Backport patches for T27779

### DIFF
--- a/lib/gs-self-test.c
+++ b/lib/gs-self-test.c
@@ -11,7 +11,6 @@
 #include "gnome-software-private.h"
 
 #include "gs-test.h"
-#include <xmlb.h>
 
 static gboolean
 gs_app_list_filter_cb (GsApp *app, gpointer user_data)
@@ -706,90 +705,6 @@ gs_app_list_wildcard_dedupe_func (void)
 	g_assert_cmpint (gs_app_list_length (list), ==, 1);
 }
 
-/* Tests if an app's appdata, not present in appstream, still makes it to the xmlb silo.
- * This confirms that the standalone appdata will be eventually converted to be an GsApp. */
-static void
-gs_app_is_actual_app_func (void)
-{
-	g_autoptr(XbBuilder) builder = xb_builder_new ();
-	g_autoptr(XbBuilderSource) source1 = xb_builder_source_new ();
-	g_autoptr(XbBuilderSource) source2 = xb_builder_source_new ();
-	g_autoptr(GString) xpath = g_string_new (NULL);
-	g_autoptr(GPtrArray) components = NULL;
-	g_autoptr(XbSilo) silo = NULL;
-	g_autoptr(GFileIOStream) iostream = NULL;
-	const gchar *appdata;
-	const gchar *appstream;
-	g_autoptr(GFile) xmlb = NULL;
-	g_autoptr(GError) error = NULL;
-	const gchar *tmp;
-
-	appdata = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-		  "<component type=\"desktop\">\n"
-		  "<id>appA.desktop</id>\n"
-		  "<metadata_license>CC0-1.0</metadata_license>\n"
-		  "<project_license>GPL-2.0+</project_license>\n"
-		  "<name>app A</name>\n"
-		  "<summary>app A summary</summary>\n"
-		  "<description>app A description</description>\n"
-		  "</component>\n";
-
-	appstream = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-		    "<components version=\"0.8\" origin=\"org\">\n"
-		    "<component type=\"desktop\">\n"
-		    "<id>appB.desktop</id>\n"
-		    "<metadata_license>CC0-1.0</metadata_license>\n"
-		    "<project_license>GPL-2.0+</project_license>\n"
-		    "<name>app B</name>\n"
-		    "<summary>app B summary</summary>\n"
-		    "<description>app B description</description>\n"
-		    "</component>\n"
-		    "<component type=\"desktop\">\n"
-		    "<id>appC.desktop</id>\n"
-		    "<metadata_license>CC0-1.0</metadata_license>\n"
-		    "<project_license>GPL-2.0+</project_license>\n"
-		    "<name>app C</name>\n"
-		    "<summary>app C summary</summary>\n"
-		    "<description>app C description</description>\n"
-		    "</component>\n"
-		    "</components>\n";
-
-	xb_builder_source_load_xml (source1, appstream, XB_BUILDER_SOURCE_FLAG_NONE, &error);
-	g_assert_no_error (error);
-	xb_builder_import_source (builder, source1);
-
-	xb_builder_source_load_xml (source2, appdata, XB_BUILDER_SOURCE_FLAG_NONE, &error);
-	g_assert_no_error (error);
-	xb_builder_import_source (builder, source2);
-
-        xmlb = g_file_new_tmp ("temp-XXXXXX.xmlb", &iostream, &error);
-        g_assert_no_error (error);
-        g_assert_nonnull (xmlb);
-        silo = xb_builder_ensure (builder, xmlb,
-                                  XB_BUILDER_COMPILE_FLAG_WATCH_BLOB,
-                                  NULL, &error);
-	g_assert_no_error (error);
-	g_assert_nonnull (silo);
-
-	xb_string_append_union (xpath, "components/component/id/..");
-	xb_string_append_union (xpath, "component/description/..");
-	components = xb_silo_query (silo, xpath->str, 0, &error);
-	g_assert_no_error (error);
-
-	g_assert_cmpint (components->len, ==, 3);
-
-        for (guint i = 0; i < components->len; i++) {
-		XbNode *component = g_ptr_array_index (components, i);
-		tmp = xb_node_query_text (component, "id", NULL);
-		g_assert_true (g_strcmp0 (tmp, "appA.desktop") == 0 ||
-			       g_strcmp0 (tmp, "appB.desktop") == 0 ||
-			       g_strcmp0 (tmp, "appC.desktop") == 0);
-        }
-
-
-
-}
-
 static void
 gs_app_list_func (void)
 {
@@ -888,7 +803,6 @@ main (int argc, char **argv)
 	g_test_add_func ("/gnome-software/lib/app{list-wildcard-dedupe}", gs_app_list_wildcard_dedupe_func);
 	g_test_add_func ("/gnome-software/lib/app{list-performance}", gs_app_list_performance_func);
 	g_test_add_func ("/gnome-software/lib/app{list-related}", gs_app_list_related_func);
-	g_test_add_func ("/gnome-software/lib/app{actual-app}", gs_app_is_actual_app_func);
 	g_test_add_func ("/gnome-software/lib/plugin", gs_plugin_func);
 	g_test_add_func ("/gnome-software/lib/plugin{download-rewrite}", gs_plugin_download_rewrite_func);
 

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -146,8 +146,7 @@ if get_option('tests')
       gtk,
       json_glib,
       libm,
-      libsoup,
-      libxmlb,
+      libsoup
     ],
     link_with : [
       libgnomesoftware

--- a/plugins/core/gs-plugin-appstream.c
+++ b/plugins/core/gs-plugin-appstream.c
@@ -94,17 +94,6 @@ gs_plugin_appstream_upgrade_cb (XbBuilderFixup *self,
 }
 
 static gboolean
-gs_plugin_appstream_add_pkgname_cb (XbBuilderFixup *self,
-				    XbBuilderNode *bn,
-				    gpointer user_data,
-				    GError **error)
-{
-	if (g_strcmp0 (xb_builder_node_get_element (bn), "component") == 0)
-		xb_builder_node_insert_text (bn, "pkgname", "", NULL);
-	return TRUE;
-}
-
-static gboolean
 gs_plugin_appstream_add_icons_cb (XbBuilderFixup *self,
 				  XbBuilderNode *bn,
 				  gpointer user_data,
@@ -248,13 +237,6 @@ gs_plugin_appstream_load_desktop_fn (GsPlugin *plugin,
 	/* add support for desktop files */
 	xb_builder_source_add_adapter (source, "application/x-desktop",
 				       gs_plugin_appstream_load_desktop_cb, NULL, NULL);
-
-	/* add a dummy package name */
-	fixup = xb_builder_fixup_new ("AddDesktopPackageName",
-				      gs_plugin_appstream_add_pkgname_cb,
-				      plugin, NULL);
-	xb_builder_fixup_set_max_depth (fixup, 2);
-	xb_builder_source_add_fixup (source, fixup);
 
 	/* add source */
 	if (!xb_builder_source_load_file (source, file,
@@ -720,7 +702,7 @@ gs_plugin_refine_from_id (GsPlugin *plugin,
 	/* look in AppStream then fall back to AppData */
 	xb_string_append_union (xpath, "components/component/id[text()='%s']/../pkgname/..", id);
 	xb_string_append_union (xpath, "components/component[@type='webapp']/id[text()='%s']/..", id);
-	xb_string_append_union (xpath, "component/id[text()='%s']/../pkgname/..", id);
+	xb_string_append_union (xpath, "component/id[text()='%s']/..", id);
 	components = xb_silo_query (priv->silo, xpath->str, 0, &error_local);
 	if (components == NULL) {
 		if (g_error_matches (error_local, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))

--- a/plugins/core/gs-plugin-appstream.c
+++ b/plugins/core/gs-plugin-appstream.c
@@ -721,7 +721,6 @@ gs_plugin_refine_from_id (GsPlugin *plugin,
 	xb_string_append_union (xpath, "components/component/id[text()='%s']/../pkgname/..", id);
 	xb_string_append_union (xpath, "components/component[@type='webapp']/id[text()='%s']/..", id);
 	xb_string_append_union (xpath, "component/id[text()='%s']/../pkgname/..", id);
-	xb_string_append_union (xpath, "component/id[text()='%s']/../description/..", id);
 	components = xb_silo_query (priv->silo, xpath->str, 0, &error_local);
 	if (components == NULL) {
 		if (g_error_matches (error_local, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))

--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -151,7 +151,7 @@ perms_from_metadata (GKeyFile *keyfile)
 		permissions |= GS_APP_PERMISSIONS_FILESYSTEM_FULL;
 	else if (strv != NULL && g_strv_contains ((const gchar * const *)strv, "host:ro"))
 		permissions |= GS_APP_PERMISSIONS_FILESYSTEM_READ;
-	if (strv != NULL && (g_strv_contains ((const gchar * const *)strv, "xdg-dowwnload") ||
+	if (strv != NULL && (g_strv_contains ((const gchar * const *)strv, "xdg-download") ||
 	                     g_strv_contains ((const gchar * const *)strv, "xdg-download:rw")))
 		permissions |= GS_APP_PERMISSIONS_DOWNLOADS_FULL;
 	else if (strv != NULL && g_strv_contains ((const gchar * const *)strv, "xdg-download:ro"))


### PR DESCRIPTION
This PR basically backports the patches for T27779. The earlier commit 
6aaada0 can also be reverted as it was not accepted [upstream](https://gitlab.gnome.org/GNOME/gnome-software/merge_requests/306) and was superseded by this [merge request](https://gitlab.gnome.org/GNOME/gnome-software/merge_requests/320) (which we are backporting).

Also included a simple typo fix in the backport. 

https://phabricator.endlessm.com/T27779