### PR TITLE
eos-blocklist: Remove GNOME Contacts from blocklist

### DIFF
--- a/plugins/eos-blocklist/gs-plugin-eos-blocklist.c
+++ b/plugins/eos-blocklist/gs-plugin-eos-blocklist.c
@@ -453,7 +453,6 @@ gs_plugin_eos_blocklist_app_for_remote_if_needed (GsPlugin *plugin,
 	};
 
 	static const char *core_apps[] = {
-		"org.gnome.Contacts",
 		"org.gnome.Evince",
 		"org.gnome.Evolution",
 		"org.gnome.Nautilus",


### PR DESCRIPTION
We have removed this from the OSTree and ship the Flatpak instead.

https://phabricator.endlessm.com/T32983