### PR TITLE
T34081 Backport major/minor update UI to EOS 5

### DIFF
--- a/plugins/eos-updater/com.endlessm.Updater.xml
+++ b/plugins/eos-updater/com.endlessm.Updater.xml
@@ -1,6 +1,8 @@
 <!DOCTYPE node PUBLIC
 '-//freedesktop//DTD D-BUS Object Introspection 1.0//EN'
 'http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd'>
+<!-- Copyright 2018, 2019 Endless Mobile, Inc.
+     SPDX-License-Identifier: LGPL-2.1-or-later -->
 <node>
   <!--
     com.endlessm.Updater:
@@ -184,6 +186,14 @@
     <property name="Version" type="s" access="read"/>
 
     <!--
+      UpdateIsUserVisible:
+      If the update contains significant user visible changes which should be
+      notified to the user in advance of the update being applied, this is
+      `True`. Otherwise, or if no update is available, this is `False`.
+    -->
+    <property name="UpdateIsUserVisible" type="b" access="read"/>
+
+    <!--
       DownloadSize:
 
       Size (in bytes) of the update when downloaded, or `-1` if an update is
@@ -230,7 +240,7 @@
       ErrorCode:
 
       Error code of the current error, or `0` if no error has been reported.
-      This is in an unspecified error doman, and hence is useless.
+      This is in an unspecified error domain, and hence is useless.
 
       Deprecated: Use `ErrorName` instead.
     -->

--- a/plugins/eos-updater/gs-plugin-eos-updater.c
+++ b/plugins/eos-updater/gs-plugin-eos-updater.c
@@ -434,12 +434,17 @@ sync_state_from_updater_unlocked (GsPluginEosUpdater *self)
 	}
 	case EOS_UPDATER_STATE_UPDATE_READY: {
 		app_set_state (plugin, app, GS_APP_STATE_UPDATABLE);
+
+		/* Nothing further to download. */
+		gs_app_set_size_download (app, GS_SIZE_TYPE_VALID, 0);
+
 		break;
 	}
 	case EOS_UPDATER_STATE_APPLYING_UPDATE: {
 		/* set as 'installing' because if it is applying the update, we
 		 * want to show the progress bar */
 		app_set_state (plugin, app, GS_APP_STATE_INSTALLING);
+		gs_app_set_size_download (app, GS_SIZE_TYPE_VALID, 0);
 
 		/* set up the fake progress to inform the user that something
 		 * is still being done (we don't get progress reports from
@@ -456,6 +461,7 @@ sync_state_from_updater_unlocked (GsPluginEosUpdater *self)
 	}
 	case EOS_UPDATER_STATE_UPDATE_APPLIED: {
 		app_set_state (plugin, app, GS_APP_STATE_UPDATABLE);
+		gs_app_set_size_download (app, GS_SIZE_TYPE_VALID, 0);
 
 		break;
 	}
@@ -1059,6 +1065,9 @@ gs_plugin_app_upgrade_download (GsPlugin *plugin,
 			/* if there's an update ready to deployed, and it was started by
 			 * the user, we should proceed to applying the upgrade */
 			gs_app_set_progress (app, max_progress_for_update);
+
+			/* Nothing further to download. */
+			gs_app_set_size_download (app, GS_SIZE_TYPE_VALID, 0);
 
 			if (!gs_eos_updater_call_apply_sync (self->updater_proxy,
 							     cancellable, error)) {

--- a/plugins/eos-updater/gs-plugin-eos-updater.c
+++ b/plugins/eos-updater/gs-plugin-eos-updater.c
@@ -951,11 +951,11 @@ cancelled_cb (GCancellable *ui_cancellable,
 
 /* Called in a #GTask worker thread, and it needs to hold `self->mutex` due to
  * synchronising on state with the main thread. */
-gboolean
-gs_plugin_app_upgrade_download (GsPlugin *plugin,
-				GsApp *app,
-			        GCancellable *cancellable,
-				GError **error)
+static gboolean
+gs_plugin_eos_updater_app_upgrade_download (GsPlugin      *plugin,
+                                            GsApp         *app,
+                                            GCancellable  *cancellable,
+                                            GError       **error)
 {
 	GsPluginEosUpdater *self = GS_PLUGIN_EOS_UPDATER (plugin);
 	gulong cancelled_id = 0;
@@ -1166,6 +1166,15 @@ gs_plugin_app_upgrade_download (GsPlugin *plugin,
 	}
 
 	return TRUE;
+}
+
+gboolean
+gs_plugin_app_upgrade_download (GsPlugin *plugin,
+				GsApp *app,
+			        GCancellable *cancellable,
+				GError **error)
+{
+	return gs_plugin_eos_updater_app_upgrade_download (plugin, app, cancellable, error);
 }
 
 static void

--- a/plugins/eos-updater/gs-plugin-eos-updater.c
+++ b/plugins/eos-updater/gs-plugin-eos-updater.c
@@ -57,7 +57,14 @@
  *
  * This plugin follows the state transitions signalled by the daemon, and
  * updates the state of a single #GsApp instance (`os_upgrade`) to reflect the
- * OS upgrade in the UI.
+ * OS update or upgrade in the UI.
+ *
+ * The #GsApp instance is returned by
+ * `gs_plugin_eos_updater_list_distro_upgrades_async()` or
+ * `gs_plugin_add_updates()` depending on whether it contains significant
+ * user visible changes, as determined by the `update-is-user-visible` property
+ * on the proxy. (This in turn is set from information on the release OSTree
+ * commit.) The #GsApp will be returned by at most one of these vfuncs.
  *
  * Calling gs_plugin_eos_updater_refresh_metadata_async() will result in this
  * plugin calling the `Poll()` method on the `eos-updater` daemon to check for a
@@ -211,7 +218,7 @@ struct _GsPluginEosUpdater
 	/* These members are only set once in gs_plugin_eos_updater_setup(), and are
 	 * internally thread-safe, so can be accessed without holding @mutex: */
 	GsEosUpdater *updater_proxy;  /* (owned) */
-	GsApp *os_upgrade;  /* (owned) */
+	GsApp *os_upgrade;  /* (owned); represents both large upgrades and small updates */
 	GCancellable *cancellable;  /* (owned) */
 	gulong cancelled_id;
 
@@ -238,7 +245,7 @@ os_upgrade_cancelled_cb (GCancellable *cancellable,
 }
 
 static gboolean
-should_add_os_upgrade (GsAppState state)
+should_add_os_update_or_upgrade (GsAppState state)
 {
 	switch (state) {
 	case GS_APP_STATE_AVAILABLE:
@@ -257,6 +264,20 @@ should_add_os_upgrade (GsAppState state)
 	}
 }
 
+static gboolean
+should_add_os_upgrade (GsPluginEosUpdater *self)
+{
+	return (should_add_os_update_or_upgrade (gs_app_get_state (self->os_upgrade)) &&
+	        gs_app_has_quirk (self->os_upgrade, GS_APP_QUIRK_IS_PROXY));
+}
+
+static gboolean
+should_add_os_update (GsPluginEosUpdater *self)
+{
+	return (should_add_os_update_or_upgrade (gs_app_get_state (self->os_upgrade)) &&
+	        !gs_app_has_quirk (self->os_upgrade, GS_APP_QUIRK_IS_PROXY));
+}
+
 /* Wrapper around gs_app_set_state() which ensures we also notify of update
  * changes if we change between non-upgradable and upgradable states, so that
  * the app is notified to appear in the UI. */
@@ -272,8 +293,8 @@ app_set_state (GsPlugin   *plugin,
 
 	gs_app_set_state (app, new_state);
 
-	if (should_add_os_upgrade (old_state) !=
-	    should_add_os_upgrade (new_state)) {
+	if (should_add_os_update_or_upgrade (old_state) !=
+	    should_add_os_update_or_upgrade (new_state)) {
 		g_debug ("%s: Calling gs_plugin_updates_changed()", G_STRFUNC);
 		gs_plugin_updates_changed (plugin);
 	}
@@ -283,6 +304,32 @@ static gboolean
 eos_updater_error_is_cancelled (const gchar *error_name)
 {
 	return (g_strcmp0 (error_name, "com.endlessm.Updater.Error.Cancelled") == 0);
+}
+
+static void
+app_set_update_is_user_visible (GsApp    *app,
+                                gboolean  update_is_user_visible)
+{
+	g_debug ("%s: Setting OS update as %s", G_STRFUNC,
+		 update_is_user_visible ? "containing significant user visible changes" : "only containing non-user visible changes");
+
+	/* If the update contains significant user visible changes, we want to
+	 * show it using the OS upgrade banner (#GsUpgradeBanner), which means
+	 * it needs a certain set of metadata set on it.
+	 *
+	 * If it doesn’t contain significant user visible changes, we want to
+	 * show it as a normal update row (a row in a #GsUpdatesSection), which
+	 * means it needs different metadata.
+	 *
+	 * Other parts of the code in this plugin use the presence of
+	 * #GS_APP_QUIRK_IS_PROXY to distinguish these two states. */
+	if (update_is_user_visible) {
+		gs_app_add_quirk (app, GS_APP_QUIRK_IS_PROXY);
+		gs_app_set_special_kind (app, GS_APP_SPECIAL_KIND_OS_UPDATE);
+	} else {
+		gs_app_remove_quirk (app, GS_APP_QUIRK_IS_PROXY);
+		gs_app_set_special_kind (app, GS_APP_SPECIAL_KIND_NONE);
+	}
 }
 
 /* This will be invoked in the main thread. */
@@ -321,6 +368,17 @@ updater_version_changed (GsPluginEosUpdater *self)
 	 * of the version, for use in error messages. */
 	if (version != NULL)
 		gs_app_set_version (self->os_upgrade, version);
+}
+
+/* This will be invoked in the main thread, but doesn’t currently need to hold
+ * `mutex` since it only accesses `self->updater_proxy` and `self->os_upgrade`,
+ * both of which are internally thread-safe. */
+static void
+updater_update_is_user_visible_changed (GsPluginEosUpdater *self)
+{
+	gboolean update_is_user_visible = gs_eos_updater_get_update_is_user_visible (self->updater_proxy);
+
+	app_set_update_is_user_visible (self->os_upgrade, update_is_user_visible);
 }
 
 /* This will be invoked in the main thread, but doesn’t currently need to hold
@@ -392,6 +450,7 @@ sync_state_from_updater_unlocked (GsPluginEosUpdater *self)
 	} case EOS_UPDATER_STATE_UPDATE_AVAILABLE: {
 		gint64 total_size;
 
+		app_set_update_is_user_visible (app, gs_eos_updater_get_update_is_user_visible (self->updater_proxy));
 		app_set_state (plugin, app, GS_APP_STATE_AVAILABLE);
 
 		/* The property returns -1 to indicate unknown size */
@@ -503,8 +562,8 @@ sync_state_from_updater_unlocked (GsPluginEosUpdater *self)
 
 	/* if the state changed from or to 'unknown', we need to notify that a
 	 * new update should be shown */
-	if (should_add_os_upgrade (previous_app_state) !=
-	    should_add_os_upgrade (current_app_state)) {
+	if (should_add_os_update_or_upgrade (previous_app_state) !=
+	    should_add_os_update_or_upgrade (current_app_state)) {
 		g_debug ("%s: Calling gs_plugin_updates_changed()", G_STRFUNC);
 		gs_plugin_updates_changed (plugin);
 	}
@@ -572,6 +631,7 @@ proxy_new_cb (GObject      *source_object,
 	g_autofree gchar *css = NULL;
 	g_autofree gchar *summary = NULL;
 	g_autofree gchar *version = NULL;
+	gboolean update_is_user_visible = FALSE;
 	g_autoptr(GsOsRelease) os_release = NULL;
 	g_autoptr(GMutexLocker) locker = NULL;
 	g_autoptr(GError) local_error = NULL;
@@ -604,6 +664,9 @@ proxy_new_cb (GObject      *source_object,
 	g_signal_connect_object (self->updater_proxy, "notify::version",
 				 G_CALLBACK (updater_version_changed),
 				 self, G_CONNECT_SWAPPED);
+	g_signal_connect_object (self->updater_proxy, "notify::update-is-user-visible",
+				 G_CALLBACK (updater_update_is_user_visible_changed),
+				 self, G_CONNECT_SWAPPED);
 
 	/* prepare EOS upgrade app + sync initial state */
 
@@ -629,6 +692,7 @@ proxy_new_cb (GObject      *source_object,
 
 	g_object_get (G_OBJECT (self->updater_proxy),
 		"version", &version,
+		"update-is-user-visible", &update_is_user_visible,
 		"update-message", &summary,
 		NULL);
 
@@ -653,6 +717,7 @@ proxy_new_cb (GObject      *source_object,
 	gs_app_set_name (app, GS_APP_QUALITY_LOWEST, os_name);
 	gs_app_set_summary (app, GS_APP_QUALITY_NORMAL, summary);
 	gs_app_set_version (app, version == NULL ? "" : version);
+	app_set_update_is_user_visible (app, update_is_user_visible);
 	gs_app_add_quirk (app, GS_APP_QUIRK_NEEDS_REBOOT);
 	gs_app_add_quirk (app, GS_APP_QUIRK_PROVENANCE);
 	gs_app_add_quirk (app, GS_APP_QUIRK_NOT_REVIEWABLE);
@@ -699,6 +764,9 @@ gs_plugin_eos_updater_dispose (GObject *object)
 						      self);
 		g_signal_handlers_disconnect_by_func (self->updater_proxy,
 						      G_CALLBACK (updater_version_changed),
+						      self);
+		g_signal_handlers_disconnect_by_func (self->updater_proxy,
+						      G_CALLBACK (updater_update_is_user_visible_changed),
 						      self);
 	}
 
@@ -887,12 +955,12 @@ gs_plugin_eos_updater_list_distro_upgrades_async (GsPlugin                      
 		return;
 	}
 
-	if (should_add_os_upgrade (gs_app_get_state (self->os_upgrade))) {
-		g_debug ("Adding EOS upgrade: %s",
+	if (should_add_os_upgrade (self)) {
+		g_debug ("Adding EOS upgrade as user visible OS upgrade: %s",
 			 gs_app_get_unique_id (self->os_upgrade));
 		gs_app_list_add (list, self->os_upgrade);
 	} else {
-		g_debug ("Not adding EOS upgrade");
+		g_debug ("Not adding EOS upgrade as user visible OS upgrade");
 	}
 
 	g_task_return_pointer (task, g_steal_pointer (&list), g_object_unref);
@@ -904,6 +972,39 @@ gs_plugin_eos_updater_list_distro_upgrades_finish (GsPlugin      *plugin,
                                                    GError       **error)
 {
 	return g_task_propagate_pointer (G_TASK (result), error);
+}
+
+/* This is called in a #GTask worker thread.
+ *
+ * It’s used to check for non-significant or non-user-visible updates, in
+ * contrast to the significant user visible updates checked for by
+ * gs_plugin_eos_updater_list_distro_upgrades_async(). The polling process is
+ * the same in either case, though. */
+gboolean
+gs_plugin_add_updates (GsPlugin      *plugin,
+                       GsAppList     *list,
+                       GCancellable  *cancellable,
+                       GError       **error)
+{
+	GsPluginEosUpdater *self = GS_PLUGIN_EOS_UPDATER (plugin);
+
+	g_debug ("%s", G_STRFUNC);
+
+	/* check if the OS upgrade has been disabled */
+	if (self->updater_proxy == NULL) {
+		g_debug ("%s: Updater disabled", G_STRFUNC);
+		return TRUE;
+	}
+
+	if (should_add_os_update (self)) {
+		g_debug ("Adding EOS upgrade as non-user visible OS update: %s",
+			 gs_app_get_unique_id (self->os_upgrade));
+		gs_app_list_add (list, self->os_upgrade);
+	} else {
+		g_debug ("Not adding EOS upgrade as non-user visible OS update");
+	}
+
+	return TRUE;
 }
 
 /* Must be called with self->mutex already locked. */
@@ -1168,11 +1269,28 @@ gs_plugin_eos_updater_app_upgrade_download (GsPlugin      *plugin,
 	return TRUE;
 }
 
+/* This is called in a #GTask worker thread.
+ *
+ * It’s used to download the update if it’s been listed in the UI as a major
+ * upgrade. The download process is the same. */
 gboolean
 gs_plugin_app_upgrade_download (GsPlugin *plugin,
 				GsApp *app,
 			        GCancellable *cancellable,
 				GError **error)
+{
+	return gs_plugin_eos_updater_app_upgrade_download (plugin, app, cancellable, error);
+}
+
+/* This is called in a #GTask worker thread.
+ *
+ * It’s used to download the update if it’s been listed in the UI as a minor
+ * update. The download process is the same. */
+gboolean
+gs_plugin_download_app (GsPlugin      *plugin,
+                        GsApp         *app,
+                        GCancellable  *cancellable,
+                        GError       **error)
 {
 	return gs_plugin_eos_updater_app_upgrade_download (plugin, app, cancellable, error);
 }

--- a/plugins/eos-updater/gs-plugin-eos-updater.c
+++ b/plugins/eos-updater/gs-plugin-eos-updater.c
@@ -608,7 +608,7 @@ proxy_new_cb (GObject      *source_object,
 	/* prepare EOS upgrade app + sync initial state */
 
 	/* use stock icon */
-	ic = g_themed_icon_new ("system-component-addon");
+	ic = g_themed_icon_new ("system-component-os-updates");
 
 	/* Check for a background image in the standard location. */
 	background_filename = gs_utils_get_upgrade_background (NULL);

--- a/plugins/eos-updater/tests/eos_updater.py
+++ b/plugins/eos-updater/tests/eos_updater.py
@@ -1,3 +1,25 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2019 Endless Mobile, Inc.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA  02110-1301  USA
+
 '''eos-updater mock template
 
 This creates a mock eos-updater interface (com.endlessm.Updater), with several
@@ -24,16 +46,8 @@ supports.
 
 Usage:
    python3 -m dbusmock \
-       --template ./plugins/eos-updater/tests/mock-eos-updater.py
+       --template ./eos-updater/tests/eos_updater.py
 '''
-
-# This program is free software; you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the Free
-# Software Foundation; either version 2.1 of the License, or (at your option)
-# any later version.  See http://www.gnu.org/copyleft/lgpl.html for the full
-# text of the license.
-#
-# The LGPL 2.1+ has been chosen as that’s the license eos-updater is under.
 
 from enum import IntEnum
 from gi.repository import GLib
@@ -45,7 +59,7 @@ from dbusmock import MOCK_IFACE
 
 
 __author__ = 'Philip Withnall'
-__email__ = 'withnall@endlessm.com'
+__email__ = 'pwithnall@endlessos.org'
 __copyright__ = '© 2019 Endless Mobile Inc.'
 __license__ = 'LGPL 2.1+'
 
@@ -84,6 +98,8 @@ def load(mock, parameters):
             'UpdateLabel': dbus.String(parameters.get('UpdateLabel', '')),
             'UpdateMessage': dbus.String(parameters.get('UpdateMessage', '')),
             'Version': dbus.String(parameters.get('Version', '')),
+            'UpdateIsUserVisible':
+                dbus.Boolean(parameters.get('UpdateIsUserVisible', False)),
             'DownloadSize': dbus.Int64(parameters.get('DownloadSize', 0)),
             'DownloadedBytes':
                 dbus.Int64(parameters.get('DownloadedBytes', 0)),
@@ -174,7 +190,9 @@ def Poll(self):
     self.__change_state(self, UpdaterState.POLLING)
 
     if self.__poll_action == 'early-error':
+        # Simulate some network polling activity
         time.sleep(0.5)
+
         self.__set_error(self, self.__poll_error_name,
                          self.__poll_error_message)
     else:
@@ -201,7 +219,9 @@ def FetchFull(self, options=None):
     self.__change_state(self, UpdaterState.FETCHING)
 
     if self.__fetch_action == 'early-error':
+        # Simulate some network fetching activity
         time.sleep(0.5)
+
         self.__set_error(self, self.__fetch_error_name,
                          self.__fetch_error_message)
     else:
@@ -217,7 +237,9 @@ def Apply(self):
     self.__change_state(self, UpdaterState.APPLYING_UPDATE)
 
     if self.__apply_action == 'early-error':
+        # Simulate some disk applying activity
         time.sleep(0.5)
+
         self.__set_error(self, self.__apply_error_name,
                          self.__apply_error_message)
     else:
@@ -234,7 +256,9 @@ def Cancel(self):
         UpdaterState.APPLYING_UPDATE,
     ]))
 
+    # Simulate some work to cancel whatever’s happening
     time.sleep(1)
+
     self.__set_error(self, 'com.endlessm.Updater.Error.Cancelled',
                      'Update was cancelled')
 
@@ -264,6 +288,7 @@ def SetPollAction(self, action, update_properties, error_name, error_message):
             'UpdateMessage':
                 dbus.String('Some release notes.', variant_level=1),
             'Version': dbus.String('3.7.0', variant_level=1),
+            'UpdateIsUserVisible': dbus.Boolean(False),
             'DownloadSize': dbus.Int64(1000000000, variant_level=1),
             'UnpackedSize': dbus.Int64(1500000000, variant_level=1),
             'FullDownloadSize': dbus.Int64(1000000000 * 0.8, variant_level=1),
@@ -291,6 +316,7 @@ def FinishPoll(self):
             'UpdateLabel',
             'UpdateMessage',
             'Version',
+            'UpdateIsUserVisible',
             'FullDownloadSize',
             'FullUnpackedSize',
             'DownloadSize',


### PR DESCRIPTION
Trivial backport of https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/1555 to EOS 5.

Compile tested only.