### PR TITLE
T31351 Correctly set interactive status for various operations

### DIFF
--- a/src/gs-page.c
+++ b/src/gs-page.c
@@ -344,7 +344,7 @@ gs_page_copy_app (GsPage *page,
 		plugin_job = gs_plugin_job_newv (helper->action,
 						 "app", helper->app,
 						 "copy-dest", copy_dest,
-						 "interactive", TRUE,
+						 "interactive", (interaction == GS_SHELL_INTERACTION_FULL),
 						 NULL);
 
 		gs_plugin_loader_job_process_async (priv->plugin_loader,
@@ -375,7 +375,7 @@ gs_page_copy_os (GsPage *page,
 
 	plugin_job = gs_plugin_job_newv (helper->action,
 					 "copy-dest", copy_dest,
-					 "interactive", TRUE,
+					 "interactive", (interaction == GS_SHELL_INTERACTION_FULL),
 					 NULL);
 
 	gs_plugin_loader_job_process_async (priv->plugin_loader,

--- a/src/gs-page.c
+++ b/src/gs-page.c
@@ -313,7 +313,7 @@ gs_page_install_app (GsPage *page,
 	helper->interaction = interaction;
 
 	plugin_job = gs_plugin_job_newv (helper->action,
-					 "interactive", TRUE,
+					 "interactive", (interaction == GS_SHELL_INTERACTION_FULL),
 					 "app", helper->app,
 					 NULL);
 	gs_plugin_loader_job_process_async (priv->plugin_loader,


### PR DESCRIPTION
This is a trivial backport of https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/666 from upstream, plus an additional commit to do the same to the USB operations, which are not yet upstream.

https://phabricator.endlessm.com/T31351