### PR TITLE
flatpak: Fixup <metadata> tag to <custom>

### DIFF
--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -357,6 +357,20 @@ gs_flatpak_fix_id_desktop_suffix_cb (XbBuilderFixup *self,
 }
 
 static gboolean
+gs_flatpak_fix_metadata_tag_cb (XbBuilderFixup *self,
+				XbBuilderNode *bn,
+				gpointer user_data,
+				GError **error)
+{
+	if (g_strcmp0 (xb_builder_node_get_element (bn), "component") == 0) {
+		g_autoptr(XbBuilderNode) metadata = xb_builder_node_get_child (bn, "metadata", NULL);
+		if (metadata != NULL)
+			xb_builder_node_set_element (metadata, "custom");
+	}
+	return TRUE;
+}
+
+static gboolean
 gs_flatpak_set_origin_cb (XbBuilderFixup *self,
 			  XbBuilderNode *bn,
 			  gpointer user_data,
@@ -528,6 +542,7 @@ gs_flatpak_add_apps_from_xremote (GsFlatpak *self,
 	g_autoptr(XbBuilderFixup) fixup1 = NULL;
 	g_autoptr(XbBuilderFixup) fixup2 = NULL;
 	g_autoptr(XbBuilderFixup) fixup3 = NULL;
+	g_autoptr(XbBuilderFixup) fixup4 = NULL;
 	g_autoptr(XbBuilderNode) info = NULL;
 	g_autoptr(XbBuilderSource) source = xb_builder_source_new ();
 	g_autofree gchar *remote_url = NULL;
@@ -591,6 +606,13 @@ gs_flatpak_add_apps_from_xremote (GsFlatpak *self,
 				       xremote, NULL);
 	xb_builder_fixup_set_max_depth (fixup3, 1);
 	xb_builder_source_add_fixup (source, fixup3);
+
+	/* Fixup <metadata> to <custom> for appstream versions >= 0.9 */
+	fixup4 = xb_builder_fixup_new ("FixMetadataTag",
+				       gs_flatpak_fix_metadata_tag_cb,
+				       xremote, NULL);
+	xb_builder_fixup_set_max_depth (fixup4, 2);
+	xb_builder_source_add_fixup (source, fixup4);
 
 	/* add metadata */
 	icon_prefix = g_build_filename (appstream_dir_fn, "icons", NULL);


### PR DESCRIPTION
Fixup <metadata> tag to <custom> for appstream versions >= 0.9.
Appstream plugin already does this for it's appstreams' xmlb
silos via gs_plugin_appstream_upgrade_cb hence, flatpak
plugin should also follow it.

(Manually cherry-picked from upstream commit
22dd273fab2145dd4564e8c97cc336bc1dcbc93b)

https://phabricator.endlessm.com/T28093

-----

Note: Needed a manual cherry-pick of code, as git cherry-pick was conflicting.

Upstream MR: https://gitlab.gnome.org/GNOME/gnome-software/merge_requests/341