### PR TITLE
debian: Stop disabling Snap in EOS build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -55,7 +55,6 @@ GS_CONFIGURE_FLAGS += \
 	-Dmogwai=true \
 	-Dostree=true \
 	-Dpackagekit=false \
-	-Dsnap=false \
 	-Dtests=true
 
 DISTRO_ID = debian


### PR DESCRIPTION
While we don’t want the snap plugin to be installed or enabled on EOS,
the Debian packaging has now been changed (upstream in Debian) to build
the snap plugin as a separate package, which we can just not install on
EOS.

Explicitly disabling the plugin causes that package to fail to build.

This can be squashed into the commit to apply Endless-specific packaging
changes next time we rebase.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T32854