### PR TITLE
gs-details-page: Avoid a NULL object dereference

### DIFF
--- a/src/gs-details-page.c
+++ b/src/gs-details-page.c
@@ -2709,7 +2709,7 @@ gs_details_page_plugin_status_changed_cb (GsPluginLoader *plugin_loader,
                                           GsPluginStatus status,
                                           GsDetailsPage *self)
 {
-	if (app == NULL)
+	if (app == NULL || self->app == NULL)
 		return;
 
 	/* Various bits of UI state depend on the plugin status, so refresh


### PR DESCRIPTION
When checking for updates, the plugin status will change. If that
happens before an app detail page is first viewed by the user (which is
a common situation if gnome-software is started in the background and
does a background update check), a load of `gs_app_*()` methods will be
called on `self->app` when it is `NULL`, giving a load of critical
warnings.

Avoid that by doing what every other call site of
`gs_details_page_refresh_all()` does, and checking whether `self->app ==
NULL` first.

Signed-off-by: Philip Withnall <withnall@endlessm.com>