### PR TITLE
eos-blacklist: unblacklist Firefox from Flathub

### DIFF
--- a/plugins/eos-blacklist/gs-plugin-eos-blacklist.c
+++ b/plugins/eos-blacklist/gs-plugin-eos-blacklist.c
@@ -447,7 +447,6 @@ gs_plugin_eos_blacklist_app_for_remote_if_needed (GsPlugin *plugin,
 		"com.google.Chrome",
 		"com.stencyl.Game",
 		"org.learningequality.KALite",
-		"org.mozilla.Firefox",
 		"org.snap4arduino.App",
 		NULL
 	};


### PR DESCRIPTION
As with so many of these, the blacklist is completely ineffective
because when it was ultimately added to Flathub, the app ID was
different (lowercase 'f' in 'org.mozilla.firefox').

I haven't even compiled this because there is nothing to test. The Flathub version is already visible, crap metadata and all.

![Capture d’écran de 2020-05-06 23-05-35](https://user-images.githubusercontent.com/86760/81233186-1ffec480-8fee-11ea-81b3-b438c442b717.png)

https://phabricator.endlessm.com/T29746