### PR TITLE
T27438 - Flatpak apps autoupdates

### DIFF
--- a/plugins/flatpak/gs-flatpak-transaction.c
+++ b/plugins/flatpak/gs-flatpak-transaction.c
@@ -255,6 +255,7 @@ _transaction_operation_done (FlatpakTransaction *transaction,
 			     const gchar *commit,
 			     FlatpakTransactionResult details)
 {
+	GsFlatpakTransaction *self = GS_FLATPAK_TRANSACTION (transaction);
 	/* invalidate */
 	GsApp *app = _transaction_operation_get_app (operation);
 	if (app == NULL) {
@@ -274,7 +275,10 @@ _transaction_operation_done (FlatpakTransaction *transaction,
 		gs_app_set_update_version (app, NULL);
 		/* force getting the new runtime */
 		gs_app_remove_kudo (app, GS_APP_KUDO_SANDBOXED);
-		gs_app_set_state (app, AS_APP_STATE_INSTALLED);
+		if (self->no_deploy) /* autoupdate in progress? */
+			gs_app_set_state (app, AS_APP_STATE_UPDATABLE_LIVE);
+		else
+			gs_app_set_state (app, AS_APP_STATE_INSTALLED);
 		break;
 	case FLATPAK_TRANSACTION_OPERATION_UNINSTALL:
 		/* we don't actually know if this app is re-installable */

--- a/plugins/flatpak/gs-flatpak-transaction.c
+++ b/plugins/flatpak/gs-flatpak-transaction.c
@@ -15,7 +15,12 @@ struct _GsFlatpakTransaction {
 	FlatpakTransaction	 parent_instance;
 	GHashTable		*refhash;	/* ref:GsApp */
 	GError			*first_operation_error;
+	gboolean		 no_deploy;
 };
+
+typedef enum {
+  PROP_NO_DEPLOY = 1,
+} GsFlatpakTransactionProperty;
 
 enum {
 	SIGNAL_REF_TO_APP,
@@ -39,6 +44,22 @@ gs_flatpak_transaction_finalize (GObject *object)
 		g_error_free (self->first_operation_error);
 
 	G_OBJECT_CLASS (gs_flatpak_transaction_parent_class)->finalize (object);
+}
+
+void
+gs_flatpak_transaction_set_no_deploy (FlatpakTransaction *transaction, gboolean no_deploy)
+{
+	GsFlatpakTransaction *self;
+
+	g_return_if_fail (GS_IS_FLATPAK_TRANSACTION (transaction));
+
+	self = GS_FLATPAK_TRANSACTION (transaction);
+	if (self->no_deploy == no_deploy)
+		return;
+	self->no_deploy = no_deploy;
+	flatpak_transaction_set_no_deploy (transaction, no_deploy);
+
+	g_object_notify (G_OBJECT (self), "no-deploy");
 }
 
 GsApp *
@@ -349,10 +370,27 @@ _transaction_add_new_remote (FlatpakTransaction *transaction,
 }
 
 static void
+gs_flatpak_transaction_set_property (GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
+{
+	FlatpakTransaction *transaction = FLATPAK_TRANSACTION (object);
+
+	switch ((GsFlatpakTransactionProperty) prop_id) {
+	case PROP_NO_DEPLOY:
+		gs_flatpak_transaction_set_no_deploy (transaction, g_value_get_boolean (value));
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
+}
+
+static void
 gs_flatpak_transaction_class_init (GsFlatpakTransactionClass *klass)
 {
+	GParamSpec *pspec;
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
 	FlatpakTransactionClass *transaction_class = FLATPAK_TRANSACTION_CLASS (klass);
+	object_class->set_property = gs_flatpak_transaction_set_property;
 	object_class->finalize = gs_flatpak_transaction_finalize;
 	transaction_class->ready = _transaction_ready;
 	transaction_class->add_new_remote = _transaction_add_new_remote;
@@ -361,6 +399,13 @@ gs_flatpak_transaction_class_init (GsFlatpakTransactionClass *klass)
 	transaction_class->operation_error = _transaction_operation_error;
 	transaction_class->choose_remote_for_ref = _transaction_choose_remote_for_ref;
 	transaction_class->end_of_lifed = _transaction_end_of_lifed;
+
+	/* FIXME: getter functions for "no-deploy" are now added to libflatpak (1.5.1) but we are creating a property
+	 * here to avoid the libflatpak version bump. In future, port to use the libflatpak's getters. */
+	pspec = g_param_spec_boolean ("no-deploy",NULL,
+				      "Whether the current transaction will deploy the downloaded objects",
+				      FALSE, G_PARAM_WRITABLE | G_PARAM_CONSTRUCT);
+	g_object_class_install_property (object_class, PROP_NO_DEPLOY, pspec);
 
 	signals[SIGNAL_REF_TO_APP] =
 		g_signal_new ("ref-to-app",

--- a/plugins/flatpak/gs-flatpak-transaction.h
+++ b/plugins/flatpak/gs-flatpak-transaction.h
@@ -26,5 +26,8 @@ void			 gs_flatpak_transaction_add_app		(FlatpakTransaction	*transaction,
 gboolean		 gs_flatpak_transaction_run		(FlatpakTransaction	*transaction,
 								 GCancellable		*cancellable,
 								 GError			**error);
+void			 gs_flatpak_transaction_set_no_deploy	(FlatpakTransaction	*transaction,
+								 gboolean		 no_deploy);
+
 
 G_END_DECLS

--- a/plugins/flatpak/gs-plugin-flatpak.c
+++ b/plugins/flatpak/gs-plugin-flatpak.c
@@ -657,7 +657,7 @@ gs_plugin_download (GsPlugin *plugin, GsAppList *list,
 			gs_flatpak_error_convert (error);
 			return FALSE;
 		}
-		flatpak_transaction_set_no_deploy (transaction, TRUE);
+		gs_flatpak_transaction_set_no_deploy (transaction, TRUE);
 		for (guint i = 0; i < gs_app_list_length (list_tmp); i++) {
 			GsApp *app = gs_app_list_index (list_tmp, i);
 			g_autofree gchar *ref = NULL;

--- a/plugins/flatpak/gs-plugin-flatpak.c
+++ b/plugins/flatpak/gs-plugin-flatpak.c
@@ -952,6 +952,10 @@ gs_plugin_flatpak_update (GsPlugin *plugin,
 		return FALSE;
 	}
 
+	/* Update action on auto updates is essentially a deploy operation. */
+	if (is_auto_update)
+		flatpak_transaction_set_no_pull (transaction, TRUE);
+
 	for (guint i = 0; i < gs_app_list_length (list_tmp); i++) {
 		GsApp *app = gs_app_list_index (list_tmp, i);
 		g_autofree gchar *ref = NULL;

--- a/plugins/flatpak/gs-self-test.c
+++ b/plugins/flatpak/gs-self-test.c
@@ -1402,6 +1402,7 @@ gs_plugins_flatpak_app_update_func (GsPluginLoader *plugin_loader)
 	g_object_unref (plugin_job);
 	plugin_job = gs_plugin_job_newv (GS_PLUGIN_ACTION_UPDATE,
 					 "app", app,
+					 "interactive", TRUE,
 					 NULL);
 	gs_plugin_loader_job_process_async (plugin_loader, plugin_job,
 					    NULL,

--- a/src/gs-update-monitor.c
+++ b/src/gs-update-monitor.c
@@ -327,8 +327,6 @@ _should_auto_update (GsApp *app)
 		return FALSE;
 	if (gs_app_get_kind (app) == AS_APP_KIND_FIRMWARE)
 		return FALSE;
-	if (gs_app_has_quirk (app, GS_APP_QUIRK_NEW_PERMISSIONS))
-		return FALSE;
 	return TRUE;
 }
 


### PR DESCRIPTION
See https://phabricator.endlessm.com/T27438#760799

These patches seems to me in a pretty good shape but still lacking upstream review as of now. 
These are cherry-picked from upstream's merge-requests as mentioned in the above phabricator link.
Ideally, we should backport them after merging them upstream but that probably will miss the hard-code freeze. 

I have been interactively tested these patches for autoupdates code path and made sure that the apps update reliably, pointing to the latest flatpak commit. This is one of the major issues of  T27438 as [noticed](https://phabricator.endlessm.com/T27438#758602) by me and Will. 

I have included the commit "updates monitor: Don't skip automatic updates that require new permission"  (which is basically a revert of cc6f8df) because I have strong objection with holding back such apps **without** having proper fallback/user-action mechanism in place. This is being c[ooked upstream](https://gitlab.gnome.org/GNOME/gnome-software/merge_requests/329) and we can always backport it in any point releases. Also, we didn't have this mechanism earlier anyways(not a good argument but still keeping fallout risks as low as possible). 
 
https://phabricator.endlessm.com/T27438