### PR TITLE
Better flatpak skip parental controls

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -237,6 +237,9 @@ test_env = [
   'GSETTINGS_BACKEND=memory',
   'MALLOC_CHECK_=2',
   'GS_UNIT_TESTS_SKIP_MOGWAI=1',
+  # Make flatpak skip parental controls
+  # https://github.com/flatpak/flatpak/issues/2993
+  'FLATPAK_SYSTEM_HELPER_ON_SESSION=1',
 ]
 
 subdir('data')

--- a/meson.build
+++ b/meson.build
@@ -237,9 +237,6 @@ test_env = [
   'GSETTINGS_BACKEND=memory',
   'MALLOC_CHECK_=2',
   'GS_UNIT_TESTS_SKIP_MOGWAI=1',
-  # FIXME: Use a mock service for parental controls
-  # https://phabricator.endlessm.com/T30645
-  'FLATPAK_SKIP_PARENTAL_CONTROLS_NO_SYSTEM_BUS=1',
 ]
 
 subdir('data')

--- a/plugins/flatpak/gs-self-test.c
+++ b/plugins/flatpak/gs-self-test.c
@@ -1894,30 +1894,21 @@ main (int argc, char **argv)
 	g_assert_true (ret);
 
 	/* plugin tests go here */
-
-	/* FIXME: Temporarily disabling some failing tests so we can build
-	 *        ostrees while they get fixed */
-
-#if 0
 	g_test_add_data_func ("/gnome-software/plugins/flatpak/app-with-runtime",
 			      plugin_loader,
 			      (GTestDataFunc) gs_plugins_flatpak_app_with_runtime_func);
-#endif
 	g_test_add_data_func ("/gnome-software/plugins/flatpak/app-missing-runtime",
 			      plugin_loader,
 			      (GTestDataFunc) gs_plugins_flatpak_app_missing_runtime_func);
-#if 0
 	g_test_add_data_func ("/gnome-software/plugins/flatpak/ref",
 			      plugin_loader,
 			      (GTestDataFunc) gs_plugins_flatpak_ref_func);
 	g_test_add_data_func ("/gnome-software/plugins/flatpak/bundle",
 			      plugin_loader,
 			      (GTestDataFunc) gs_plugins_flatpak_bundle_func);
-#endif
 	g_test_add_data_func ("/gnome-software/plugins/flatpak/broken-remote",
 			      plugin_loader,
 			      (GTestDataFunc) gs_plugins_flatpak_broken_remote_func);
-#if 0
 	g_test_add_data_func ("/gnome-software/plugins/flatpak/runtime-repo",
 			      plugin_loader,
 			      (GTestDataFunc) gs_plugins_flatpak_runtime_repo_func);
@@ -1930,7 +1921,6 @@ main (int argc, char **argv)
 	g_test_add_data_func ("/gnome-software/plugins/flatpak/app-update-runtime",
 			      plugin_loader,
 			      (GTestDataFunc) gs_plugins_flatpak_app_update_func);
-#endif
 	g_test_add_data_func ("/gnome-software/plugins/flatpak/repo",
 			      plugin_loader,
 			      (GTestDataFunc) gs_plugins_flatpak_repo_func);


### PR DESCRIPTION
This uses upstream flatpak's environment variable to skip parental controls rather than our downstream environment variable that was recently removed. I tested this in OBS and it succeeded. I believe the 2nd commit is a candidate for upstream gnome-software (at least until malcontent mocking is written or there's some other non-dbus method to skip parental controls).

https://phabricator.endlessm.com/T32793