### PR TITLE
T34292 Backport ‘Learn More’ link changes for upgrades to eos4.0

### DIFF
--- a/lib/gs-app.c
+++ b/lib/gs-app.c
@@ -138,6 +138,7 @@ enum {
 	PROP_PENDING_ACTION,
 	PROP_KEY_COLORS,
 	PROP_IS_UPDATE_DOWNLOADED,
+	PROP_URLS,
 	PROP_LAST
 };
 
@@ -2314,6 +2315,8 @@ gs_app_set_url (GsApp *app, AsUrlKind kind, const gchar *url)
 	g_hash_table_insert (priv->urls,
 			     GINT_TO_POINTER (kind),
 			     g_strdup (url));
+
+	gs_app_queue_notify (app, obj_props[PROP_URLS]);
 }
 
 /**
@@ -4247,6 +4250,9 @@ gs_app_get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *
 	case PROP_IS_UPDATE_DOWNLOADED:
 		g_value_set_boolean (value, priv->is_update_downloaded);
 		break;
+	case PROP_URLS:
+		g_value_set_boxed (value, priv->urls);
+		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
 		break;
@@ -4307,6 +4313,10 @@ gs_app_set_property (GObject *object, guint prop_id, const GValue *value, GParam
 		break;
 	case PROP_IS_UPDATE_DOWNLOADED:
 		gs_app_set_is_update_downloaded (app, g_value_get_boolean (value));
+		break;
+	case PROP_URLS:
+		/* Read only */
+		g_assert_not_reached ();
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -4504,6 +4514,23 @@ gs_app_class_init (GsAppClass *klass)
 	obj_props[PROP_IS_UPDATE_DOWNLOADED] = g_param_spec_boolean ("is-update-downloaded", NULL, NULL,
 					       FALSE,
 					       G_PARAM_READWRITE);
+
+	/**
+	 * GsApp:urls: (nullable) (element-type AsUrlKind utf8)
+	 *
+	 * The URLs associated with the app.
+	 *
+	 * This is %NULL if no URLs are available. If provided, it is a mapping
+	 * from #AsUrlKind to the URLs.
+	 *
+	 * This property is read-only: use gs_app_set_url() to set URLs.
+	 *
+	 * Since: 41
+	 */
+	obj_props[PROP_URLS] =
+		g_param_spec_boxed ("urls", NULL, NULL,
+				    G_TYPE_HASH_TABLE,
+				    G_PARAM_READABLE | G_PARAM_EXPLICIT_NOTIFY | G_PARAM_STATIC_STRINGS);
 
 	g_object_class_install_properties (object_class, PROP_LAST, obj_props);
 

--- a/lib/gs-app.c
+++ b/lib/gs-app.c
@@ -2294,7 +2294,8 @@ gs_app_get_url (GsApp *app, AsUrlKind kind)
  * gs_app_set_url:
  * @app: a #GsApp
  * @kind: a #AsUrlKind, e.g. %AS_URL_KIND_HOMEPAGE
- * @url: a web URL, e.g. "http://www.hughsie.com/"
+ * @url: (nullable): a web URL, e.g. "http://www.hughsie.com/", or %NULL to
+ *   unset the URL of this @kind
  *
  * Sets a web address of a specific type.
  *
@@ -2305,18 +2306,26 @@ gs_app_set_url (GsApp *app, AsUrlKind kind, const gchar *url)
 {
 	GsAppPrivate *priv = gs_app_get_instance_private (app);
 	g_autoptr(GMutexLocker) locker = NULL;
+	gboolean changed;
+
 	g_return_if_fail (GS_IS_APP (app));
+
 	locker = g_mutex_locker_new (&priv->mutex);
 
 	if (priv->urls == NULL)
 		priv->urls = g_hash_table_new_full (g_direct_hash, g_direct_equal,
 						    NULL, g_free);
 
-	g_hash_table_insert (priv->urls,
-			     GINT_TO_POINTER (kind),
-			     g_strdup (url));
+	if (url != NULL)
+		changed = g_hash_table_insert (priv->urls,
+					       GINT_TO_POINTER (kind),
+					       g_strdup (url));
+	else
+		changed = g_hash_table_remove (priv->urls,
+					       GINT_TO_POINTER (kind));
 
-	gs_app_queue_notify (app, obj_props[PROP_URLS]);
+	if (changed)
+		gs_app_queue_notify (app, obj_props[PROP_URLS]);
 }
 
 /**

--- a/plugins/eos-updater/com.endlessm.Updater.xml
+++ b/plugins/eos-updater/com.endlessm.Updater.xml
@@ -187,11 +187,20 @@
 
     <!--
       UpdateIsUserVisible:
+
       If the update contains significant user visible changes which should be
       notified to the user in advance of the update being applied, this is
       `True`. Otherwise, or if no update is available, this is `False`.
     -->
     <property name="UpdateIsUserVisible" type="b" access="read"/>
+
+    <!--
+      ReleaseNotesUri:
+
+      URI of a page containing release notes or news for the update being
+      applied, or the empty string if it’s not set or if no update is available.
+    -->
+    <property name="ReleaseNotesUri" type="s" access="read"/>
 
     <!--
       DownloadSize:

--- a/plugins/eos-updater/tests/eos_updater.py
+++ b/plugins/eos-updater/tests/eos_updater.py
@@ -100,6 +100,8 @@ def load(mock, parameters):
             'Version': dbus.String(parameters.get('Version', '')),
             'UpdateIsUserVisible':
                 dbus.Boolean(parameters.get('UpdateIsUserVisible', False)),
+            'ReleaseNotesUri':
+                dbus.String(parameters.get('ReleaseNotesUri', '')),
             'DownloadSize': dbus.Int64(parameters.get('DownloadSize', 0)),
             'DownloadedBytes':
                 dbus.Int64(parameters.get('DownloadedBytes', 0)),
@@ -288,7 +290,9 @@ def SetPollAction(self, action, update_properties, error_name, error_message):
             'UpdateMessage':
                 dbus.String('Some release notes.', variant_level=1),
             'Version': dbus.String('3.7.0', variant_level=1),
-            'UpdateIsUserVisible': dbus.Boolean(False),
+            'UpdateIsUserVisible': dbus.Boolean(False, variant_level=1),
+            'ReleaseNotesUri':
+                dbus.String('https://example.com/release-notes', variant_level=1),
             'DownloadSize': dbus.Int64(1000000000, variant_level=1),
             'UnpackedSize': dbus.Int64(1500000000, variant_level=1),
             'FullDownloadSize': dbus.Int64(1000000000 * 0.8, variant_level=1),
@@ -317,6 +321,7 @@ def FinishPoll(self):
             'UpdateMessage',
             'Version',
             'UpdateIsUserVisible',
+            'ReleaseNotesUri',
             'FullDownloadSize',
             'FullUnpackedSize',
             'DownloadSize',


### PR DESCRIPTION
Non-trivial backport of https://github.com/endlessm/gnome-software/pull/607 to `eos4.0`.

I had to pull two more commits in from GNOME 41 to get the `GsApp:urls` property in a suitable state to cherry-pick the actual changes onto. After that, the cherry pick conflicts were trivial.

https://phabricator.endlessm.com/T34292