### PR TITLE
eos: Remove eos-link-* special handling from blocklist

### DIFF
--- a/plugins/eos-blocklist/gs-plugin-eos-blocklist.c
+++ b/plugins/eos-blocklist/gs-plugin-eos-blocklist.c
@@ -842,10 +842,6 @@ gs_plugin_eos_blocklist_if_needed (GsPlugin *plugin, GsApp *app)
 		g_debug ("Blocklisting '%s': it's a compulsory, non-desktop app",
 			 gs_app_get_unique_id (app));
 		blocklist_app = TRUE;
-	} else if (g_str_has_prefix (id, "eos-link-")) {
-		g_debug ("Blocklisting '%s': app is an eos-link",
-			 gs_app_get_unique_id (app));
-		blocklist_app = TRUE;
 	} else if (gs_app_has_quirk (app, GS_APP_QUIRK_COMPULSORY) &&
 		   g_strcmp0 (id, "org.gnome.Software.desktop") == 0) {
 		g_debug ("Blocklisting '%s': app is GNOME Software itself",


### PR DESCRIPTION
We are removing all web links from the OS, let's remove the special handling here also.

Depends on whether we are also dropping image personalities' specific web links - see https://github.com/endlessm/eos-image-builder/pull/975.

https://phabricator.endlessm.com/T31560