### PR TITLE
debian: Distribute external-appstream files

### DIFF
--- a/debian/gnome-software.install
+++ b/debian/gnome-software.install
@@ -3,6 +3,7 @@ usr/bin/gnome-software
 usr/lib/*/gnome-software/libgnomesoftware.so*
 usr/lib/*/gnome-software/plugins-*/*.so
 usr/libexec/gnome-software-cmd
+usr/libexec/gnome-software-install-appstream
 usr/libexec/gnome-software-restarter
 usr/share/applications/
 usr/share/dbus-1/
@@ -11,3 +12,4 @@ usr/share/glib-2.0/schemas/
 usr/share/gnome-shell/
 usr/share/man/
 usr/share/metainfo/
+usr/share/polkit-1/actions/org.gnome.software.external-appstream.policy


### PR DESCRIPTION
These are enabled on EOS by `-Dexternal_appstream=true`, but are not
enabled in the default Debian packaging.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T32854