### PR TITLE
Revert "debian: List available firmware updates in gnome-software"

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,3 @@
-gnome-software (3.38.0-1endless2) eos; urgency=medium
-
-  * debian: List available firmware updates in gnome-software (T29506)
-    - Enable fwupd
-    - Enable libfwupd-dev
-
- -- Jian-Hong Pan <jhp@endlessos.org>  Mon, 26 Oct 2020 11:46:16 +0800
-
 gnome-software (3.38.0-1endless1) eos; urgency=medium
 
   * Drop Discovery Feed support (T30294)

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,6 @@ Build-Depends: appstream,
                gtk-doc-tools,
                libappstream-glib-dev (>= 0.7.14),
                libflatpak-dev (>= 1.6.2+dev54.f333129-2) [amd64 arm64 armel armhf i386 mips mipsel mips64el ppc64el s390x hppa powerpc powerpcspe ppc64],
-               libfwupd-dev (>= 1.0.3) [linux-any],
                libglib2.0-dev (>= 2.56.0),
                libgnome-desktop-3-dev (>= 3.18.0),
                libgoa-1.0-dev,
@@ -56,7 +55,7 @@ Depends: appstream,
          ${misc:Depends},
          ${shlibs:Depends}
 Conflicts: sessioninstaller
-Recommends: fwupd [linux-any], ${plugin:Recommends},
+Recommends: ${plugin:Recommends},
 Suggests: gnome-software-plugin-flatpak [amd64 arm64 armel armhf i386 mips mipsel mips64el ppc64el s390x hppa powerpc powerpcspe ppc64],
           ${plugin:Suggests}
 Description: Software Center for GNOME

--- a/debian/control.in
+++ b/debian/control.in
@@ -13,7 +13,6 @@ Build-Depends: appstream,
                gtk-doc-tools,
                libappstream-glib-dev (>= 0.7.14),
                libflatpak-dev (>= 1.6.2+dev54.f333129-2) [amd64 arm64 armel armhf i386 mips mipsel mips64el ppc64el s390x hppa powerpc powerpcspe ppc64],
-               libfwupd-dev (>= 1.0.3) [linux-any],
                libglib2.0-dev (>= 2.56.0),
                libgnome-desktop-3-dev (>= 3.18.0),
                libgoa-1.0-dev,
@@ -52,7 +51,7 @@ Depends: appstream,
          ${misc:Depends},
          ${shlibs:Depends}
 Conflicts: sessioninstaller
-Recommends: fwupd [linux-any], ${plugin:Recommends},
+Recommends: ${plugin:Recommends},
 Suggests: gnome-software-plugin-flatpak [amd64 arm64 armel armhf i386 mips mipsel mips64el ppc64el s390x hppa powerpc powerpcspe ppc64],
           ${plugin:Suggests}
 Description: Software Center for GNOME

--- a/debian/rules
+++ b/debian/rules
@@ -50,7 +50,7 @@ endif
 GS_CONFIGURE_FLAGS += \
 	-Deos_updater=true \
 	-Dexternal_appstream=true \
-	-Dfwupd=true \
+	-Dfwupd=false \
 	-Dgudev=false \
 	-Dhardcoded_popular=false \
 	-Dmalcontent=true \


### PR DESCRIPTION
Reverts endlessm/gnome-software#532

https://phabricator.endlessm.com/T29506