### PR TITLE
Add build dependency on policykit-1

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -33,6 +33,7 @@ Build-Depends: appstream,
                libxmlb-dev (>= 0.1.7),
                meson (>= 0.47),
                pkg-config,
+               policykit-1,
                valgrind [amd64 arm64 armhf i386 mips mips64 mips64el mipsel powerpc ppc64 ppc64el s390x],
                xsltproc
 Build-Depends-Indep: appstream-glib-doc <!nodoc>,

--- a/debian/control.in
+++ b/debian/control.in
@@ -29,6 +29,7 @@ Build-Depends: appstream,
                libxmlb-dev (>= 0.1.7),
                meson (>= 0.47),
                pkg-config,
+               policykit-1,
                valgrind [amd64 arm64 armhf i386 mips mips64 mips64el mipsel powerpc ppc64 ppc64el s390x],
                xsltproc
 Build-Depends-Indep: appstream-glib-doc <!nodoc>,


### PR DESCRIPTION
The build is failing with:

```
msgfmt: cannot locate ITS rules for data/org.gnome.software.external-appstream.policy.in
```

This is because the ITS rules come from policykit-1 and the translations
can't be completed without them. This was fixed in Debian in 3.38.0-2.

https://phabricator.endlessm.com/T30746