### PR TITLE
T30217 appstream error handling

### DIFF
--- a/lib/gs-plugin-loader.c
+++ b/lib/gs-plugin-loader.c
@@ -555,6 +555,9 @@ gs_plugin_loader_call_vfunc (GsPluginLoaderHelper *helper,
 	if (func == NULL)
 		return TRUE;
 
+	/* at least one plugin supports this vfunc */
+	helper->anything_ran = TRUE;
+
 	/* fallback if unset */
 	if (app == NULL)
 		app = gs_plugin_job_get_app (helper->plugin_job);
@@ -862,8 +865,6 @@ gs_plugin_loader_call_vfunc (GsPluginLoaderHelper *helper,
 					   gs_plugin_action_to_string (action));
 	}
 
-	/* success */
-	helper->anything_ran = TRUE;
 	return TRUE;
 }
 

--- a/plugins/core/gs-appstream.c
+++ b/plugins/core/gs-appstream.c
@@ -900,18 +900,23 @@ gs_appstream_refine_app (GsPlugin *plugin,
 		for (guint i = 0; i < bundles->len; i++) {
 			XbNode *bundle = g_ptr_array_index (bundles, i);
 			const gchar *kind = xb_node_get_attr (bundle, "type");
-			gs_app_add_source (app, xb_node_get_text (bundle));
+			const gchar *bundle_id = xb_node_get_text (bundle);
+
+			if (bundle_id == NULL || kind == NULL)
+				continue;
+
+			gs_app_add_source (app, bundle_id);
 			gs_app_set_bundle_kind (app, as_bundle_kind_from_string (kind));
 
 			/* get the type/name/arch/branch */
 			if (gs_app_get_bundle_kind (app) == AS_BUNDLE_KIND_FLATPAK) {
-				g_auto(GStrv) split = g_strsplit (xb_node_get_text (bundle), "/", -1);
+				g_auto(GStrv) split = g_strsplit (bundle_id, "/", -1);
 				if (g_strv_length (split) != 4) {
 					g_set_error (error,
 						     GS_PLUGIN_ERROR,
 						     GS_PLUGIN_ERROR_NOT_SUPPORTED,
 						     "invalid ID %s for a flatpak ref",
-						     xb_node_get_text (bundle));
+						     bundle_id);
 					return FALSE;
 				}
 


### PR DESCRIPTION
Trivial backport of https://gitlab.gnome.org/GNOME/gnome-software/-/commit/a93ae7330f and https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/521 to improve error handling of failed downloads.

https://phabricator.endlessm.com/T30217