### PR TITLE
Fix crash when switching categories on ARM

### DIFF
--- a/lib/gs-app-list-private.h
+++ b/lib/gs-app-list-private.h
@@ -42,19 +42,16 @@ typedef enum {
  * @GS_APP_LIST_FILTER_FLAG_PREFER_INSTALLED:	Prefer installed applications
  * @GS_APP_LIST_FILTER_FLAG_KEY_ID_PROVIDES:	Filter using the provides ID
  *
- * Flags to use when filtering. The priority of eash #GsApp is used to choose
+ * Flags to use when filtering. The priority of each #GsApp is used to choose
  * which application object to keep.
  **/
-typedef enum {
-	GS_APP_LIST_FILTER_FLAG_NONE		= 0,
-	GS_APP_LIST_FILTER_FLAG_KEY_ID		= 1 << 0,
-	GS_APP_LIST_FILTER_FLAG_KEY_SOURCE	= 1 << 1,
-	GS_APP_LIST_FILTER_FLAG_KEY_VERSION	= 1 << 2,
-	GS_APP_LIST_FILTER_FLAG_PREFER_INSTALLED= 1 << 3,
-	GS_APP_LIST_FILTER_FLAG_KEY_ID_PROVIDES	= 1 << 4,
-	/*< private >*/
-	GS_APP_LIST_FILTER_FLAG_LAST
-} GsAppListFilterFlags;
+#define GS_APP_LIST_FILTER_FLAG_NONE             ((guint64) 0)
+#define GS_APP_LIST_FILTER_FLAG_KEY_ID           ((guint64) 1 << 0)
+#define GS_APP_LIST_FILTER_FLAG_KEY_SOURCE       ((guint64) 1 << 1)
+#define GS_APP_LIST_FILTER_FLAG_KEY_VERSION      ((guint64) 1 << 2)
+#define GS_APP_LIST_FILTER_FLAG_PREFER_INSTALLED ((guint64) 1 << 3)
+#define GS_APP_LIST_FILTER_FLAG_KEY_ID_PROVIDES  ((guint64) 1 << 4)
+typedef guint64 GsAppListFilterFlags;
 
 GsAppList	*gs_app_list_copy		(GsAppList	*list);
 guint		 gs_app_list_get_size_peak	(GsAppList	*list);

--- a/lib/gs-plugin-job.c
+++ b/lib/gs-plugin-job.c
@@ -71,7 +71,7 @@ gs_plugin_job_to_string (GsPluginJob *self)
 		g_string_append_printf (str, " with filter-flags=%s", tmp);
 	}
 	if (self->dedupe_flags > 0)
-		g_string_append_printf (str, " with dedupe-flags=%x", self->dedupe_flags);
+		g_string_append_printf (str, " with dedupe-flags=%" G_GUINT64_FORMAT, self->dedupe_flags);
 	if (self->refine_flags > 0) {
 		g_autofree gchar *tmp = gs_plugin_refine_flags_to_string (self->refine_flags);
 		g_string_append_printf (str, " with refine-flags=%s", tmp);

--- a/plugins/core/gs-appstream.c
+++ b/plugins/core/gs-appstream.c
@@ -601,9 +601,18 @@ gs_appstream_refine_app_content_rating (GsPlugin *plugin,
 	g_autoptr(AsContentRating) cr = as_content_rating_new ();
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GPtrArray) content_attributes = NULL;
+	const gchar *content_rating_kind = NULL;
 
 	/* get kind */
-	as_content_rating_set_kind (cr, xb_node_get_attr (content_rating, "type"));
+	content_rating_kind = xb_node_get_attr (content_rating, "type");
+	/* we only really expect/support OARS 1.0 and 1.1 */
+	if (content_rating_kind == NULL ||
+	    (g_strcmp0 (content_rating_kind, "oars-1.0") != 0 &&
+	     g_strcmp0 (content_rating_kind, "oars-1.1") != 0)) {
+		return TRUE;
+	}
+
+	as_content_rating_set_kind (cr, content_rating_kind);
 
 	/* get attributes; no attributes being found (i.e.
 	 * `<content_rating type="*"/>`) is OK: it means that all attributes have
@@ -628,9 +637,7 @@ gs_appstream_refine_app_content_rating (GsPlugin *plugin,
 						 as_content_rating_value_from_string (xb_node_get_text (content_attribute)));
 	}
 
-	/* we only really expect OARS 1.0 and 1.1 */
-	if (g_str_has_prefix (as_content_rating_get_kind (cr), "oars-1."))
-		gs_app_set_content_rating (app, cr);
+	gs_app_set_content_rating (app, cr);
 	return TRUE;
 }
 


### PR DESCRIPTION
This PR also fixes another warning when refining an app with <content_rating> without the "type" attr set (note that this commit is not really needed to fix the crash):
```
22:32:03:0210 GLib g_str_has_prefix: assertion 'str != NULL' failed
```

https://phabricator.endlessm.com/T28074