### PR TITLE
eos-blacklist: remove Etoys entry from duplicates list

### DIFF
--- a/plugins/eos-blacklist/gs-plugin-eos-blacklist.c
+++ b/plugins/eos-blacklist/gs-plugin-eos-blacklist.c
@@ -462,7 +462,6 @@ gs_plugin_eos_blacklist_app_for_remote_if_needed (GsPlugin *plugin,
 		"org.mozilla.Firefox",
 		"org.platformio.Ide",
 		"org.snap4arduino.App",
-		"org.squeakland.Etoys",
 		NULL
 	};
 


### PR DESCRIPTION
Migrated to Flathub.

https://phabricator.endlessm.com/T28386