### PR TITLE
flatpak: Use new flatpak API to automatically remove EOL runtimes

### DIFF
--- a/plugins/flatpak/gs-plugin-flatpak.c
+++ b/plugins/flatpak/gs-plugin-flatpak.c
@@ -1198,6 +1198,11 @@ gs_plugin_flatpak_update (GsPlugin *plugin,
 		}
 	}
 
+#if FLATPAK_CHECK_VERSION(1, 8, 2)
+	/* automatically clean up unused EOL runtimes when updating */
+	flatpak_transaction_set_include_unused_uninstall_ops (transaction, TRUE);
+#endif
+
 	if (!gs_flatpak_transaction_run (transaction, cancellable, error)) {
 		for (guint i = 0; i < gs_app_list_length (list_tmp); i++) {
 			GsApp *app = gs_app_list_index (list_tmp, i);


### PR DESCRIPTION
When constructing the update transaction, tell flatpak that it can clean
up unused EOL runtimes during the transaction.

We don't have any UI for that, which hopefully should be fine.

Note from downstream cherry-pick: Changed Flatpak version check from
  1.9.1 to 1.8.2, since we backported the relevant Flatpak API:
  https://github.com/endlessm/flatpak/pull/241

(cherry picked from commit b01c36b7509c336ba628c76e2d08b3f88a63d310)

https://phabricator.endlessm.com/T22790