### PR TITLE
flatpak: Properly check if an app is a runtime

### DIFF
--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -267,7 +267,7 @@ gs_flatpak_create_app (GsFlatpak *self, const gchar *origin, FlatpakRef *xref)
 		return app_cached;
 
 	/* fallback values */
-	if (gs_app_get_kind (app) == AS_APP_KIND_RUNTIME) {
+	if (gs_flatpak_app_get_ref_kind (app) == FLATPAK_REF_KIND_RUNTIME) {
 		g_autoptr(AsIcon) icon = NULL;
 		gs_app_set_name (app, GS_APP_QUALITY_NORMAL,
 				 flatpak_ref_get_name (FLATPAK_REF (xref)));
@@ -1136,8 +1136,12 @@ gs_flatpak_set_metadata_installed (GsFlatpak *self, GsApp *app,
 		gs_app_set_install_date (app, mtime);
 	}
 
-	/* if it's a runtime, check if the main-app info should be set */
-	if (gs_app_get_kind (app) == AS_APP_KIND_RUNTIME &&
+    /* If it's a runtime, check if the main-app info should be set. Note that
+     * checking the app for AS_APP_KIND_RUNTIME is not good enough because it
+     * could be e.g. AS_APP_KIND_LOCALIZATION and still be a runtime from
+     * Flatpak's perspective.
+     */
+	if (gs_flatpak_app_get_ref_kind (app) == FLATPAK_REF_KIND_RUNTIME &&
 	    gs_flatpak_app_get_main_app_ref_name (app) == NULL) {
 		g_autoptr(GError) error = NULL;
 		g_autoptr(GKeyFile) metadata_file = NULL;
@@ -1505,7 +1509,7 @@ get_real_app_for_update (GsFlatpak *self,
 	GsApp *main_app = NULL;
 	g_autoptr(GError) error_local = NULL;
 
-	if (gs_app_get_kind (app) == AS_APP_KIND_RUNTIME)
+	if (gs_flatpak_app_get_ref_kind (app) == FLATPAK_REF_KIND_RUNTIME)
 		main_app = get_main_app_of_related (self, app, cancellable, &error_local);
 
 	if (main_app == NULL) {


### PR DESCRIPTION
In gs_flatpak_set_kind_from_flatpak(), we use AS_APP_KIND_LOCALIZATION
and AS_APP_KIND_GENERIC in addition to AS_APP_KIND_RUNTIME, all for
things which from Flatpak's perspective are runtimes (their ref starts
with "runtime/"). So change checks in a few places to correctly identify
Flatpak runtimes instead of checking for AS_APP_KIND_RUNTIME, which has
the effect of ensuring that applications properly show as needing an
update when their locale extension needs an update, e.g. because the
user chose a language other than the one the locale extensions already
have.

https://phabricator.endlessm.com/T24168