### PR TITLE
gs-plugin-loader: Only return success if task hasn't been cancelled yet

### DIFF
--- a/lib/gs-plugin-loader.c
+++ b/lib/gs-plugin-loader.c
@@ -1466,6 +1466,7 @@ gs_plugin_loader_job_process_finish (GsPluginLoader *plugin_loader,
 				     GAsyncResult *res,
 				     GError **error)
 {
+	GTask *task;
 	GsAppList *list = NULL;
 
 	g_return_val_if_fail (GS_IS_PLUGIN_LOADER (plugin_loader), NULL);
@@ -1473,7 +1474,27 @@ gs_plugin_loader_job_process_finish (GsPluginLoader *plugin_loader,
 	g_return_val_if_fail (g_task_is_valid (res, plugin_loader), NULL);
 	g_return_val_if_fail (error == NULL || *error == NULL, NULL);
 
-	list = g_task_propagate_pointer (G_TASK (res), error);
+	task = G_TASK (res);
+
+	/* Return cancelled if the task was cancelled and there is no other error set.
+	 *
+	 * This is needed because we set the task `check_cancellable` to FALSE,
+	 * to be able to catch other errors such as timeout, but that means
+	 * g_task_propagate_pointer() will ignore if the task was cancelled and only
+	 * check if there was an error (i.e. g_task_return_*error*).
+	 *
+	 * We only do this if there is no error already set in the task (e.g.
+	 * timeout) because in that case we want to return the existing error.
+	 */
+	if (!g_task_had_error (task)) {
+		GCancellable *cancellable = g_task_get_cancellable (task);
+
+		if (g_cancellable_set_error_if_cancelled (cancellable, error)) {
+			gs_utils_error_convert_gio (error);
+			return NULL;
+		}
+	}
+	list = g_task_propagate_pointer (task, error);
 	gs_utils_error_convert_gio (error);
 	return list;
 }

--- a/lib/gs-plugin-loader.c
+++ b/lib/gs-plugin-loader.c
@@ -1466,13 +1466,16 @@ gs_plugin_loader_job_process_finish (GsPluginLoader *plugin_loader,
 				     GAsyncResult *res,
 				     GError **error)
 {
+	GsAppList *list = NULL;
+
 	g_return_val_if_fail (GS_IS_PLUGIN_LOADER (plugin_loader), NULL);
 	g_return_val_if_fail (G_IS_TASK (res), NULL);
 	g_return_val_if_fail (g_task_is_valid (res, plugin_loader), NULL);
 	g_return_val_if_fail (error == NULL || *error == NULL, NULL);
 
+	list = g_task_propagate_pointer (G_TASK (res), error);
 	gs_utils_error_convert_gio (error);
-	return g_task_propagate_pointer (G_TASK (res), error);
+	return list;
 }
 
 /**
@@ -1639,13 +1642,16 @@ gs_plugin_loader_job_get_categories_finish (GsPluginLoader *plugin_loader,
 					   GAsyncResult *res,
 					   GError **error)
 {
+	GPtrArray *array;
+
 	g_return_val_if_fail (GS_IS_PLUGIN_LOADER (plugin_loader), NULL);
 	g_return_val_if_fail (G_IS_TASK (res), NULL);
 	g_return_val_if_fail (g_task_is_valid (res, plugin_loader), NULL);
 	g_return_val_if_fail (error == NULL || *error == NULL, NULL);
 
+	array = g_task_propagate_pointer (G_TASK (res), error);
 	gs_utils_error_convert_gio (error);
-	return g_task_propagate_pointer (G_TASK (res), error);
+	return array;
 }
 
 


### PR DESCRIPTION
This fixes an issue when switching categories in a quick succession where `gs_plugin_loader_job_process_async()` is invoked for a category, then gets cancelled before completing when the category is changed but the thread running the initial job still returns a valid result, which then confuses GsCategoryPage which ends up re-adding the items.

**Note**: I am not sure if the issue is on Glib itself, given `gs_plugin_loader_job_process_async()` sets `g_task_set_check_cancellable (task, FALSE)` and `g_task_set_return_on_cancel (task, FALSE)`, but doesn't check if the task was cancelled before returning a valid result.

Note also that the thread doing the initial async job (`gs_plugin_loader_process_thread_cb()`) already checks the cancellable in a few places, but then proceeds to do other things (e.g. filter the list) without considering the cancellable, which in turn does extra processing that should not be needed. We should also consider either adding more checks for cancellable in `gs_plugin_loader_process_thread_cb()` or maybe setting `g_task_set_check_cancellable()` to `TRUE` as an alternative.

https://phabricator.endlessm.com/T28198