### PR TITLE
Fix USB category (again)

### DIFF
--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -485,6 +485,10 @@ gs_flatpak_mark_apps_from_usb_remote (GsFlatpak *self,
 			continue;
 		}
 
+		/* Don't show runtimes, locale extensions, etc. */
+		if (gs_app_get_kind (app) != AS_APP_KIND_DESKTOP)
+			continue;
+
 		gs_app_add_category (app, "usb");
 
 		/* add a keyword so users can search for "usb" */

--- a/src/gs-category-page.c
+++ b/src/gs-category-page.c
@@ -238,6 +238,11 @@ gs_category_page_get_apps_cb (GObject *source_object,
 	/* ensure the filter will show the apps, not the placeholders */
 	self->num_placeholders_to_show = -1;
 	gtk_flow_box_invalidate_filter (GTK_FLOW_BOX (self->category_detail_box));
+
+	if (g_strcmp0 (gs_category_get_id (self->category), "usb") == 0) {
+		gtk_widget_set_visible (self->no_apps_box, gs_category_get_size (self->subcategory) == 0);
+		gtk_widget_set_visible (self->scrolledwindow_category, gs_category_get_size (self->subcategory) != 0);
+	}
 }
 
 static gboolean

--- a/src/gs-shell.c
+++ b/src/gs-shell.c
@@ -609,6 +609,11 @@ on_overview_categories_loaded (GsOverviewPage *page, gpointer user_data)
 					      user_data);
 	if (!gs_overview_page_set_category (page, data->category_id))
 		gs_shell_change_mode (data->shell, GS_SHELL_MODE_OVERVIEW, NULL, TRUE);
+	else {
+		GsShellPrivate *priv = gs_shell_get_instance_private (data->shell);
+		GsPage *usb_category_page = GS_PAGE (g_hash_table_lookup (priv->pages, "category"));
+		gs_page_reload (usb_category_page);
+	}
 }
 
 static void


### PR DESCRIPTION
This makes apps show up in the USB category more reliably, and makes only apps show up, rather than various kinds of runtimes showing up also.

https://phabricator.endlessm.com/T25941

https://phabricator.endlessm.com/T23882