### PR TITLE
eos: Stop marking all non-flatpak apps as installed and compulsory

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -122,13 +122,13 @@ gs_plugin_eos_refine_core_app (GsApp *app)
 	if (gs_app_get_kind (app) == AS_APP_KIND_OS_UPGRADE)
 		return;
 
-	/* we only allow to remove flatpak apps */
-	gs_app_add_quirk (app, GS_APP_QUIRK_COMPULSORY);
-
+	/* Hide non-installed apt packages, as they can’t actually be installed.
+	 * The installed ones are pre-installed in the image, and can’t be
+	 * removed. We only allow flatpaks to be removed. */
 	if (!gs_app_is_installed (app)) {
-		/* forcibly set the installed state */
-		gs_app_set_state (app, AS_APP_STATE_UNKNOWN);
-		gs_app_set_state (app, AS_APP_STATE_INSTALLED);
+		gs_app_add_quirk (app, GS_APP_QUIRK_HIDE_EVERYWHERE);
+	} else {
+		gs_app_add_quirk (app, GS_APP_QUIRK_COMPULSORY);
 	}
 }
 


### PR DESCRIPTION
Since adding the upstream Debian repositories to our apt configuration,
`appstreamcli refresh-cache` has been pulling in appstream for all the
Debian repositories, via the configuration in
`/etc/apt/apt.conf.d/50appstream`.

This appstream data includes many applications which are available in
apt but which are not installed on the image. It also includes a few
applications which are installed on the image and which aren’t removable.

Previously, when this data was unavailable, the `eos` plugin in
gnome-software could safely assume that all non-flatpak apps were built
in to the image, and hence were both installed, and compulsory.

That situation has now changed, so change the logic to:
 * Mark any non-flatpak app as compulsory (not uninstallable) if it’s
   installed.
 * Hide any other non-flatpak app.

This relies on the apt metadata about which apps are installed and which
are not yet installed to be correct, which I believe it now is.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T31490