### PR TITLE
transaction: Sync main app's state if a related ref is installed

### DIFF
--- a/plugins/flatpak/gs-flatpak-transaction.c
+++ b/plugins/flatpak/gs-flatpak-transaction.c
@@ -62,6 +62,41 @@ gs_flatpak_transaction_set_no_deploy (FlatpakTransaction *transaction, gboolean 
 	g_object_notify (G_OBJECT (self), "no-deploy");
 }
 
+/* Checks if a ref is a related ref to one of the installed ref.
+ * If yes, return the GsApp corresponding to the installed ref,
+ * NULL otherwise.
+ */
+static GsApp *
+get_installed_main_app_of_related_ref (FlatpakTransaction          *transaction,
+                                       FlatpakTransactionOperation *operation)
+{
+	FlatpakInstallation *installation = flatpak_transaction_get_installation (transaction);
+	const gchar *remote = flatpak_transaction_operation_get_remote (operation);
+	const gchar *op_ref = flatpak_transaction_operation_get_ref (operation);
+	GsFlatpakTransaction *self = GS_FLATPAK_TRANSACTION (transaction);
+	g_autoptr(GList) keys = NULL;
+
+	if (g_str_has_prefix (op_ref, "app/"))
+		return NULL;
+
+	keys = g_hash_table_get_keys (self->refhash);
+	for (GList *l = keys; l != NULL; l = l->next) {
+		g_autoptr(GPtrArray) related_refs = NULL;
+		related_refs = flatpak_installation_list_installed_related_refs_sync (installation, remote,
+										      l->data, NULL, NULL);
+		if (related_refs == NULL)
+			continue;
+
+		for (guint i = 0; i < related_refs->len; i++) {
+			g_autofree gchar *rref = flatpak_ref_format_ref (g_ptr_array_index (related_refs, i));
+			if (g_strcmp0 (rref, op_ref) == 0) {
+				return g_hash_table_lookup (self->refhash, l->data);
+			}
+		}
+	}
+	return NULL;
+}
+
 GsApp *
 gs_flatpak_transaction_get_app_by_ref (FlatpakTransaction *transaction, const gchar *ref)
 {
@@ -256,6 +291,8 @@ _transaction_operation_done (FlatpakTransaction *transaction,
 			     FlatpakTransactionResult details)
 {
 	GsFlatpakTransaction *self = GS_FLATPAK_TRANSACTION (transaction);
+	GsApp *main_app = NULL;
+
 	/* invalidate */
 	GsApp *app = _transaction_operation_get_app (operation);
 	if (app == NULL) {
@@ -265,6 +302,26 @@ _transaction_operation_done (FlatpakTransaction *transaction,
 	}
 	switch (flatpak_transaction_operation_get_operation_type (operation)) {
 	case FLATPAK_TRANSACTION_OPERATION_INSTALL:
+		/* Handle special snowflake where "should-download" related refs for an installed ref
+		 * goes missing. In that case, libflatpak marks the main app ref as updatable
+		 * and then FlatpakTransaction resolves one of its ops to install the related ref(s).
+		 *
+		 * We can depend on libflatpak till here. Since, libflatpak returns the main app
+		 * ref as updatable (instead of the related ref), we need to sync the main app's
+		 * state for UI/UX.
+		 *
+		 * Map the current op's ref (which is related ref) to its main app ref (which is
+		 * currently shown in the UI) and set the state of the main GsApp object back
+		 * to INSTALLED here.
+		 *
+		 * This detection whether a related ref belongs to a main ref is quite sub-optimal as
+		 * of now.
+		 */
+		main_app = get_installed_main_app_of_related_ref (transaction, operation);
+		if (main_app != NULL)
+			gs_app_set_state (main_app, AS_APP_STATE_INSTALLED);
+		gs_app_set_state (app, AS_APP_STATE_INSTALLED);
+		break;
 	case FLATPAK_TRANSACTION_OPERATION_INSTALL_BUNDLE:
 		gs_app_set_state (app, AS_APP_STATE_INSTALLED);
 		break;

--- a/plugins/flatpak/gs-plugin-flatpak.c
+++ b/plugins/flatpak/gs-plugin-flatpak.c
@@ -965,6 +965,9 @@ gs_plugin_flatpak_update (GsPlugin *plugin,
 			gs_flatpak_error_convert (error);
 			return FALSE;
 		}
+
+		/* Add the update applist for easier lookup */
+		gs_flatpak_transaction_add_app (transaction, app);
 	}
 
 	/* run transaction */


### PR DESCRIPTION
In T28302, due to encyclopedia split between
com.endlessm.encyclopedia.en and com.endlessm.encyclopedia.en.Content,
old versions of encyclopedia (under one ref) didn't get the
content ref when they tried to upgrade the app. Hence, encyclopedia
broke for those users as there was no content ref.

The content ref is a related ref. Flatpak changes [1] can detect if
such a related ref is missing on the installation and therefore,
can mark the app as updatable again.

We need to make sure that gnome-software can be aware of this state
and sync the main app and related app's states accordingly for UI/UX.

[1] https://github.com/endlessm/flatpak/pull/197

https://phabricator.endlessm.com/T28302