### PR TITLE
T31562 Cherry-pick some patches from gnome-3-38 branch

### DIFF
--- a/plugins/flatpak/gs-flatpak.c
+++ b/plugins/flatpak/gs-flatpak.c
@@ -3044,7 +3044,7 @@ gs_flatpak_refine_appstream (GsFlatpak *self,
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(XbNode) component = NULL;
 
-	if (origin == NULL || source == NULL)
+	if (origin == NULL || source == NULL || gs_flatpak_app_get_ref_name (app) == NULL)
 		return TRUE;
 
 	/* find using source and origin */

--- a/src/gs-app-row.c
+++ b/src/gs-app-row.c
@@ -481,7 +481,10 @@ child_unrevealed (GObject *revealer, GParamSpec *pspec, gpointer user_data)
 	GsAppRow *app_row = user_data;
 	GsAppRowPrivate *priv = gs_app_row_get_instance_private (app_row);
 
-	/* return immediately if we are in destruction */
+	/* return immediately if we are in destruction (this doesn't, however,
+	 * catch the case where we are being removed from a container without
+	 * having been destroyed first.)
+	 */
 	if (priv->app == NULL)
 		return;
 

--- a/src/gs-app-row.c
+++ b/src/gs-app-row.c
@@ -479,6 +479,11 @@ static void
 child_unrevealed (GObject *revealer, GParamSpec *pspec, gpointer user_data)
 {
 	GsAppRow *app_row = user_data;
+	GsAppRowPrivate *priv = gs_app_row_get_instance_private (app_row);
+
+	/* return immediately if we are in destruction */
+	if (priv->app == NULL)
+		return;
 
 	g_signal_emit (app_row, signals[SIGNAL_UNREVEALED], 0);
 }

--- a/src/gs-updates-section.c
+++ b/src/gs-updates-section.c
@@ -73,7 +73,7 @@ _row_unrevealed_cb (GObject *row, GParamSpec *pspec, gpointer data)
 	list = gtk_widget_get_parent (GTK_WIDGET (row));
 	if (list == NULL)
 		return;
-	gtk_container_remove (GTK_CONTAINER (list), GTK_WIDGET (row));
+	gtk_widget_destroy (GTK_WIDGET (row));
 }
 
 static void
@@ -132,7 +132,10 @@ gs_updates_section_remove_all (GsUpdatesSection *self)
 	children = gtk_container_get_children (GTK_CONTAINER (self));
 	for (GList *l = children; l != NULL; l = l->next) {
 		GtkWidget *w = GTK_WIDGET (l->data);
-		gtk_container_remove (GTK_CONTAINER (self), w);
+		/* Destroying, rather than just removing, prevents the ::unrevealed
+		 * signal from being emitted, which would cause unfortunate reentrancy.
+		 */
+		gtk_widget_destroy (w);
 	}
 	gs_app_list_remove_all (self->list);
 	gtk_widget_hide (GTK_WIDGET (self));


### PR DESCRIPTION
This is the result of:
```
$ git cherry-pick c0a287cd7620274010fda1e9b998bb41ec610bb5 a9f1143e900632ed57eabe2da11f684cf0418972 c28636404e36ee6b8d6a0a06474a70aa26aafe5b
Auto-merging plugins/flatpak/gs-flatpak.c
[T31562-38-update 02e008781] flatpak: Fix assertation in new libflatpak version
 Author: Richard Hughes <richard@hughsie.com>
 Date: Mon Feb 8 09:56:55 2021 +0000
 1 file changed, 1 insertion(+), 1 deletion(-)
Auto-merging src/gs-app-row.c
[T31562-38-update 781b7c8bc] app row: Avoid emitting "unrevealed" signal when in destruction
 Author: Kalev Lember <klember@redhat.com>
 Date: Tue Oct 13 16:46:11 2020 +0200
 1 file changed, 5 insertions(+)
Auto-merging src/gs-updates-section.c
Auto-merging src/gs-app-row.c
[T31562-38-update 13532dac0] gs-updates-section.c: destroy() rows rather than just removing
 Author: Owen W. Taylor <otaylor@fishsoup.net>
 Date: Tue Oct 13 12:14:34 2020 -0400
 2 files changed, 9 insertions(+), 3 deletions(-)
```

I haven’t tested it; I think these changes are trivial enough (and the cherry pick was uneventful enough) that smoketesting after it lands on `master` will be sufficient.

https://phabricator.endlessm.com/T31562