### PR TITLE
debian: Enable fwupd plugin

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -37,7 +37,6 @@ endif
 GS_CONFIGURE_FLAGS += \
 	-Deos_updater=true \
 	-Dexternal_appstream=true \
-	-Dfwupd=false \
 	-Dgudev=false \
 	-Dhardcoded_curated=false \
 	-Dmalcontent=true \


### PR DESCRIPTION
fwupd is now going to be shipped in the OS (albeit with the UEFI capsule plugin disabled), so re-enable the g-s fwupd plugin. This can be squashed into 4cc430313 on the next rebase.

This depends on https://github.com/endlessm/eos-meta/pull/762. Marking as a draft until that's merged.

https://phabricator.endlessm.com/T29506