### PR TITLE
debian: Ensure tests are actually run

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -105,9 +105,6 @@ override_dh_missing:
 override_dh_makeshlibs:
 	dh_makeshlibs -Xlibgs_plugin
 
-# DISABLED
-override_dh_auto_test:
-
 override_dh_gencontrol:
 ifeq ($(shell dpkg-vendor --query vendor),Ubuntu)
 	dh_gencontrol -- -Vplugin:Recommends='gnome-software-plugin-snap [linux-any]'


### PR DESCRIPTION
Setting -Dtests=true isn't enough to enable the unit tests in OBS builds
(as I did in the last commit). We also need to avoid overriding
dh_auto_test.

https://phabricator.endlessm.com/T21809