### PR TITLE
Re-enable tests in CI

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
-option('tests', type : 'boolean', value : false, description : 'enable tests')
+option('tests', type : 'boolean', value : true, description : 'enable tests')
 option('gspell', type : 'boolean', value : false, description : 'enable gspell')
 option('gnome_desktop', type : 'boolean', value : true, description : 'enable gnome-desktop')
 option('man', type : 'boolean', value : true, description : 'enable man pages')


### PR DESCRIPTION
Make sure we always run tests in the CI.
This doesn't mean all tests gets executed for e.g.
see 15c6a8d159d77 that comes from upstream.
Re-enabling that particular test is being tackled
in  T28825.

https://phabricator.endlessm.com/T21809

______

Lets see if this is a good idea!