### PR TITLE
Show system apps in their relevant categories

### DIFF
--- a/plugins/core/gs-appstream.c
+++ b/plugins/core/gs-appstream.c
@@ -1182,22 +1182,24 @@ gs_appstream_add_category_apps (GsPlugin *plugin,
 	}
 	for (guint j = 0; j < desktop_groups->len; j++) {
 		const gchar *desktop_group = g_ptr_array_index (desktop_groups, j);
-		g_autofree gchar *xpath = NULL;
+		g_autoptr(GString) xpath = g_string_new (NULL);
 		g_auto(GStrv) split = g_strsplit (desktop_group, "::", -1);
 		g_autoptr(GPtrArray) components = NULL;
 
 		/* generate query */
 		if (g_strv_length (split) == 1) {
-			xpath = g_strdup_printf ("components/component/categories/"
-						 "category[text()='%s']/../..",
-						 split[0]);
+			xb_string_append_union (xpath,
+						"components/component/categories/"
+						"category[text()='%s']/../..",
+						split[0]);
 		} else if (g_strv_length (split) == 2) {
-			xpath = g_strdup_printf ("components/component/categories/"
-						 "category[text()='%s']/../"
-						 "category[text()='%s']/../..",
-						 split[0], split[1]);
+			xb_string_append_union (xpath,
+						"components/component/categories/"
+						"category[text()='%s']/../"
+						"category[text()='%s']/../..",
+						split[0], split[1]);
 		}
-		components = xb_silo_query (silo, xpath, 0, &error_local);
+		components = xb_silo_query (silo, xpath->str, 0, &error_local);
 		if (components == NULL) {
 			if (g_error_matches (error_local, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
 				return TRUE;

--- a/plugins/core/gs-appstream.c
+++ b/plugins/core/gs-appstream.c
@@ -1192,11 +1192,20 @@ gs_appstream_add_category_apps (GsPlugin *plugin,
 						"components/component/categories/"
 						"category[text()='%s']/../..",
 						split[0]);
+			xb_string_append_union (xpath,
+						"component/categories/"
+						"category[text()='%s']/../../description/..",
+						split[0]);
 		} else if (g_strv_length (split) == 2) {
 			xb_string_append_union (xpath,
 						"components/component/categories/"
 						"category[text()='%s']/../"
 						"category[text()='%s']/../..",
+						split[0], split[1]);
+			xb_string_append_union (xpath,
+						"component/categories/"
+						"category[text()='%s']/../"
+						"category[text()='%s']/../../description/..",
 						split[0], split[1]);
 		}
 		components = xb_silo_query (silo, xpath->str, 0, &error_local);

--- a/plugins/core/gs-plugin-appstream.c
+++ b/plugins/core/gs-plugin-appstream.c
@@ -874,6 +874,8 @@ gs_plugin_refine_wildcard (GsPlugin *plugin,
 
 	/* find all app with package names when matching any prefixes */
 	xb_string_append_union (xpath, "components/component/id[text()='%s']/../pkgname/..", id);
+	/* Also query appdata */
+	xb_string_append_union (xpath, "component/id[text()='%s']/..", id);
 	components = xb_silo_query (priv->silo, xpath->str, 0, &error_local);
 	if (components == NULL) {
 		if (g_error_matches (error_local, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))

--- a/plugins/core/gs-plugin-appstream.c
+++ b/plugins/core/gs-plugin-appstream.c
@@ -856,7 +856,7 @@ gs_plugin_refine_wildcard (GsPlugin *plugin,
 {
 	GsPluginData *priv = gs_plugin_get_data (plugin);
 	const gchar *id;
-	g_autofree gchar *xpath = NULL;
+	g_autoptr(GString) xpath = g_string_new (NULL);
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GRWLockReaderLocker) locker = NULL;
 	g_autoptr(GPtrArray) components = NULL;
@@ -873,8 +873,8 @@ gs_plugin_refine_wildcard (GsPlugin *plugin,
 	locker = g_rw_lock_reader_locker_new (&priv->silo_lock);
 
 	/* find all app with package names when matching any prefixes */
-	xpath = g_strdup_printf ("components/component/id[text()='%s']/../pkgname/..", id);
-	components = xb_silo_query (priv->silo, xpath, 0, &error_local);
+	xb_string_append_union (xpath, "components/component/id[text()='%s']/../pkgname/..", id);
+	components = xb_silo_query (priv->silo, xpath->str, 0, &error_local);
 	if (components == NULL) {
 		if (g_error_matches (error_local, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
 			return TRUE;


### PR DESCRIPTION
This fixes the problem of system installed apps not appearing
in their relevant categories as mentioned in their appdata.
These apps are marked as wildcards by gs_appstream_add_category_apps,
hence the refine function for wilcards should also match the real
GsApp using the appdata query.

https://phabricator.endlessm.com/T27899

https://phabricator.endlessm.com/T27505
