### PR TITLE
Move 3 dpkg/apt-related packages to Suggests:

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -52,18 +52,18 @@ X-Ubuntu-Use-Langpack: yes
 Package: gnome-software
 Architecture: any
 Depends: appstream,
-         apt-config-icons,
          gnome-software-common (= ${source:Version}),
          gsettings-desktop-schemas (>= 3.18),
-         libgtk3-perl,
-         packagekit (>= 1.1.11),
-         software-properties-gtk,
          ${misc:Depends},
          ${shlibs:Depends}
 Conflicts: sessioninstaller
 Recommends: fwupd [linux-any], ${plugin:Recommends}
-Suggests: apt-config-icons-hidpi,
+Suggests: apt-config-icons,
+          apt-config-icons-hidpi,
           gnome-software-plugin-flatpak [amd64 arm64 armel armhf i386 mips mipsel mips64el ppc64el s390x hppa powerpc powerpcspe ppc64],
+          libgtk3-perl,
+          packagekit (>= 1.1.11),
+          software-properties-gtk,
           ${plugin:Suggests}
 Description: Software Center for GNOME
  Software lets you install and update applications and system extensions.

--- a/debian/control.in
+++ b/debian/control.in
@@ -48,18 +48,18 @@ X-Ubuntu-Use-Langpack: yes
 Package: gnome-software
 Architecture: any
 Depends: appstream,
-         apt-config-icons,
          gnome-software-common (= ${source:Version}),
          gsettings-desktop-schemas (>= 3.18),
-         libgtk3-perl,
-         packagekit (>= 1.1.11),
-         software-properties-gtk,
          ${misc:Depends},
          ${shlibs:Depends}
 Conflicts: sessioninstaller
 Recommends: fwupd [linux-any], ${plugin:Recommends}
-Suggests: apt-config-icons-hidpi,
+Suggests: apt-config-icons,
+          apt-config-icons-hidpi,
           gnome-software-plugin-flatpak [amd64 arm64 armel armhf i386 mips mipsel mips64el ppc64el s390x hppa powerpc powerpcspe ppc64],
+          libgtk3-perl,
+          packagekit (>= 1.1.11),
+          software-properties-gtk,
           ${plugin:Suggests}
 Description: Software Center for GNOME
  Software lets you install and update applications and system extensions.


### PR DESCRIPTION
- libgtk3-perl: Needed for debconf
- software-properties-gtk: Debian-specific apt repository configuration tool
- apt-config-icons: Needed to show icons for apps to be installed with apt
- packagekit: It's packagekit!

None of these are relevant on Endless OS where apps cannot be installed
with apt.

This is spiritually a cherry-pick of
683c20c33345a8fd9fe8620e42b35fec0e75987c.

https://phabricator.endlessm.com/T32854
￼
