### PR TITLE
HACK: Disable timeout for plugin job operations

### DIFF
--- a/lib/gs-plugin-loader.c
+++ b/lib/gs-plugin-loader.c
@@ -3811,6 +3811,10 @@ gs_plugin_loader_job_timeout_cb (gpointer user_data)
 {
 	GsPluginLoaderHelper *helper = (GsPluginLoaderHelper *) user_data;
 
+	g_debug ("was cancelling job as it took too long, not anymore");
+	helper->timeout_id = 0;
+	return G_SOURCE_REMOVE;
+
 	/* call the cancellable */
 	g_debug ("cancelling job as it took too long");
 	g_cancellable_cancel (helper->cancellable);


### PR DESCRIPTION
With the introduction of adedc2e09 the plugin jobs started to actually
get cancelled when requested, instead of returning a valid result
even though they got cancelled.

This introduced a new issue where if the plugin loader times out (which
in turn cancels the current operation) while loading a category we end up
with an empty list of tiles (which are created as placeholders before the
load operation finishes).

This happens because now we respect the cancellation request and return
an error when the operation gets cancelled, opposed to the way it was before
where a valid result could still be returned even though the operation was
cancelled.

As a workaround to fix this issue we are now removing the timeout, given
we don't want cancelled operations to return valid values and neither show
an empty list of tiles.

https://phabricator.endlessm.com/T28481