### PR TITLE
T34184 Backport major/minor update UI to EOS 4

### DIFF
--- a/plugins/eos-updater/com.endlessm.Updater.xml
+++ b/plugins/eos-updater/com.endlessm.Updater.xml
@@ -1,6 +1,8 @@
 <!DOCTYPE node PUBLIC
 '-//freedesktop//DTD D-BUS Object Introspection 1.0//EN'
 'http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd'>
+<!-- Copyright 2018, 2019 Endless Mobile, Inc.
+     SPDX-License-Identifier: LGPL-2.1-or-later -->
 <node>
   <!--
     com.endlessm.Updater:
@@ -184,6 +186,14 @@
     <property name="Version" type="s" access="read"/>
 
     <!--
+      UpdateIsUserVisible:
+      If the update contains significant user visible changes which should be
+      notified to the user in advance of the update being applied, this is
+      `True`. Otherwise, or if no update is available, this is `False`.
+    -->
+    <property name="UpdateIsUserVisible" type="b" access="read"/>
+
+    <!--
       DownloadSize:
 
       Size (in bytes) of the update when downloaded, or `-1` if an update is
@@ -230,7 +240,7 @@
       ErrorCode:
 
       Error code of the current error, or `0` if no error has been reported.
-      This is in an unspecified error doman, and hence is useless.
+      This is in an unspecified error domain, and hence is useless.
 
       Deprecated: Use `ErrorName` instead.
     -->

--- a/plugins/eos-updater/gs-plugin-eos-updater.c
+++ b/plugins/eos-updater/gs-plugin-eos-updater.c
@@ -414,12 +414,17 @@ sync_state_from_updater_unlocked (GsPlugin *plugin)
 	}
 	case EOS_UPDATER_STATE_UPDATE_READY: {
 		app_set_state (plugin, app, AS_APP_STATE_UPDATABLE);
+
+		/* Nothing further to download. */
+		gs_app_set_size_download (app, 0);
+
 		break;
 	}
 	case EOS_UPDATER_STATE_APPLYING_UPDATE: {
 		/* set as 'installing' because if it is applying the update, we
 		 * want to show the progress bar */
 		app_set_state (plugin, app, AS_APP_STATE_INSTALLING);
+		gs_app_set_size_download (app, 0);
 
 		/* set up the fake progress to inform the user that something
 		 * is still being done (we don't get progress reports from
@@ -436,6 +441,7 @@ sync_state_from_updater_unlocked (GsPlugin *plugin)
 	}
 	case EOS_UPDATER_STATE_UPDATE_APPLIED: {
 		app_set_state (plugin, app, AS_APP_STATE_UPDATABLE);
+		gs_app_set_size_download (app, 0);
 
 		break;
 	}
@@ -913,6 +919,9 @@ gs_plugin_app_upgrade_download (GsPlugin *plugin,
 			/* if there's an update ready to deployed, and it was started by
 			 * the user, we should proceed to applying the upgrade */
 			gs_app_set_progress (app, max_progress_for_update);
+
+			/* Nothing further to download. */
+			gs_app_set_size_download (app, 0);
 
 			if (!gs_eos_updater_call_apply_sync (priv->updater_proxy,
 							     cancellable, error)) {

--- a/plugins/eos-updater/gs-plugin-eos-updater.c
+++ b/plugins/eos-updater/gs-plugin-eos-updater.c
@@ -807,11 +807,11 @@ cancelled_cb (GCancellable *ui_cancellable,
 
 /* Called in a #GTask worker thread, and it needs to hold `priv->mutex` due to
  * synchronising on state with the main thread. */
-gboolean
-gs_plugin_app_upgrade_download (GsPlugin *plugin,
-				GsApp *app,
-			        GCancellable *cancellable,
-				GError **error)
+static gboolean
+gs_plugin_eos_updater_app_upgrade_download (GsPlugin      *plugin,
+                                            GsApp         *app,
+                                            GCancellable  *cancellable,
+                                            GError       **error)
 {
 	GsPluginData *priv = gs_plugin_get_data (plugin);
 	gulong cancelled_id = 0;
@@ -1017,6 +1017,17 @@ gs_plugin_app_upgrade_download (GsPlugin *plugin,
 	}
 
 	return TRUE;
+}
+
+/* Called in a #GTask worker thread, and it needs to hold `priv->mutex` due to
+ * synchronising on state with the main thread. */
+gboolean
+gs_plugin_app_upgrade_download (GsPlugin *plugin,
+				GsApp *app,
+			        GCancellable *cancellable,
+				GError **error)
+{
+	return gs_plugin_eos_updater_app_upgrade_download (plugin, app, cancellable, error);
 }
 
 /* Called in a #GTask worker thread, but it can run without holding

--- a/plugins/eos-updater/gs-plugin-eos-updater.c
+++ b/plugins/eos-updater/gs-plugin-eos-updater.c
@@ -559,7 +559,7 @@ gs_plugin_setup (GsPlugin *plugin,
 	/* use stock icon */
 	ic = as_icon_new ();
 	as_icon_set_kind (ic, AS_ICON_KIND_STOCK);
-	as_icon_set_name (ic, "application-x-addon");
+	as_icon_set_name (ic, "software-update-available-symbolic");
 
 	/* create the OS upgrade */
 	app = gs_app_new ("com.endlessm.EOS.upgrade");

--- a/plugins/eos-updater/tests/eos_updater.py
+++ b/plugins/eos-updater/tests/eos_updater.py
@@ -1,3 +1,25 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2019 Endless Mobile, Inc.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA  02110-1301  USA
+
 '''eos-updater mock template
 
 This creates a mock eos-updater interface (com.endlessm.Updater), with several
@@ -24,16 +46,8 @@ supports.
 
 Usage:
    python3 -m dbusmock \
-       --template ./plugins/eos-updater/tests/mock-eos-updater.py
+       --template ./eos-updater/tests/eos_updater.py
 '''
-
-# This program is free software; you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the Free
-# Software Foundation; either version 2.1 of the License, or (at your option)
-# any later version.  See http://www.gnu.org/copyleft/lgpl.html for the full
-# text of the license.
-#
-# The LGPL 2.1+ has been chosen as that’s the license eos-updater is under.
 
 from enum import IntEnum
 from gi.repository import GLib
@@ -45,7 +59,7 @@ from dbusmock import MOCK_IFACE
 
 
 __author__ = 'Philip Withnall'
-__email__ = 'withnall@endlessm.com'
+__email__ = 'pwithnall@endlessos.org'
 __copyright__ = '© 2019 Endless Mobile Inc.'
 __license__ = 'LGPL 2.1+'
 
@@ -84,6 +98,8 @@ def load(mock, parameters):
             'UpdateLabel': dbus.String(parameters.get('UpdateLabel', '')),
             'UpdateMessage': dbus.String(parameters.get('UpdateMessage', '')),
             'Version': dbus.String(parameters.get('Version', '')),
+            'UpdateIsUserVisible':
+                dbus.Boolean(parameters.get('UpdateIsUserVisible', False)),
             'DownloadSize': dbus.Int64(parameters.get('DownloadSize', 0)),
             'DownloadedBytes':
                 dbus.Int64(parameters.get('DownloadedBytes', 0)),
@@ -174,7 +190,9 @@ def Poll(self):
     self.__change_state(self, UpdaterState.POLLING)
 
     if self.__poll_action == 'early-error':
+        # Simulate some network polling activity
         time.sleep(0.5)
+
         self.__set_error(self, self.__poll_error_name,
                          self.__poll_error_message)
     else:
@@ -201,7 +219,9 @@ def FetchFull(self, options=None):
     self.__change_state(self, UpdaterState.FETCHING)
 
     if self.__fetch_action == 'early-error':
+        # Simulate some network fetching activity
         time.sleep(0.5)
+
         self.__set_error(self, self.__fetch_error_name,
                          self.__fetch_error_message)
     else:
@@ -217,7 +237,9 @@ def Apply(self):
     self.__change_state(self, UpdaterState.APPLYING_UPDATE)
 
     if self.__apply_action == 'early-error':
+        # Simulate some disk applying activity
         time.sleep(0.5)
+
         self.__set_error(self, self.__apply_error_name,
                          self.__apply_error_message)
     else:
@@ -234,7 +256,9 @@ def Cancel(self):
         UpdaterState.APPLYING_UPDATE,
     ]))
 
+    # Simulate some work to cancel whatever’s happening
     time.sleep(1)
+
     self.__set_error(self, 'com.endlessm.Updater.Error.Cancelled',
                      'Update was cancelled')
 
@@ -264,6 +288,7 @@ def SetPollAction(self, action, update_properties, error_name, error_message):
             'UpdateMessage':
                 dbus.String('Some release notes.', variant_level=1),
             'Version': dbus.String('3.7.0', variant_level=1),
+            'UpdateIsUserVisible': dbus.Boolean(False),
             'DownloadSize': dbus.Int64(1000000000, variant_level=1),
             'UnpackedSize': dbus.Int64(1500000000, variant_level=1),
             'FullDownloadSize': dbus.Int64(1000000000 * 0.8, variant_level=1),
@@ -291,6 +316,7 @@ def FinishPoll(self):
             'UpdateLabel',
             'UpdateMessage',
             'Version',
+            'UpdateIsUserVisible',
             'FullDownloadSize',
             'FullUnpackedSize',
             'DownloadSize',


### PR DESCRIPTION
Backport of https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/1555 to EOS 4. There were quite a few cherry pick conflicts to resolve, but almost all of them were superficial (API renames, better use of GObject, etc.)

Compile tested only.

https://phabricator.endlessm.com/T34184