### PR TITLE
T34082 Backport ‘Learn More’ link changes for upgrades from upstream

### DIFF
--- a/lib/gs-app.c
+++ b/lib/gs-app.c
@@ -2555,7 +2555,8 @@ gs_app_get_url (GsApp *app, AsUrlKind kind)
  * gs_app_set_url:
  * @app: a #GsApp
  * @kind: a #AsUrlKind, e.g. %AS_URL_KIND_HOMEPAGE
- * @url: a web URL, e.g. "http://www.hughsie.com/"
+ * @url: (nullable): a web URL, e.g. "http://www.hughsie.com/", or %NULL to
+ *   unset the URL of this @kind
  *
  * Sets a web address of a specific type.
  *
@@ -2566,18 +2567,26 @@ gs_app_set_url (GsApp *app, AsUrlKind kind, const gchar *url)
 {
 	GsAppPrivate *priv = gs_app_get_instance_private (app);
 	g_autoptr(GMutexLocker) locker = NULL;
+	gboolean changed;
+
 	g_return_if_fail (GS_IS_APP (app));
+
 	locker = g_mutex_locker_new (&priv->mutex);
 
 	if (priv->urls == NULL)
 		priv->urls = g_hash_table_new_full (g_direct_hash, g_direct_equal,
 						    NULL, g_free);
 
-	g_hash_table_insert (priv->urls,
-			     GINT_TO_POINTER (kind),
-			     g_strdup (url));
+	if (url != NULL)
+		changed = g_hash_table_insert (priv->urls,
+					       GINT_TO_POINTER (kind),
+					       g_strdup (url));
+	else
+		changed = g_hash_table_remove (priv->urls,
+					       GINT_TO_POINTER (kind));
 
-	gs_app_queue_notify (app, obj_props[PROP_URLS]);
+	if (changed)
+		gs_app_queue_notify (app, obj_props[PROP_URLS]);
 }
 
 /**

--- a/plugins/eos-updater/com.endlessm.Updater.xml
+++ b/plugins/eos-updater/com.endlessm.Updater.xml
@@ -187,11 +187,20 @@
 
     <!--
       UpdateIsUserVisible:
+
       If the update contains significant user visible changes which should be
       notified to the user in advance of the update being applied, this is
       `True`. Otherwise, or if no update is available, this is `False`.
     -->
     <property name="UpdateIsUserVisible" type="b" access="read"/>
+
+    <!--
+      ReleaseNotesUri:
+
+      URI of a page containing release notes or news for the update being
+      applied, or the empty string if it’s not set or if no update is available.
+    -->
+    <property name="ReleaseNotesUri" type="s" access="read"/>
 
     <!--
       DownloadSize:

--- a/plugins/eos-updater/gs-plugin-eos-updater.c
+++ b/plugins/eos-updater/gs-plugin-eos-updater.c
@@ -382,6 +382,21 @@ updater_update_is_user_visible_changed (GsPluginEosUpdater *self)
 }
 
 /* This will be invoked in the main thread, but doesn’t currently need to hold
+ * `mutex` since it only accesses `self->updater_proxy` and `self->os_upgrade`,
+ * both of which are internally thread-safe. */
+static void
+updater_release_notes_uri_changed (GsPluginEosUpdater *self)
+{
+	const gchar *release_notes_uri = gs_eos_updater_get_release_notes_uri (self->updater_proxy);
+
+	/* @release_notes_uri may be the empty string, in which case we want to remove the URL */
+	if (release_notes_uri != NULL && *release_notes_uri == '\0')
+		release_notes_uri = NULL;
+
+	gs_app_set_url (self->os_upgrade, AS_URL_KIND_HOMEPAGE, release_notes_uri);
+}
+
+/* This will be invoked in the main thread, but doesn’t currently need to hold
  * `mutex` since `self->updater_proxy` and `self->os_upgrade` are both
  * thread-safe, and `self->upgrade_fake_progress` and
  * `self->upgrade_fake_progress_handler` are only ever accessed from the main
@@ -667,6 +682,9 @@ proxy_new_cb (GObject      *source_object,
 	g_signal_connect_object (self->updater_proxy, "notify::update-is-user-visible",
 				 G_CALLBACK (updater_update_is_user_visible_changed),
 				 self, G_CONNECT_SWAPPED);
+	g_signal_connect_object (self->updater_proxy, "notify::release-notes-uri",
+				 G_CALLBACK (updater_release_notes_uri_changed),
+				 self, G_CONNECT_SWAPPED);
 
 	/* prepare EOS upgrade app + sync initial state */
 
@@ -767,6 +785,9 @@ gs_plugin_eos_updater_dispose (GObject *object)
 						      self);
 		g_signal_handlers_disconnect_by_func (self->updater_proxy,
 						      G_CALLBACK (updater_update_is_user_visible_changed),
+						      self);
+		g_signal_handlers_disconnect_by_func (self->updater_proxy,
+						      G_CALLBACK (updater_release_notes_uri_changed),
 						      self);
 	}
 

--- a/plugins/eos-updater/tests/eos_updater.py
+++ b/plugins/eos-updater/tests/eos_updater.py
@@ -100,6 +100,8 @@ def load(mock, parameters):
             'Version': dbus.String(parameters.get('Version', '')),
             'UpdateIsUserVisible':
                 dbus.Boolean(parameters.get('UpdateIsUserVisible', False)),
+            'ReleaseNotesUri':
+                dbus.String(parameters.get('ReleaseNotesUri', '')),
             'DownloadSize': dbus.Int64(parameters.get('DownloadSize', 0)),
             'DownloadedBytes':
                 dbus.Int64(parameters.get('DownloadedBytes', 0)),
@@ -288,7 +290,9 @@ def SetPollAction(self, action, update_properties, error_name, error_message):
             'UpdateMessage':
                 dbus.String('Some release notes.', variant_level=1),
             'Version': dbus.String('3.7.0', variant_level=1),
-            'UpdateIsUserVisible': dbus.Boolean(False),
+            'UpdateIsUserVisible': dbus.Boolean(False, variant_level=1),
+            'ReleaseNotesUri':
+                dbus.String('https://example.com/release-notes', variant_level=1),
             'DownloadSize': dbus.Int64(1000000000, variant_level=1),
             'UnpackedSize': dbus.Int64(1500000000, variant_level=1),
             'FullDownloadSize': dbus.Int64(1000000000 * 0.8, variant_level=1),
@@ -317,6 +321,7 @@ def FinishPoll(self):
             'UpdateMessage',
             'Version',
             'UpdateIsUserVisible',
+            'ReleaseNotesUri',
             'FullDownloadSize',
             'FullUnpackedSize',
             'DownloadSize',


### PR DESCRIPTION
Trivial backport of https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/1567 to EOS `master`.

This will need fast-forwarding to on `eos5.0` once landed, and then backporting to `eos4.0`. I haven’t done that yet as there are a couple of other backports waiting review and it’s getting to the point where a merge train would be needed if I added more PRs.