### PR TITLE
eos-updater: Use the OS logo for minor update rows (backport to eos4.0)

### DIFF
--- a/lib/gs-os-release.c
+++ b/lib/gs-os-release.c
@@ -36,6 +36,7 @@ struct _GsOsRelease
 	gchar			*cpe_name;
 	gchar			*distro_codename;
 	gchar			*home_url;
+	gchar			*logo;
 };
 
 static void gs_os_release_initable_iface_init (GInitableIface *iface);
@@ -121,6 +122,10 @@ gs_os_release_initable_init (GInitable *initable,
 		}
 		if (g_strcmp0 (lines[i], "HOME_URL") == 0) {
 			os_release->home_url = g_strdup (tmp);
+			continue;
+		}
+		if (g_strcmp0 (lines[i], "LOGO") == 0) {
+			os_release->logo = g_strdup (tmp);
 			continue;
 		}
 	}
@@ -282,6 +287,23 @@ gs_os_release_get_home_url (GsOsRelease *os_release)
 	return os_release->home_url;
 }
 
+/**
+ * gs_os_release_get_logo:
+ * @os_release: A #GsOsRelease
+ *
+ * Gets the logo icon name from the os-release parser.
+ *
+ * Returns: a string, or %NULL
+ *
+ * Since: 44
+ **/
+const gchar *
+gs_os_release_get_logo (GsOsRelease *os_release)
+{
+	g_return_val_if_fail (GS_IS_OS_RELEASE (os_release), NULL);
+	return os_release->logo;
+}
+
 static void
 gs_os_release_finalize (GObject *object)
 {
@@ -295,6 +317,8 @@ gs_os_release_finalize (GObject *object)
 	g_free (os_release->cpe_name);
 	g_free (os_release->distro_codename);
 	g_free (os_release->home_url);
+	g_free (os_release->logo);
+
 	G_OBJECT_CLASS (gs_os_release_parent_class)->finalize (object);
 }
 

--- a/lib/gs-os-release.h
+++ b/lib/gs-os-release.h
@@ -29,5 +29,6 @@ const gchar		*gs_os_release_get_pretty_name		(GsOsRelease	*os_release);
 const gchar		*gs_os_release_get_cpe_name		(GsOsRelease	*os_release);
 const gchar		*gs_os_release_get_distro_codename	(GsOsRelease	*os_release);
 const gchar		*gs_os_release_get_home_url		(GsOsRelease	*os_release);
+const gchar		*gs_os_release_get_logo			(GsOsRelease	*os_release);
 
 G_END_DECLS

--- a/plugins/eos-updater/gs-plugin-eos-updater.c
+++ b/plugins/eos-updater/gs-plugin-eos-updater.c
@@ -566,7 +566,10 @@ gs_plugin_setup (GsPlugin *plugin,
 	g_autofree gchar *name_owner = NULL;
 	g_autoptr(GsApp) app = NULL;
 	g_autoptr(AsIcon) ic = NULL;
+	g_autoptr(GsOsRelease) os_release = NULL;
 	g_autoptr(GMutexLocker) locker = NULL;
+	g_autoptr(GError) local_error = NULL;
+	const gchar *os_logo;
 
 	g_debug ("%s", G_STRFUNC);
 
@@ -622,11 +625,19 @@ gs_plugin_setup (GsPlugin *plugin,
 				 plugin, G_CONNECT_SWAPPED);
 
 	/* prepare EOS upgrade app + sync initial state */
+	os_release = gs_os_release_new (&local_error);
+	if (os_release == NULL) {
+		g_warning ("Failed to get OS release information: %s", local_error->message);
+		os_logo = NULL;
+		g_clear_error (&local_error);
+	} else {
+		os_logo = gs_os_release_get_logo (os_release);
+	}
 
 	/* use stock icon */
 	ic = as_icon_new ();
 	as_icon_set_kind (ic, AS_ICON_KIND_STOCK);
-	as_icon_set_name (ic, "software-update-available-symbolic");
+	as_icon_set_name (ic, (os_logo != NULL) ? os_logo : "software-update-available-symbolic");
 
 	/* create the OS upgrade */
 	app = gs_app_new ("com.endlessm.EOS.upgrade");


### PR DESCRIPTION
Just like using an app icon to brand the updates for an app, this makes it a bit more obvious what the updates are.

(Backport 4.0: Rework code in eos-updater plugin as the control flow is significantly different in eos4.0 vs eos5.0.)

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>
Upstream: https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/1556 https://phabricator.endlessm.com/T33143