### PR TITLE
eos: Drop usr/share/gnome-software installed files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+gnome-software (41.3-1endless0) eos; urgency=medium
+
+  * Drop usr/share/gnome-software installed files as upgrade banner backgrounds
+    are no longer being installed (T33015)
+     - This can be dropped when we rebase on 42, as backgrounds will have been
+       dropped upstream in that release
+
+ -- Philip Withnall <pwithnall@endlessos.org>  Wed, 09 Feb 2022 12:35:00 +0000
+
 gnome-software (41.3-1) eos; urgency=medium
 
   * Rebase EOS on GNOME 41.3 release

--- a/debian/gnome-software-common.install
+++ b/debian/gnome-software-common.install
@@ -1,5 +1,4 @@
 debian/source_gnome-software.py /usr/share/apport/package-hooks
 usr/share/app-info/xmls
-usr/share/gnome-software/
 usr/share/icons/
 usr/share/locale/


### PR DESCRIPTION
Upgrade banner backgrounds are no longer being installed.

This can be dropped when we rebase on 42, as backgrounds will have been
dropped upstream in that release

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T33015