### PR TITLE
Backport #611 “gs-updates-page: Ensure correct section is used for minor OS updates” to eos4.0

### DIFF
--- a/src/gs-updates-page.c
+++ b/src/gs-updates-page.c
@@ -155,6 +155,10 @@ gs_updates_page_invalidate (GsUpdatesPage *self)
 static GsUpdatesSectionKind
 _get_app_section (GsApp *app)
 {
+	if (gs_app_get_kind (app) == AS_APP_KIND_OS_UPGRADE &&
+	    gs_app_has_quirk (app, GS_APP_QUIRK_NEEDS_REBOOT))
+		return GS_UPDATES_SECTION_KIND_OFFLINE;
+
 	if (gs_app_get_state (app) == AS_APP_STATE_UPDATABLE_LIVE) {
 		if (gs_app_get_kind (app) == AS_APP_KIND_FIRMWARE)
 			return GS_UPDATES_SECTION_KIND_ONLINE_FIRMWARE;


### PR DESCRIPTION
Image based OS updates, which need a restart to be applied, should always be labelled as needing a restart.

While that would happen OK if gnome-software added them to the updates page when eos-updater is polling or ready, if they were added to the page when already being fetched (or in subsequent states of eos-updater), the `GsApp` for the update would be in the `GS_APP_STATE_INSTALLING` state, and this would trigger the updates page to add the update to the wrong section.

Fix that by always putting OS updates which need a reboot into the `OFFLINE` section.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>
Upstream: https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/1588

Fixes: #2028, #2038

---

Not entirely trivial backport of #611 to `eos4.0`. I had to change the `GsAppKind` to `AsAppKind`, and I think the conditions which trigger the bug on `eos5.0`/`master` don’t actually hold on `eos4.0` as the code on `eos4.0` doesn’t check for `GS_APP_STATE_INSTALLING`. But it makes sense to backport anyway to avoid diverging this code too much, since we’re potentially going to need to backport other fixes to this code in future.

Not tested.