### PR TITLE
build: Enable unit tests for CI

### DIFF
--- a/lib/gs-app.c
+++ b/lib/gs-app.c
@@ -1017,6 +1017,7 @@ gs_app_set_state_internal (GsApp *app, AsAppState state)
 	case AS_APP_STATE_AVAILABLE_LOCAL:
 		/* local has to go into an action state */
 		if (state == AS_APP_STATE_UNKNOWN ||
+		    state == AS_APP_STATE_QUEUED_FOR_INSTALL ||
 		    state == AS_APP_STATE_INSTALLING)
 			state_change_ok = TRUE;
 		break;

--- a/lib/gs-metered.c
+++ b/lib/gs-metered.c
@@ -132,6 +132,13 @@ gs_metered_block_on_download_scheduler (GVariant      *parameters,
                                         GCancellable  *cancellable,
                                         GError       **error)
 {
+	/* FIXME: Use a mock service instead of skipping the check here.
+	 * https://phabricator.endlessm.com/T30646 */
+	if (g_getenv ("GS_UNIT_TESTS_SKIP_MOGWAI") != NULL) {
+		g_debug ("%s: Allowed to download (Skipping check in unit tests)", G_STRFUNC);
+		return TRUE;
+	}
+
 #ifdef HAVE_MOGWAI
 	g_autoptr(MwscScheduler) scheduler = NULL;
 	g_autoptr(MwscScheduleEntry) schedule_entry = NULL;

--- a/lib/gs-plugin-loader.c
+++ b/lib/gs-plugin-loader.c
@@ -2080,7 +2080,6 @@ remove_app_from_install_queue (GsPluginLoader *plugin_loader, GsApp *app)
 	g_mutex_unlock (&priv->pending_apps_mutex);
 
 	if (ret) {
-		gs_app_set_state (app, AS_APP_STATE_AVAILABLE);
 		id = g_idle_add (emit_pending_apps_idle, g_object_ref (plugin_loader));
 		g_source_set_name_by_id (id, "[gnome-software] emit_pending_apps_idle");
 		save_install_queue (plugin_loader);
@@ -3340,6 +3339,7 @@ gs_plugin_loader_app_installed_cb (GObject *source,
 						   res,
 						   &error);
 	if (!ret) {
+		gs_app_set_state (app, AS_APP_STATE_AVAILABLE);
 		remove_app_from_install_queue (plugin_loader, app);
 		g_warning ("failed to install %s: %s",
 			   gs_app_get_unique_id (app), error->message);

--- a/lib/gs-plugin-loader.c
+++ b/lib/gs-plugin-loader.c
@@ -2024,8 +2024,8 @@ pending_app_state_changed_cb (GsApp *app,
 			      GParamSpec *pspec,
 			      GsPluginLoader *plugin_loader)
 {
-	if (gs_app_get_state (app) != AS_APP_STATE_INSTALLING ||
-	    gs_app_get_state (app) != AS_APP_STATE_QUEUED_FOR_INSTALL)
+	if (gs_app_get_state (app) == AS_APP_STATE_INSTALLING ||
+	    gs_app_get_state (app) == AS_APP_STATE_QUEUED_FOR_INSTALL)
 		return;
 
 	remove_app_from_install_queue (plugin_loader, app);

--- a/lib/gs-self-test.c
+++ b/lib/gs-self-test.c
@@ -800,7 +800,11 @@ gs_app_list_related_func (void)
 int
 main (int argc, char **argv)
 {
-	g_test_init (&argc, &argv, NULL);
+	g_test_init (&argc, &argv,
+#if GLIB_CHECK_VERSION(2, 60, 0)
+		     G_TEST_OPTION_ISOLATE_DIRS,
+#endif
+		     NULL);
 	g_setenv ("G_MESSAGES_DEBUG", "all", TRUE);
 
 	/* only critical and error are fatal */

--- a/lib/gs-test.h
+++ b/lib/gs-test.h
@@ -14,5 +14,6 @@ G_BEGIN_DECLS
 void	 gs_test_flush_main_context		(void);
 gchar	*gs_test_get_filename			(const gchar	*testdatadir,
 						 const gchar	*filename);
+void	 gs_test_expose_icon_theme_paths	(void);
 
 G_END_DECLS

--- a/meson.build
+++ b/meson.build
@@ -229,6 +229,9 @@ test_env = [
   'GSETTINGS_BACKEND=memory',
   'MALLOC_CHECK_=2',
   'GS_UNIT_TESTS_SKIP_MOGWAI=1',
+  # FIXME: Use a mock service for parental controls
+  # https://phabricator.endlessm.com/T30645
+  'FLATPAK_SKIP_PARENTAL_CONTROLS_NO_SYSTEM_BUS=1',
 ]
 
 subdir('data')

--- a/meson.build
+++ b/meson.build
@@ -228,6 +228,7 @@ test_env = [
   'GSETTINGS_SCHEMA_DIR=@0@/data/'.format(meson.build_root()),
   'GSETTINGS_BACKEND=memory',
   'MALLOC_CHECK_=2',
+  'GS_UNIT_TESTS_SKIP_MOGWAI=1',
 ]
 
 subdir('data')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
-option('tests', type : 'boolean', value : false, description : 'enable tests')
+option('tests', type : 'boolean', value : true, description : 'enable tests')
 option('gspell', type : 'boolean', value : false, description : 'enable gspell')
 option('gnome_desktop', type : 'boolean', value : true, description : 'enable gnome-desktop')
 option('man', type : 'boolean', value : true, description : 'enable man pages')

--- a/plugins/core/gs-plugin-icons.c
+++ b/plugins/core/gs-plugin-icons.c
@@ -26,14 +26,27 @@ struct GsPluginData {
 	GHashTable		*icon_theme_paths;
 };
 
+static void gs_plugin_icons_add_theme_path (GsPlugin *plugin, const gchar *path);
+
 void
 gs_plugin_initialize (GsPlugin *plugin)
 {
 	GsPluginData *priv = gs_plugin_alloc_data (plugin, sizeof(GsPluginData));
+	const gchar *test_search_path;
+
 	priv->icon_theme = gtk_icon_theme_new ();
 	gtk_icon_theme_set_screen (priv->icon_theme, gdk_screen_get_default ());
 	priv->icon_theme_paths = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
 	g_mutex_init (&priv->icon_theme_lock);
+
+	test_search_path = g_getenv ("GS_SELF_TEST_ICON_THEME_PATH");
+	if (test_search_path != NULL) {
+		g_auto(GStrv) dirs = g_strsplit (test_search_path, ":", -1);
+
+		/* add_theme_path() prepends, so we have to iterate in reverse to preserve order */
+		for (gsize i = g_strv_length (dirs); i > 0; i--)
+			gs_plugin_icons_add_theme_path (plugin, dirs[i - 1]);
+	}
 
 	/* needs remote icons downloaded */
 	gs_plugin_add_rule (plugin, GS_PLUGIN_RULE_RUN_AFTER, "appstream");

--- a/plugins/core/gs-self-test.c
+++ b/plugins/core/gs-self-test.c
@@ -193,7 +193,22 @@ main (int argc, char **argv)
 		NULL
 	};
 
-	g_test_init (&argc, &argv, NULL);
+	/* While we use %G_TEST_OPTION_ISOLATE_DIRS to create temporary directories
+	 * for each of the tests, we want to use the system MIME registry, assuming
+	 * that it exists and correctly has shared-mime-info installed. */
+#if GLIB_CHECK_VERSION(2, 60, 0)
+	g_content_type_set_mime_dirs (NULL);
+#endif
+
+	/* Similarly, add the system-wide icon theme path before it’s
+	 * overwritten by %G_TEST_OPTION_ISOLATE_DIRS. */
+	gs_test_expose_icon_theme_paths ();
+
+	g_test_init (&argc, &argv,
+#if GLIB_CHECK_VERSION(2, 60, 0)
+		     G_TEST_OPTION_ISOLATE_DIRS,
+#endif
+		     NULL);
 	g_setenv ("G_MESSAGES_DEBUG", "all", TRUE);
 
 	/* Use a common cache directory for all tests, since the appstream

--- a/plugins/dpkg/gs-self-test.c
+++ b/plugins/dpkg/gs-self-test.c
@@ -59,7 +59,18 @@ main (int argc, char **argv)
 		NULL
 	};
 
-	g_test_init (&argc, &argv, NULL);
+	/* While we use %G_TEST_OPTION_ISOLATE_DIRS to create temporary directories
+	 * for each of the tests, we want to use the system MIME registry, assuming
+	 * that it exists and correctly has shared-mime-info installed. */
+#if GLIB_CHECK_VERSION(2, 60, 0)
+	g_content_type_set_mime_dirs (NULL);
+#endif
+
+	g_test_init (&argc, &argv,
+#if GLIB_CHECK_VERSION(2, 60, 0)
+		     G_TEST_OPTION_ISOLATE_DIRS,
+#endif
+		     NULL);
 	g_setenv ("G_MESSAGES_DEBUG", "all", TRUE);
 
 	/* only critical and error are fatal */

--- a/plugins/dummy/gs-self-test.c
+++ b/plugins/dummy/gs-self-test.c
@@ -691,7 +691,7 @@ gs_plugins_dummy_limit_parallel_ops_func (GsPluginLoader *plugin_loader)
 
 	/* since we have only 1 parallel installation op possible,
 	 * verify the last operations are pending */
-	g_assert_cmpint (gs_app_get_state (app2), ==, AS_APP_STATE_AVAILABLE);
+	g_assert_cmpint (gs_app_get_state (app2), ==, AS_APP_STATE_QUEUED_FOR_INSTALL);
 	g_assert_cmpint (gs_app_get_pending_action (app2), ==, GS_PLUGIN_ACTION_INSTALL);
 	g_assert_cmpint (gs_app_get_state (app3), ==, AS_APP_STATE_UPDATABLE_LIVE);
 	g_assert_cmpint (gs_app_get_pending_action (app3), ==, GS_PLUGIN_ACTION_UPDATE);

--- a/plugins/dummy/gs-self-test.c
+++ b/plugins/dummy/gs-self-test.c
@@ -388,7 +388,7 @@ gs_plugins_dummy_installed_func (GsPluginLoader *plugin_loader)
 	g_assert (!gs_app_has_category (app, "ImageProcessing"));
 	g_assert (gs_app_get_menu_path (app) != NULL);
 	menu_path = g_strjoinv ("->", gs_app_get_menu_path (app));
-	g_assert_cmpstr (menu_path, ==, "Audio & Video->Music Players");
+	g_assert_cmpstr (menu_path, ==, "Multimedia->Music Players");
 
 	/* check addon */
 	addons = gs_app_get_addons (app);

--- a/plugins/dummy/gs-self-test.c
+++ b/plugins/dummy/gs-self-test.c
@@ -467,6 +467,11 @@ gs_plugins_dummy_hang_func (GsPluginLoader *plugin_loader)
 	g_autoptr(GsAppList) list = NULL;
 	g_autoptr(GsPluginJob) plugin_job = NULL;
 
+	/* Endless patch: we can't test timeouts of plugin jobs because we disable
+	 * them */
+	g_test_skip ("Timeouts disabled; see https://phabricator.endlessm.com/T28481");
+	return;
+
 	/* drop all caches */
 	gs_utils_rmtree (g_getenv ("GS_SELF_TEST_CACHEDIR"), NULL);
 	gs_plugin_loader_setup_again (plugin_loader);

--- a/plugins/dummy/gs-self-test.c
+++ b/plugins/dummy/gs-self-test.c
@@ -737,7 +737,22 @@ main (int argc, char **argv)
 		NULL
 	};
 
-	g_test_init (&argc, &argv, NULL);
+	/* While we use %G_TEST_OPTION_ISOLATE_DIRS to create temporary directories
+	 * for each of the tests, we want to use the system MIME registry, assuming
+	 * that it exists and correctly has shared-mime-info installed. */
+#if GLIB_CHECK_VERSION(2, 60, 0)
+	g_content_type_set_mime_dirs (NULL);
+#endif
+
+	/* Similarly, add the system-wide icon theme path before it’s
+	 * overwritten by %G_TEST_OPTION_ISOLATE_DIRS. */
+	gs_test_expose_icon_theme_paths ();
+
+	g_test_init (&argc, &argv,
+#if GLIB_CHECK_VERSION(2, 60, 0)
+		     G_TEST_OPTION_ISOLATE_DIRS,
+#endif
+		     NULL);
 	g_setenv ("G_MESSAGES_DEBUG", "all", TRUE);
 	g_setenv ("GS_XMLB_VERBOSE", "1", TRUE);
 

--- a/plugins/fedora-langpacks/gs-self-test.c
+++ b/plugins/fedora-langpacks/gs-self-test.c
@@ -21,6 +21,13 @@ gs_plugins_fedora_langpacks_func (GsPluginLoader *plugin_loader)
 	g_autoptr(GsApp) app = NULL;
 	g_autoptr(GsAppList) list = NULL;
 	g_autoptr(GsPluginJob) plugin_job = NULL;
+	g_autoptr(GsOsRelease) os_release = NULL;
+
+	os_release = gs_os_release_new (NULL);
+	if (g_strcmp0 (gs_os_release_get_id (os_release), "fedora") != 0) {
+		g_test_skip ("not on fedora");
+		return;
+	}
 
 	/* start with a clean slate */
 	cachefn = gs_utils_get_cache_filename ("langpacks", "langpacks-ja",

--- a/plugins/fedora-langpacks/gs-self-test.c
+++ b/plugins/fedora-langpacks/gs-self-test.c
@@ -63,7 +63,11 @@ main (int argc, char **argv)
 		NULL
 	};
 
-	g_test_init (&argc, &argv, NULL);
+	g_test_init (&argc, &argv,
+#if GLIB_CHECK_VERSION(2, 60, 0)
+		     G_TEST_OPTION_ISOLATE_DIRS,
+#endif
+		     NULL);
 	g_setenv ("G_MESSAGES_DEBUG", "all", TRUE);
 
 	/* only critical and error are fatal */

--- a/plugins/flatpak/gs-self-test.c
+++ b/plugins/flatpak/gs-self-test.c
@@ -204,6 +204,16 @@ gs_plugins_flatpak_repo_func (GsPluginLoader *plugin_loader)
 }
 
 static void
+progress_notify_cb (GObject *obj, GParamSpec *pspec, gpointer user_data)
+{
+	gboolean *seen_unknown = user_data;
+	GsApp *app = GS_APP (obj);
+
+	if (gs_app_get_progress (app) == GS_APP_PROGRESS_UNKNOWN)
+		*seen_unknown = TRUE;
+}
+
+static void
 gs_plugins_flatpak_app_with_runtime_func (GsPluginLoader *plugin_loader)
 {
 	GsApp *app;
@@ -228,6 +238,8 @@ gs_plugins_flatpak_app_with_runtime_func (GsPluginLoader *plugin_loader)
 	g_autoptr(GsAppList) list = NULL;
 	g_autoptr(GsAppList) sources = NULL;
 	g_autoptr(GsPluginJob) plugin_job = NULL;
+	gulong signal_id;
+	gboolean seen_unknown;
 
 	/* drop all caches */
 	gs_utils_rmtree (g_getenv ("GS_SELF_TEST_CACHEDIR"), NULL);
@@ -421,7 +433,13 @@ gs_plugins_flatpak_app_with_runtime_func (GsPluginLoader *plugin_loader)
 	g_assert_true (!g_file_test (metadata_fn, G_FILE_TEST_IS_REGULAR));
 	g_assert_true (!g_file_test (desktop_fn, G_FILE_TEST_IS_REGULAR));
 
-	/* install again, to check whether the progress gets initialized */
+	/* install again, to check whether the progress gets initialized;
+	 * since installation happens in another thread, we have to monitor all
+	 * changes to the progress and see if we see the one we want */
+	seen_unknown = (gs_app_get_progress (app) == GS_APP_PROGRESS_UNKNOWN);
+	signal_id = g_signal_connect (app, "notify::progress",
+				      G_CALLBACK (progress_notify_cb), &seen_unknown);
+
 	g_object_unref (plugin_job);
 	plugin_job = gs_plugin_job_newv (GS_PLUGIN_ACTION_INSTALL,
 					 "app", app,
@@ -429,13 +447,15 @@ gs_plugins_flatpak_app_with_runtime_func (GsPluginLoader *plugin_loader)
 	ret = gs_plugin_loader_job_action (plugin_loader, plugin_job, NULL, &error);
 
 	/* progress should be set to unknown right before installing */
-	gs_test_flush_main_context ();
-	g_assert_cmpint (gs_app_get_progress (app), ==, GS_APP_PROGRESS_UNKNOWN);
+	while (!seen_unknown)
+		g_main_context_iteration (NULL, TRUE);
+	g_assert_true (seen_unknown);
 	g_assert_no_error (error);
 	g_assert_true (ret);
 	g_assert_cmpint (gs_app_get_state (app), ==, AS_APP_STATE_INSTALLED);
 	g_assert_cmpstr (gs_app_get_version (app), ==, "1.2.3");
 	g_assert_cmpint (gs_app_get_progress (app), ==, GS_APP_PROGRESS_UNKNOWN);
+	g_signal_handler_disconnect (app, signal_id);
 
 	/* remove the application */
 	g_object_unref (plugin_job);

--- a/plugins/flatpak/gs-self-test.c
+++ b/plugins/flatpak/gs-self-test.c
@@ -1816,7 +1816,22 @@ main (int argc, char **argv)
 		NULL
 	};
 
-	g_test_init (&argc, &argv, NULL);
+	/* While we use %G_TEST_OPTION_ISOLATE_DIRS to create temporary directories
+	 * for each of the tests, we want to use the system MIME registry, assuming
+	 * that it exists and correctly has shared-mime-info installed. */
+#if GLIB_CHECK_VERSION(2, 60, 0)
+	g_content_type_set_mime_dirs (NULL);
+#endif
+
+	/* Similarly, add the system-wide icon theme path before it’s
+	 * overwritten by %G_TEST_OPTION_ISOLATE_DIRS. */
+	gs_test_expose_icon_theme_paths ();
+
+	g_test_init (&argc, &argv,
+#if GLIB_CHECK_VERSION(2, 60, 0)
+		     G_TEST_OPTION_ISOLATE_DIRS,
+#endif
+		     NULL);
 	g_setenv ("G_MESSAGES_DEBUG", "all", TRUE);
 	g_setenv ("GS_XMLB_VERBOSE", "1", TRUE);
 	g_setenv ("GS_SELF_TEST_PLUGIN_ERROR_FAIL_HARD", "1", TRUE);

--- a/plugins/fwupd/gs-self-test.c
+++ b/plugins/fwupd/gs-self-test.c
@@ -67,7 +67,18 @@ main (int argc, char **argv)
 		NULL
 	};
 
-	g_test_init (&argc, &argv, NULL);
+	/* While we use %G_TEST_OPTION_ISOLATE_DIRS to create temporary directories
+	 * for each of the tests, we want to use the system MIME registry, assuming
+	 * that it exists and correctly has shared-mime-info installed. */
+#if GLIB_CHECK_VERSION(2, 60, 0)
+	g_content_type_set_mime_dirs (NULL);
+#endif
+
+	g_test_init (&argc, &argv,
+#if GLIB_CHECK_VERSION(2, 60, 0)
+		     G_TEST_OPTION_ISOLATE_DIRS,
+#endif
+		     NULL);
 	g_setenv ("G_MESSAGES_DEBUG", "all", TRUE);
 
 	/* only critical and error are fatal */

--- a/plugins/modalias/gs-self-test.c
+++ b/plugins/modalias/gs-self-test.c
@@ -54,7 +54,11 @@ main (int argc, char **argv)
 		NULL
 	};
 
-	g_test_init (&argc, &argv, NULL);
+	g_test_init (&argc, &argv,
+#if GLIB_CHECK_VERSION(2, 60, 0)
+		     G_TEST_OPTION_ISOLATE_DIRS,
+#endif
+		     NULL);
 	g_setenv ("G_MESSAGES_DEBUG", "all", TRUE);
 	g_setenv ("GS_SELF_TEST_DUMMY_ENABLE", "1", TRUE);
 

--- a/plugins/packagekit/gs-self-test.c
+++ b/plugins/packagekit/gs-self-test.c
@@ -243,7 +243,11 @@ main (int argc, char **argv)
 		NULL
 	};
 
-	g_test_init (&argc, &argv, NULL);
+	g_test_init (&argc, &argv,
+#if GLIB_CHECK_VERSION(2, 60, 0)
+		     G_TEST_OPTION_ISOLATE_DIRS,
+#endif
+		     NULL);
 	g_setenv ("G_MESSAGES_DEBUG", "all", TRUE);
 
 	/* only critical and error are fatal */

--- a/plugins/repos/gs-self-test.c
+++ b/plugins/repos/gs-self-test.c
@@ -46,7 +46,11 @@ main (int argc, char **argv)
 		NULL
 	};
 
-	g_test_init (&argc, &argv, NULL);
+	g_test_init (&argc, &argv,
+#if GLIB_CHECK_VERSION(2, 60, 0)
+		     G_TEST_OPTION_ISOLATE_DIRS,
+#endif
+		     NULL);
 	g_setenv ("G_MESSAGES_DEBUG", "all", TRUE);
 
 	/* dummy data */

--- a/plugins/snap/gs-self-test.c
+++ b/plugins/snap/gs-self-test.c
@@ -343,7 +343,11 @@ main (int argc, char **argv)
 		NULL
 	};
 
-	g_test_init (&argc, &argv, NULL);
+	g_test_init (&argc, &argv,
+#if GLIB_CHECK_VERSION(2, 60, 0)
+		     G_TEST_OPTION_ISOLATE_DIRS,
+#endif
+		     NULL);
 	g_setenv ("G_MESSAGES_DEBUG", "all", TRUE);
 
 	/* only critical and error are fatal */

--- a/src/gs-self-test.c
+++ b/src/gs-self-test.c
@@ -94,7 +94,11 @@ gs_content_rating_from_locale (void)
 int
 main (int argc, char **argv)
 {
-	g_test_init (&argc, &argv, NULL);
+	g_test_init (&argc, &argv,
+#if GLIB_CHECK_VERSION(2, 60, 0)
+		     G_TEST_OPTION_ISOLATE_DIRS,
+#endif
+		     NULL);
 	g_setenv ("G_MESSAGES_DEBUG", "all", TRUE);
 
 	/* only critical and error are fatal */


### PR DESCRIPTION
Make the CI execute unit tests rather than merely building
gnome-software for downstream PRs. In T29985 I landed fixes for the
flatpak extension unit tests and that brought this issue to light.

This commit can be squashed into "build: Override meson's default
options" during the next rebase.

https://phabricator.endlessm.com/T21809