### PR TITLE
wip: installed-page: Treat chromium as an actual app

### DIFF
--- a/src/gs-installed-page.c
+++ b/src/gs-installed-page.c
@@ -162,7 +162,8 @@ gs_installed_page_is_actual_app (GsApp *app)
 	if (gs_app_get_description (app) != NULL)
 		return TRUE;
 	/* special snowflake */
-	if (g_strcmp0 (gs_app_get_id (app), "google-chrome.desktop") == 0)
+	if (g_strcmp0 (gs_app_get_id (app), "google-chrome.desktop") == 0 ||
+	    g_strcmp0 (gs_app_get_id (app), "chromium-browser.desktop") == 0)
 		return TRUE;
 	g_debug ("%s is not an actual app", gs_app_get_unique_id (app));
 	return FALSE;


### PR DESCRIPTION
While fixing an upstream issue [1], gnome-software behaviour
was changed, to merge metadata from the desktop file and appdata
for an app under a single GsApp object. This made sure that the
"Installed" tab was properly populated with all the description,
icons, screenshots etc.

Chromium only has a desktop file in EOS. Hence, either one can
add an appdata file to the CMS and make sure it ends up in
/usr/share/metainfo or /usr/share/appdata

OR

force-treat chromium as an actual app (like upstream does for
google-chrome).

(I chose the latter approach in short-term although it would be
good to have an appdata file for chromium-browser which should
be kept updated everytime we release a new chromium version)

[1] https://gitlab.gnome.org/GNOME/gnome-software/issues/813