### PR TITLE
Remove Calculator and gedit from blocklist

### DIFF
--- a/plugins/eos-blocklist/gs-plugin-eos-blocklist.c
+++ b/plugins/eos-blocklist/gs-plugin-eos-blocklist.c
@@ -452,7 +452,6 @@ gs_plugin_eos_blocklist_app_for_remote_if_needed (GsPlugin *plugin,
 	};
 
 	static const char *core_apps[] = {
-		"org.gnome.Calculator",
 		"org.gnome.Contacts",
 		"org.gnome.Evince",
 		"org.gnome.Evolution",

--- a/plugins/eos-blocklist/gs-plugin-eos-blocklist.c
+++ b/plugins/eos-blocklist/gs-plugin-eos-blocklist.c
@@ -458,7 +458,6 @@ gs_plugin_eos_blocklist_app_for_remote_if_needed (GsPlugin *plugin,
 		"org.gnome.Nautilus",
 		"org.gnome.clocks",
 		"org.gnome.eog",
-		"org.gnome.gedit",
 		NULL
 	};
 


### PR DESCRIPTION
Our App Center has a hardcoded list of Flatpak apps to hide because they are built into the OS. When we move an app from the OS to a Flatpak, we need to update this list so the App Center will show the Flatpak version.

Remove -GNOME Calculator and Gedit from this blocklist.

https://phabricator.endlessm.com/T32879
https://phabricator.endlessm.com/T32906
