### PR TITLE
Fix proxy apps updates support

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -914,7 +914,6 @@ static void
 process_proxy_updates (GsPlugin *plugin,
 		       GsAppList *list,
 		       GsApp *proxy_app,
-		       gboolean install_missing,
 		       const char **proxied_apps)
 {
 	g_autoptr(GsAppList) proxied_updates = gs_app_list_new ();
@@ -923,18 +922,6 @@ process_proxy_updates (GsPlugin *plugin,
 						      gs_app_get_unique_id (proxy_app));
 	if (cached_proxy_app != NULL)
 		gs_app_list_remove (list, cached_proxy_app);
-
-	/* add all the apps if we should install the missing ones; the real sorting for
-	 * whether they're already installed is done in the refine method */
-	if (install_missing) {
-		for (guint i = 0; proxied_apps[i] != NULL; ++i) {
-		        g_autoptr(GsApp) app = gs_app_new (proxied_apps[i]);
-			gs_app_add_quirk (app, GS_APP_QUIRK_IS_WILDCARD);
-			gs_app_set_bundle_kind (app, AS_BUNDLE_KIND_FLATPAK);
-
-			gs_app_list_add (proxied_updates, app);
-		}
-	}
 
 	for (guint i = 0; i < gs_app_list_length (list); ++i) {
 		GsApp *app = gs_app_list_index (list, i);
@@ -1002,7 +989,6 @@ add_updates (GsPlugin *plugin,
 
 	process_proxy_updates (plugin, list,
 			       framework_proxy_app,
-			       FALSE,
 			       framework_proxied_apps);
 
 	return TRUE;

--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -35,7 +35,6 @@
 
 #define ENDLESS_ID_PREFIX "com.endlessm."
 #define METADATA_SYS_DESKTOP_FILE "EndlessOS::system-desktop-file"
-#define METADATA_REPLACED_BY_DESKTOP_FILE "EndlessOS::replaced-by-desktop-file"
 #define EOS_PROXY_APP_PREFIX ENDLESS_ID_PREFIX "proxy"
 
 /*

--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -993,7 +993,6 @@ add_updates (GsPlugin *plugin,
 
 	const char *framework_proxied_apps[] = {"com.endlessm.Platform",
 						"com.endlessm.apps.Platform",
-						"com.endlessm.CompanionAppService.desktop",
 						"com.endlessm.EknServicesMultiplexer.desktop",
 						"com.endlessm.quote_of_the_day.en.desktop",
 						"com.endlessm.word_of_the_day.en.desktop",

--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -1009,13 +1009,6 @@ add_updates (GsPlugin *plugin,
 						_("Endless Platform"),
 						/* TRANSLATORS: this is the summary of the Endless Platform app */
 						_("Framework for applications"));
-	g_autoptr(GsApp) hack_proxy_app =
-		gs_plugin_eos_create_proxy_app (plugin,
-						EOS_PROXY_APP_PREFIX ".EOSHackUpdatesProxy",
-						/* TRANSLATORS: this is the name of the Endless Hack Platform app */
-						_("Endless Hack Platform"),
-						/* TRANSLATORS: this is the summary of the Endless Hack Platform app */
-						_("Endless Hack system components"));
 
 	const char *framework_proxied_apps[] = {"com.endlessm.Platform",
 						"com.endlessm.apps.Platform",
@@ -1024,32 +1017,13 @@ add_updates (GsPlugin *plugin,
 						"com.endlessm.quote_of_the_day.en.desktop",
 						"com.endlessm.word_of_the_day.en.desktop",
 						NULL};
-	const char *hack_proxied_apps[] = {"com.endlessm.Clubhouse.desktop",
-					   "com.endlessm.Fizzics.desktop",
-					   "com.endlessm.GameStateService.desktop",
-					   "com.endlessm.HackAccountService.desktop",
-					   "com.endlessm.HackComponents.desktop",
-					   "com.endlessm.HackSoundServer.desktop",
-					   "com.endlessm.HackToolbox.desktop",
-					   "com.endlessm.HackUnlock.desktop",
-					   "com.endlessm.Hackdex_chapter_one.desktop",
-					   "com.endlessm.Hackdex_chapter_two.desktop",
-					   "com.endlessm.LightSpeed.desktop",
-					   "com.endlessm.OperatingSystemApp.desktop",
-					   "com.endlessm.Sidetrack.desktop",
-					   NULL};
 
 	GsPluginData *priv = gs_plugin_get_data (plugin);
-	gboolean is_hack_product = g_strcmp0 (priv->product_name, "hack") == 0;
 
 	process_proxy_updates (plugin, list,
 			       framework_proxy_app,
 			       FALSE,
 			       framework_proxied_apps);
-	process_proxy_updates (plugin, list,
-			       hack_proxy_app,
-			       is_hack_product,
-			       hack_proxied_apps);
 
 	return TRUE;
 }

--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -993,9 +993,9 @@ add_updates (GsPlugin *plugin,
 
 	const char *framework_proxied_apps[] = {"com.endlessm.Platform",
 						"com.endlessm.apps.Platform",
-						"com.endlessm.EknServicesMultiplexer.desktop",
-						"com.endlessm.quote_of_the_day.en.desktop",
-						"com.endlessm.word_of_the_day.en.desktop",
+						"com.endlessm.EknServicesMultiplexer",
+						"com.endlessm.quote_of_the_day.en",
+						"com.endlessm.word_of_the_day.en",
 						NULL};
 
 	GsPluginData *priv = gs_plugin_get_data (plugin);

--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -64,8 +64,6 @@ struct GsPluginData
 	GHashTable *replacement_app_lookup;
 	int applications_changed_id;
 	SoupSession *soup_session;
-
-	char *product_name;
 };
 
 static gboolean
@@ -189,21 +187,6 @@ get_image_version (void)
 	return image_version;
 }
 
-static char *
-get_product_name (const char *image_version)
-{
-	char *hyphen_index = NULL;
-
-	if (image_version == NULL)
-		return NULL;
-
-	hyphen_index = strchr (image_version, '-');
-	if (hyphen_index == NULL)
-		return NULL;
-
-	return g_strndup (image_version, hyphen_index - image_version);
-}
-
 static void
 read_icon_replacement_overrides (GHashTable *replacement_app_lookup)
 {
@@ -283,7 +266,6 @@ gs_plugin_setup (GsPlugin *plugin,
 							      g_free, g_free);
 
 	image_version = get_image_version ();
-	priv->product_name = get_product_name (image_version);
 
 	/* Synchronous, but this guarantees that the lookup table will be
 	 * there when we call ReplaceApplication later on */
@@ -319,7 +301,6 @@ gs_plugin_destroy (GsPlugin *plugin)
 
 	g_hash_table_destroy (priv->desktop_apps);
 	g_hash_table_destroy (priv->replacement_app_lookup);
-	g_free (priv->product_name);
 }
 
 /* Copy of the implementation of gs_flatpak_app_get_ref_name(). */

--- a/plugins/flatpak/gs-flatpak-transaction.c
+++ b/plugins/flatpak/gs-flatpak-transaction.c
@@ -234,6 +234,19 @@ _transaction_operation_get_app (FlatpakTransactionOperation *op)
 	return g_object_get_data (G_OBJECT (op), "GsApp");
 }
 
+static void
+_transaction_progress_set_app (FlatpakTransactionProgress *progress, GsApp *app)
+{
+	g_object_set_data_full (G_OBJECT (progress), "GsApp",
+				g_object_ref (app), (GDestroyNotify) g_object_unref);
+}
+
+static GsApp *
+_transaction_progress_get_app (FlatpakTransactionProgress *progress)
+{
+	return g_object_get_data (G_OBJECT (progress), "GsApp");
+}
+
 gboolean
 gs_flatpak_transaction_run (FlatpakTransaction *transaction,
                             GCancellable *cancellable,
@@ -299,7 +312,10 @@ static void
 _transaction_progress_changed_cb (FlatpakTransactionProgress *progress,
 				  gpointer user_data)
 {
-	GsApp *app = GS_APP (user_data);
+	GsFlatpakTransaction *self = GS_FLATPAK_TRANSACTION (user_data);
+	GsApp *app = _transaction_progress_get_app (progress);
+	GsApp *proxy_app = NULL;
+
 	guint percent = flatpak_transaction_progress_get_progress (progress);
 	if (flatpak_transaction_progress_get_is_estimating (progress)) {
 		/* "Estimating" happens while fetching the metadata, which
@@ -319,7 +335,38 @@ _transaction_progress_changed_cb (FlatpakTransactionProgress *progress,
 			   gs_app_get_progress (app), percent);
 		return;
 	}
+
 	gs_app_set_progress (app, percent);
+
+	// TODO: Improve heuristics to get progress for proxy app
+	proxy_app = g_hash_table_lookup (self->apps_proxies, app);
+	if (proxy_app) {
+		GsAppList *proxied_apps;
+		guint64 total_expected_size_installed = 0;
+		guint64 total_size_installed = 0;
+
+		proxied_apps = gs_app_get_related (proxy_app);
+		for (guint i = 0; i < gs_app_list_length (proxied_apps); ++i) {
+			GsApp *proxied_app = gs_app_list_index (proxied_apps, i);
+			guint64 proxied_app_size_installed;
+			guint proxied_app_progress;
+
+			proxied_app_size_installed = gs_app_get_size_installed (proxied_app);
+			if (proxied_app_size_installed == 0 ||
+			    proxied_app_size_installed == GS_APP_SIZE_UNKNOWABLE)
+				continue;
+
+			proxied_app_progress = gs_app_get_progress (proxied_app);
+
+			total_expected_size_installed += proxied_app_size_installed;
+			total_size_installed += ((proxied_app_size_installed * proxied_app_progress) / 100);
+		}
+
+		if (total_expected_size_installed != 0) {
+			percent = (total_size_installed * 100) / total_expected_size_installed;
+			gs_app_set_progress (proxy_app, percent);
+		}
+	}
 }
 
 static const gchar *
@@ -355,9 +402,10 @@ _transaction_new_operation (FlatpakTransaction *transaction,
 	}
 
 	/* report progress */
+	_transaction_progress_set_app (progress, app);
 	g_signal_connect_object (progress, "changed",
 				 G_CALLBACK (_transaction_progress_changed_cb),
-				 app, 0);
+				 transaction, 0);
 	flatpak_transaction_progress_set_update_frequency (progress, 100); /* FIXME? */
 
 	/* set app status */

--- a/plugins/flatpak/gs-flatpak-transaction.h
+++ b/plugins/flatpak/gs-flatpak-transaction.h
@@ -23,6 +23,9 @@ GsApp			*gs_flatpak_transaction_get_app_by_ref	(FlatpakTransaction	*transaction,
 								 const gchar		*ref);
 void			 gs_flatpak_transaction_add_app		(FlatpakTransaction	*transaction,
 								 GsApp			*app);
+gboolean		 gs_flatpak_transaction_add_update	(FlatpakTransaction	*transaction,
+								 GsApp			*app,
+								 GError			**error);
 gboolean		 gs_flatpak_transaction_run		(FlatpakTransaction	*transaction,
 								 GCancellable		*cancellable,
 								 GError			**error);

--- a/plugins/flatpak/gs-plugin-flatpak.c
+++ b/plugins/flatpak/gs-plugin-flatpak.c
@@ -274,6 +274,9 @@ gs_plugin_flatpak_get_handler (GsPlugin *plugin, GsApp *app)
 	GsPluginData *priv = gs_plugin_get_data (plugin);
 	const gchar *object_id;
 
+	if (gs_app_has_quirk (app, AS_APP_QUIRK_IS_PROXY))
+		goto select_by_scope;
+
 	/* only process this app if was created by this plugin */
 	if (g_strcmp0 (gs_app_get_management_plugin (app),
 		       gs_plugin_get_name (plugin)) != 0) {
@@ -290,6 +293,7 @@ gs_plugin_flatpak_get_handler (GsPlugin *plugin, GsApp *app)
 		}
 	}
 
+select_by_scope:
 	/* find a scope that matches */
 	for (guint i = 0; i < priv->flatpaks->len; i++) {
 		GsFlatpak *flatpak = g_ptr_array_index (priv->flatpaks, i);
@@ -660,10 +664,8 @@ gs_plugin_download (GsPlugin *plugin, GsAppList *list,
 		gs_flatpak_transaction_set_no_deploy (transaction, TRUE);
 		for (guint i = 0; i < gs_app_list_length (list_tmp); i++) {
 			GsApp *app = gs_app_list_index (list_tmp, i);
-			g_autofree gchar *ref = NULL;
-	
-			ref = gs_flatpak_app_get_ref_display (app);
-			if (!flatpak_transaction_add_update (transaction, ref, NULL, NULL, error)) {
+
+			if (!gs_flatpak_transaction_add_update (transaction, app, error)) {
 				gs_flatpak_error_convert (error);
 				return FALSE;
 			}
@@ -958,16 +960,11 @@ gs_plugin_flatpak_update (GsPlugin *plugin,
 
 	for (guint i = 0; i < gs_app_list_length (list_tmp); i++) {
 		GsApp *app = gs_app_list_index (list_tmp, i);
-		g_autofree gchar *ref = NULL;
 
-		ref = gs_flatpak_app_get_ref_display (app);
-		if (!flatpak_transaction_add_update (transaction, ref, NULL, NULL, error)) {
+		if (!gs_flatpak_transaction_add_update (transaction, app, error)) {
 			gs_flatpak_error_convert (error);
 			return FALSE;
 		}
-
-		/* Add the update applist for easier lookup */
-		gs_flatpak_transaction_add_app (transaction, app);
 	}
 
 	/* run transaction */
@@ -992,13 +989,11 @@ gs_plugin_flatpak_update (GsPlugin *plugin,
 	}
 	for (guint i = 0; i < gs_app_list_length (list_tmp); i++) {
 		GsApp *app = gs_app_list_index (list_tmp, i);
-		g_autofree gchar *ref = NULL;
 
-		ref = gs_flatpak_app_get_ref_display (app);
 		if (!gs_flatpak_refine_app (flatpak, app,
 					    GS_PLUGIN_REFINE_FLAGS_REQUIRE_RUNTIME,
 					    cancellable, error)) {
-			g_prefix_error (error, "failed to run refine for %s: ", ref);
+			g_prefix_error (error, "failed to run refine for %s: ", gs_app_get_id (app));
 			gs_flatpak_error_convert (error);
 			return FALSE;
 		}


### PR DESCRIPTION
Tested locally by downgrading both `EknServicesMultiplexer` and `quote_of_the_day`. The updates are showed in the `Updates` tab grouped in the `Endless Platform` proxy app and clicking `Update` on it actually updates the proxied apps as expected.

https://phabricator.endlessm.com/T28672
https://phabricator.endlessm.com/T29298