### PR TITLE
T33138 flatpak: Don’t signal success for automatic updates if not enough space

### DIFF
--- a/plugins/flatpak/gs-plugin-flatpak.c
+++ b/plugins/flatpak/gs-plugin-flatpak.c
@@ -915,13 +915,11 @@ remove_schedule_entry (gpointer schedule_entry_handle)
 }
 
 static gboolean
-get_installation_dir_free_space (GsFlatpak *flatpak, guint64 *free_space, gboolean interactive, GError **error)
+get_installation_dir_free_space (FlatpakInstallation *installation, guint64 *free_space, GError **error)
 {
-	FlatpakInstallation *installation;
 	g_autoptr (GFile) installation_dir = NULL;
 	g_autoptr (GFileInfo) info = NULL;
 
-	installation = gs_flatpak_get_installation (flatpak, interactive);
 	installation_dir = flatpak_installation_get_path (installation);
 
 	info = g_file_query_filesystem_info (installation_dir,
@@ -961,7 +959,7 @@ gs_flatpak_has_space_to_install (GsFlatpak *flatpak, GsApp *app, gboolean intera
 	}
 	space_required = space_required + min_free_space;
 
-	if (!get_installation_dir_free_space (flatpak, &free_space, interactive, &error)) {
+	if (!get_installation_dir_free_space (installation, &free_space, &error)) {
 		g_warning ("Error getting the free space available for installing %s: %s",
 			   gs_app_get_unique_id (app), error->message);
 		g_clear_error (&error);
@@ -1005,7 +1003,7 @@ gs_flatpak_has_space_to_update (GsFlatpak *flatpak, GsAppList *list, gboolean in
 		g_clear_error (&error);
 	}
 	space_required = space_required + min_free_space;
-	if (!get_installation_dir_free_space (flatpak, &free_space, interactive, &error)) {
+	if (!get_installation_dir_free_space (installation, &free_space, &error)) {
 		g_warning ("Error getting the free space available for updating an app list: %s",
 			   error->message);
 		g_clear_error (&error);

--- a/plugins/flatpak/gs-plugin-flatpak.c
+++ b/plugins/flatpak/gs-plugin-flatpak.c
@@ -1521,14 +1521,6 @@ gs_plugin_flatpak_update (GsPlugin *plugin,
 		g_debug ("Skipping %s for %s: not enough space on disk",
 			 (!interactive ? "automatic update" : "update"),
 			 gs_flatpak_get_id (flatpak));
-		if (!interactive) {
-			/* If we're performing automatic updates in the
-			 * background, don't return an error: we don't want an
-			 * error banner showing up out of the blue. Continue to
-			 * the next installation (if any).
-			 */
-			return TRUE;
-		}
 		g_set_error (error, GS_PLUGIN_ERROR, GS_PLUGIN_ERROR_NO_SPACE,
 			     _("You don’t have enough space to update these apps. Please remove apps or documents to create more space."));
 		return FALSE;

--- a/plugins/flatpak/gs-plugin-flatpak.c
+++ b/plugins/flatpak/gs-plugin-flatpak.c
@@ -989,7 +989,8 @@ gs_flatpak_has_space_to_update (GsFlatpak *flatpak, GsAppList *list, gboolean in
 
 			size_type = gs_app_get_size_installed (app_temp, &installed_size);
 
-			if (size_type == GS_SIZE_TYPE_VALID)
+			if (size_type == GS_SIZE_TYPE_VALID ||
+			    !gs_app_get_is_update_downloaded (app_temp))
 				space_required += installed_size;
 		}
 	}


### PR DESCRIPTION
Previously the code tried to not return an error to the user if
automatic updates failed in the background due to a lack of disk space.

However, by returning `TRUE` from `gs_plugin_flatpak_update()`, this
signalled success for the updates, which would result in a “123
Applications Updated” notification banner which was completely
incorrect.

Instead, it’s better to return an error, and then let the UI layer
determine whether to display that as a massive warning dialogue, a small
in-app warning notification, or not at all.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T33138