### PR TITLE
Revert "Hide the license details in the details page"

### DIFF
--- a/src/gs-details-page.c
+++ b/src/gs-details-page.c
@@ -1466,12 +1466,6 @@ gs_details_page_refresh_all (GsDetailsPage *self)
 		break;
 	}
 
-	/* XXX: until we decide what to do regarding the styling and until we
-	 * fix the license generation in the flatpak apps, we hide the license
-	 * FIXME: https://phabricator.endlessm.com/T12886 */
-	gtk_widget_hide (self->label_details_license_title);
-	gtk_widget_hide (self->box_details_license_value);
-
 	gs_details_page_update_shortcut_button (self);
 
 	gs_details_page_update_copy_button (self);


### PR DESCRIPTION
This reverts commit 9ec0926b06793eb8b51cfd7af096ced4cdc05695.

When we next rebase, this commit and the commit it reverts can both be
dropped.

The appdata generation code has been fixed to either generate licenses
correctly or not at all, and hence it’s no longer harmful to show the
license in gnome-software.

https://phabricator.endlessm.com/T12886