### PR TITLE
transaction: Sync installed apps' state missing runtime is re-installed

### DIFF
--- a/plugins/flatpak/gs-flatpak-transaction.c
+++ b/plugins/flatpak/gs-flatpak-transaction.c
@@ -62,6 +62,58 @@ gs_flatpak_transaction_set_no_deploy (FlatpakTransaction *transaction, gboolean 
 	g_object_notify (G_OBJECT (self), "no-deploy");
 }
 
+/* Sets installed app(s) back to installed state. Flatpak can return apps as updatable
+ * (for installing a missing runtime); if it is detected that the runtime was missing
+ * at the first place.
+ *
+ * We can determine whether a GsApp is only being updated due to a missing runtime, by checking
+ * if the current operation's ref is the GsApp's runtime and also the GsApp is already deployed.
+ */
+static void
+set_installed_app_state_if_missing_runtime_is_installed (FlatpakTransaction          *transaction,
+							  FlatpakTransactionOperation *operation)
+{
+	GsFlatpakTransaction *self = GS_FLATPAK_TRANSACTION (transaction);
+	FlatpakInstallation *installation = flatpak_transaction_get_installation (transaction);
+	const gchar *op_ref = flatpak_transaction_operation_get_ref (operation);
+	g_autoptr(GList) apps = NULL;
+
+	if (g_str_has_prefix (op_ref, "app/"))
+		return;
+
+	apps = g_hash_table_get_values (self->refhash);
+	for (GList *l = apps; l != NULL; l = l->next) {
+		GsApp *app = l->data;
+		GsApp *app_runtime;
+		g_autofree gchar *app_runtime_ref = NULL;
+
+		app_runtime = gs_app_get_runtime (app);
+		if (app_runtime == NULL)
+			continue;
+
+		app_runtime_ref = gs_flatpak_app_get_ref_display (app_runtime);
+		if (app_runtime_ref != NULL &&
+		    g_strcmp0 (app_runtime_ref, op_ref) == 0) {
+			g_autoptr(FlatpakInstalledRef) app_ref = NULL;
+			g_autoptr(GBytes) metadata = NULL;
+
+			app_ref = flatpak_installation_get_installed_ref (installation,
+									  FLATPAK_REF_KIND_APP,
+									  gs_flatpak_app_get_ref_name (app),
+									  gs_flatpak_app_get_ref_arch (app),
+									  gs_flatpak_app_get_ref_branch (app),
+									  NULL, NULL);
+			if (app_ref == NULL)
+				continue;
+
+			metadata = flatpak_installed_ref_load_metadata (app_ref, NULL, NULL);
+			/* This makes sure that the app is already deployed. */
+			if (metadata != NULL)
+				gs_app_set_state (app, AS_APP_STATE_INSTALLED);
+		}
+	}
+}
+
 /* Checks if a ref is a related ref to one of the installed ref.
  * If yes, return the GsApp corresponding to the installed ref,
  * NULL otherwise.
@@ -320,6 +372,14 @@ _transaction_operation_done (FlatpakTransaction *transaction,
 		main_app = get_installed_main_app_of_related_ref (transaction, operation);
 		if (main_app != NULL)
 			gs_app_set_state (main_app, AS_APP_STATE_INSTALLED);
+
+		/* Do the same as above but if the main app is missing its runtime.
+		 * Multiple GsApp can depend on one (missing) runtime, hence set state to "installed"
+		 * state for all those apps too.
+		 */
+		set_installed_app_state_if_missing_runtime_is_installed (transaction, operation);
+
+		/* For all other trivial cases. */
 		gs_app_set_state (app, AS_APP_STATE_INSTALLED);
 		break;
 	case FLATPAK_TRANSACTION_OPERATION_INSTALL_BUNDLE:


### PR DESCRIPTION
Built on top of solution of https://github.com/endlessm/gnome-software/pull/512
(See also base branch)

---
Flatpak changes [1] will start marking apps as updatable if their
runtime component is missing on the installation. These apps will
be shown as updatable in gnome-software updates panel but in the
background they are meant to fetch their missing runtime.
 
Since many apps can target one runtime, the absence of that runtime
can make many apps show up in the updates panel. In that case,
check if the runtime is downloaded → installed and set all
apps' state back to "installed". This solves the case
if users chooses to click "Update All".
    
[1] https://github.com/flatpak/flatpak/pull/3204

https://phabricator.endlessm.com/T27077

---
#### Briefly tested with changes with [1] on following updates navigation paths:
* Single Manual update :heavy_check_mark: 
* Autoupdates behavior - Unistalled various runtimes, turned on autoupdates and used the computer for sometime. All the apps were updated(and functional) and appropriately `Updates` tab showed all updates to be done.  :heavy_check_mark: 
*  Have many apps targeting one `$runtime` :heavy_check_mark: 
   * `flatpak uninstall --force-remove $runtime`
   * Verify all apps targeting `$runtime` show up in updates tab 
   * Click `Update All` in updates tab - All apps goes back to installed state correctly.
* Have many apps targeting one `$runtime` :fish:-y
   * Click on **one** of the app targeting that runtime - Installs the runtime and goes back to installed state. However, other apps still stay on the updates page. They stay until the updates page is refreshed or gnome-software is restarted.
   * Click on **one** of the app(A) targeting that runtime, few seconds later, click on the one of the other app(B) targeting that runtime. A goes back to installed state after runtime install, whereas B is stuck in _INSTALLING state forever (until gnome-software restart) - Not sure what we can do there.
