### PR TITLE
gs-app-context-bar: Hide the Safety and Hardware tiles

### DIFF
--- a/src/gs-app-context-bar.c
+++ b/src/gs-app-context-bar.c
@@ -586,7 +586,9 @@ update_hardware_support_tile (GsAppContextBar *self)
 	g_assert (self->app != NULL);
 
 	/* Don’t show the hardware support tile for non-desktop apps. */
-	if (!show_tile_for_non_applications (self, HARDWARE_SUPPORT_TILE))
+	// In Endless OS, the hardware support tile is hidden in all cases:
+	// <https://phabricator.endlessm.com/T35252>
+	if (true || !show_tile_for_non_applications (self, HARDWARE_SUPPORT_TILE))
 		return;
 
 	relations = gs_app_get_relations (self->app);

--- a/src/gs-app-context-bar.ui
+++ b/src/gs-app-context-bar.ui
@@ -68,6 +68,7 @@
 
         <child>
           <object class="GtkButton" id="safety_tile">
+            <property name="visible">false</property>
             <signal name="clicked" handler="tile_clicked_cb"/>
             <style>
               <class name="context-tile"/>
@@ -131,6 +132,7 @@
 
         <child>
           <object class="GtkButton" id="hardware_support_tile">
+            <property name="visible">false</property>
             <signal name="clicked" handler="tile_clicked_cb"/>
             <style>
               <class name="context-tile"/>


### PR DESCRIPTION
These tend to be either alarming or confusing for Endless OS users.

https://phabricator.endlessm.com/T35252