### PR TITLE
flatpak: Fix offline installation

### DIFF
--- a/plugins/flatpak/gs-plugin-flatpak.c
+++ b/plugins/flatpak/gs-plugin-flatpak.c
@@ -781,8 +781,18 @@ static gboolean
 app_has_local_source (GsApp *app)
 {
 	const gchar *url = gs_app_get_origin_hostname (app);
-	return gs_app_has_category (app, "usb") ||
-		(url != NULL && g_str_has_prefix (url, "file://"));
+
+	if (gs_app_has_category (app, "usb"))
+		return TRUE;
+
+	if (gs_flatpak_app_get_file_kind (app) == GS_FLATPAK_APP_FILE_KIND_BUNDLE)
+		return TRUE;
+
+	if (gs_flatpak_app_get_file_kind (app) == GS_FLATPAK_APP_FILE_KIND_REF &&
+	    g_strcmp0 (url, "localhost") == 0)
+		return TRUE;
+
+	return FALSE;
 }
 
 gboolean


### PR DESCRIPTION
This commit fixes offline installation of .flatpak bundles, and fixes
offline installation of .flatpakref files that point to a file:// URL.
Currently such installations would be forever stuck in the "Pending
installation..." state. The check for a file:// prefix on the
gs_app_get_origin_hostname() return value is wrong because in case a
file:// URL is set, "localhost" is returned. See gs_app_func() in
lib/gs-self-test.c.

One might wonder if this could be implemented by checking if
gs_app_get_local_file() returns a non-NULL value, but
gs_app_set_local_file() is called for flatpakref files which are not
always offline friendly.

https://phabricator.endlessm.com/T30749