### PR TITLE
debian: Disable hardcoded webapps

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -43,7 +43,9 @@ GS_CONFIGURE_FLAGS += \
 	-Dmalcontent=true \
 	-Dmogwai=true \
 	-Dpackagekit=false \
-	-Dsoup2=true
+	-Dsoup2=true \
+	-Dhardcoded_foss_webapps=false \
+	-Dhardcoded_proprietary_webapps=false
 
 DISTRO_ID = debian
 FREE_REPOS = \'@DISTRO@-*-main\'


### PR DESCRIPTION
We're going to consume the current webapp lists into our own external appstream and don't want duplicates from the hard coded lists.

https://phabricator.endlessm.com/T34569
(cherry picked from commit 0e8949841daab47f395548885757baafbe63d50a)
https://phabricator.endlessm.com/T34678