### PR TITLE
debian: Don't provide nonexistent option to meson configure

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -53,7 +53,6 @@ GS_CONFIGURE_FLAGS += \
 	-Dhardcoded_popular=false \
 	-Dmalcontent=true \
 	-Dmogwai=true \
-	-Dostree=true \
 	-Dpackagekit=false \
 	-Dtests=true
 


### PR DESCRIPTION
There has never been an 'ostree' option, though there was an
'enable-ostree' option prior to 3.28.

Meson 0.60.1 makes providing unknown options fatal.

This can be squashed into the commit to apply Endless-specific packaging
changes next time we rebase.

https://phabricator.endlessm.com/T33213
