### PR TITLE
T27333 Partial fix for crash on updates tab

### DIFF
--- a/src/gs-shell.c
+++ b/src/gs-shell.c
@@ -2420,7 +2420,8 @@ side_filter_select_by_mode (GsShell *shell, GsShellMode mode)
 		GsShellMode row_mode = gs_side_filter_row_get_mode (GS_SIDE_FILTER_ROW (row));
 		GsCategory *row_category = gs_side_filter_row_get_category (GS_SIDE_FILTER_ROW (row));
 
-		if (row_mode == mode && gs_category_equal (row_category, category)) {
+		if (row_mode == mode && row_category != NULL && category != NULL &&
+		    gs_category_equal (row_category, category)) {
 			gs_shell_side_filter_set_visible (shell, TRUE);
 			return;
 		}

--- a/src/gs-updates-section.c
+++ b/src/gs-updates-section.c
@@ -509,9 +509,9 @@ _list_header_func (GtkListBoxRow *row, GtkListBoxRow *before, gpointer user_data
 
 	/* section changed */
 	if (before == NULL) {
-		GtkWidget *parent;
-		if ((parent = gtk_widget_get_parent (GTK_WIDGET (self->section_header))) != NULL)
-			gtk_container_remove (GTK_CONTAINER (parent), GTK_WIDGET (self->section_header));
+		if (gtk_list_box_row_get_header (row) != self->section_header) {
+			gtk_widget_unparent (self->section_header);
+		}
 		header = self->section_header;
 	} else {
 		header = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);


### PR DESCRIPTION
See https://phabricator.endlessm.com/T27333#760980.

This is a trivial backport of https://gitlab.gnome.org/GNOME/gnome-software/merge_requests/299, and another patch to fix a warning with category testing which isn’t applicable upstream.