### PR TITLE
eos: Don't hide web-apps or mark them as unremovable

### DIFF
--- a/plugins/eos/gs-plugin-eos.c
+++ b/plugins/eos/gs-plugin-eos.c
@@ -106,7 +106,8 @@ refine_core_app (GsApp *app)
 	    (gs_app_get_scope (app) == AS_COMPONENT_SCOPE_UNKNOWN))
 		return;
 
-	if (gs_app_get_kind (app) == AS_COMPONENT_KIND_OPERATING_SYSTEM)
+	if (gs_app_get_kind (app) == AS_COMPONENT_KIND_OPERATING_SYSTEM ||
+	    gs_app_get_kind (app) == AS_COMPONENT_KIND_WEB_APP)
 		return;
 
 	/* Hide non-installed apt packages, as they can’t actually be installed.


### PR DESCRIPTION
Previously we assumed that everything that is not a Flatpak (or the OS
itself, which can be upgraded) is either built-in (if it is installed)
or cannot be installed (if not).

Since the reintroduction of web-app support in GNOME Software, this is
no longer true: web apps can be installed if not already installed, and
removed if installed. Skip them when marking apps as compulsory or
hide-everywhere.

https://phabricator.endlessm.com/T19646
