### PR TITLE
eos-updater: Use the OS logo for minor update rows

### DIFF
--- a/lib/gs-os-release.c
+++ b/lib/gs-os-release.c
@@ -36,6 +36,7 @@ struct _GsOsRelease
 	gchar			*cpe_name;
 	gchar			*distro_codename;
 	gchar			*home_url;
+	gchar			*logo;
 };
 
 static void gs_os_release_initable_iface_init (GInitableIface *iface);
@@ -121,6 +122,10 @@ gs_os_release_initable_init (GInitable *initable,
 		}
 		if (g_strcmp0 (lines[i], "HOME_URL") == 0) {
 			os_release->home_url = g_strdup (tmp);
+			continue;
+		}
+		if (g_strcmp0 (lines[i], "LOGO") == 0) {
+			os_release->logo = g_strdup (tmp);
 			continue;
 		}
 	}
@@ -282,6 +287,23 @@ gs_os_release_get_home_url (GsOsRelease *os_release)
 	return os_release->home_url;
 }
 
+/**
+ * gs_os_release_get_logo:
+ * @os_release: A #GsOsRelease
+ *
+ * Gets the logo icon name from the os-release parser.
+ *
+ * Returns: a string, or %NULL
+ *
+ * Since: 44
+ **/
+const gchar *
+gs_os_release_get_logo (GsOsRelease *os_release)
+{
+	g_return_val_if_fail (GS_IS_OS_RELEASE (os_release), NULL);
+	return os_release->logo;
+}
+
 static void
 gs_os_release_finalize (GObject *object)
 {
@@ -295,6 +317,8 @@ gs_os_release_finalize (GObject *object)
 	g_free (os_release->cpe_name);
 	g_free (os_release->distro_codename);
 	g_free (os_release->home_url);
+	g_free (os_release->logo);
+
 	G_OBJECT_CLASS (gs_os_release_parent_class)->finalize (object);
 }
 

--- a/lib/gs-os-release.h
+++ b/lib/gs-os-release.h
@@ -29,5 +29,6 @@ const gchar		*gs_os_release_get_pretty_name		(GsOsRelease	*os_release);
 const gchar		*gs_os_release_get_cpe_name		(GsOsRelease	*os_release);
 const gchar		*gs_os_release_get_distro_codename	(GsOsRelease	*os_release);
 const gchar		*gs_os_release_get_home_url		(GsOsRelease	*os_release);
+const gchar		*gs_os_release_get_logo			(GsOsRelease	*os_release);
 
 G_END_DECLS

--- a/plugins/eos-updater/gs-plugin-eos-updater.c
+++ b/plugins/eos-updater/gs-plugin-eos-updater.c
@@ -635,7 +635,7 @@ proxy_new_cb (GObject      *source_object,
 	g_autoptr(GsOsRelease) os_release = NULL;
 	g_autoptr(GMutexLocker) locker = NULL;
 	g_autoptr(GError) local_error = NULL;
-	const gchar *os_name;
+	const gchar *os_name, *os_logo;
 
 	locker = g_mutex_locker_new (&self->mutex);
 
@@ -670,9 +670,6 @@ proxy_new_cb (GObject      *source_object,
 
 	/* prepare EOS upgrade app + sync initial state */
 
-	/* use stock icon */
-	ic = g_themed_icon_new ("system-component-os-updates");
-
 	/* Check for a background image in the standard location. */
 	background_filename = gs_utils_get_upgrade_background (NULL);
 
@@ -685,9 +682,11 @@ proxy_new_cb (GObject      *source_object,
 		g_warning ("Failed to get OS release information: %s", local_error->message);
 		/* Just a fallback, do not localize */
 		os_name = "Endless OS";
+		os_logo = NULL;
 		g_clear_error (&local_error);
 	} else {
 		os_name = gs_os_release_get_name (os_release);
+		os_logo = gs_os_release_get_logo (os_release);
 	}
 
 	g_object_get (G_OBJECT (self->updater_proxy),
@@ -708,6 +707,9 @@ proxy_new_cb (GObject      *source_object,
 		/* Translators: The '%s' is replaced with the OS name, like "Endless OS" */
 		summary = g_strdup_printf (_("%s update with new features and fixes."), os_name);
 	}
+
+	/* use stock icon */
+	ic = g_themed_icon_new ((os_logo != NULL) ? os_logo : "system-component-os-updates");
 
 	/* create the OS upgrade */
 	app = gs_app_new ("com.endlessm.EOS.upgrade");


### PR DESCRIPTION
Just like using an app icon to brand the updates for an app, this makes it a bit more obvious what the updates are.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>
Upstream: https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/1556

https://phabricator.endlessm.com/T33143