### PR TITLE
flatpak: Only ignore estimated progress if >10%

### DIFF
--- a/plugins/flatpak/gs-flatpak-transaction.c
+++ b/plugins/flatpak/gs-flatpak-transaction.c
@@ -175,8 +175,18 @@ _transaction_progress_changed_cb (FlatpakTransactionProgress *progress,
 {
 	GsApp *app = GS_APP (user_data);
 	guint percent = flatpak_transaction_progress_get_progress (progress);
-	if (flatpak_transaction_progress_get_is_estimating (progress))
-		return;
+	if (flatpak_transaction_progress_get_is_estimating (progress)) {
+		/* "Estimating" happens while fetching the metadata, which
+		 * flatpak arbitrarily decides happens during the first 5% of
+		 * each operation. Often there are two install operations,
+		 * for the flatpak and its locale data.
+		 * However, "estimating" may also mean bogus values. We have to
+		 * arbitrarily decide whether to show this value to the user. */
+		if (percent > 10) {
+			g_debug ("Ignoring estimated progress of %u%%", percent);
+			return;
+		}
+	}
 	if (gs_app_get_progress (app) != 100 &&
 	    gs_app_get_progress (app) > percent) {
 		g_warning ("ignoring percentage %u%% -> %u%% as going down...",


### PR DESCRIPTION
Flatpak may set the "estimating" flag on a progress report if the value
is bogus, or it may set it if it is downloading metadata which it
arbitrarily decides comprises the first 5% of an install operation.
Ignoring estimated progress therefore means we get no progress changes
for the first 10% of an app install (installing the app and its locale
extension). Instead, only ignore the estimated progress if it is an
obviously bogus value of >10%.

https://phabricator.endlessm.com/T28764