### PR TITLE
shell: Ignore G_IO_ERROR_CANCELLED errors

### DIFF
--- a/src/gs-shell.c
+++ b/src/gs-shell.c
@@ -1848,7 +1848,10 @@ gs_shell_rescan_events (GsShell *shell)
 			if (error != NULL &&
 			    !g_error_matches (error,
 					      GS_PLUGIN_ERROR,
-					      GS_PLUGIN_ERROR_CANCELLED)) {
+					      GS_PLUGIN_ERROR_CANCELLED) &&
+			    !g_error_matches (error,
+					      G_IO_ERROR,
+					      G_IO_ERROR_CANCELLED)) {
 				g_warning ("not handling error %s for action %s: %s",
 					   gs_plugin_error_to_string (error->code),
 					   gs_plugin_action_to_string (action),


### PR DESCRIPTION
Just as we ignore `GS_PLUGIN_ERROR_CANCELLED` errors, ignore
`G_IO_ERROR_CANCELLED` errors.

Realistically, we are never going to manage to find every call site
which could return `G_IO_ERROR_CANCELLED` and convert all of those
errors to `GS_PLUGIN_ERROR_CANCELLED` on an ongoing basis.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

---

This is a trivial cherry-pick from [an upstream MR](https://gitlab.gnome.org/GNOME/gnome-software/merge_requests/322) I submitted today to squash some console warnings. It’s not associated with a particular Phabricator task, but there have been related tasks about squashing ‘cancelled’ warnings in the past.