### PR TITLE
eos: Add parental controls metrics on update poll

### DIFF
--- a/plugins/eos-updater/meson.build
+++ b/plugins/eos-updater/meson.build
@@ -20,6 +20,8 @@ shared_module(
   c_args : cargs,
   dependencies : [
     plugin_libs,
+    dependency('eosmetrics-0', version: '>= 0.5.0'),
+    dependency('malcontent-0', version: '>= 0.7.0'),
     ostree,
   ],
   link_with : [


### PR DESCRIPTION
Submit a metrics event containing the current state of the parental
controls for the current user whenever a poll happens for OS updates.

This will give us an overview of whether parental controls have been
enabled by our users.

The choice of submitting it when polling for OS updates was fairly
arbitrary: we needed a regular submission event which was independent
from the parental controls being edited. See T28741 for details.

This commit should not be upstreamed.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T28742

---

Debian changes in #534.