### PR TITLE
flatpak: Count all references to task in block_scheduler_schedule_cb

### DIFF
--- a/lib/gs-metered.c
+++ b/lib/gs-metered.c
@@ -224,7 +224,7 @@ block_scheduler_schedule_cb (GObject      *source_object,
                              gpointer      user_data)
 {
 	MwscScheduler *scheduler = MWSC_SCHEDULER (source_object);
-	g_autoptr(GTask) task = g_steal_pointer (&user_data);
+	g_autoptr(GTask) task = G_TASK (user_data);
 	GCancellable *cancellable = g_task_get_cancellable (task);
 	g_autoptr(MwscScheduleEntry) schedule_entry = NULL;
 	g_autoptr(BlockData) data = NULL;
@@ -240,11 +240,11 @@ block_scheduler_schedule_cb (GObject      *source_object,
 	data = g_new0 (BlockData, 1);
 	data->schedule_entry = g_object_ref (schedule_entry);
 	data->notify_id = g_signal_connect_object (schedule_entry, "notify::download-now",
-						   (GCallback) download_now_cb, task, G_CONNECT_DEFAULT);
+						   G_CALLBACK (download_now_cb), task, G_CONNECT_DEFAULT);
 	data->invalidated_id = g_signal_connect_object (schedule_entry, "invalidated",
-							(GCallback) invalidated_cb, task, G_CONNECT_DEFAULT);
+							G_CALLBACK (invalidated_cb), task, G_CONNECT_DEFAULT);
 	data->cancelled_id = g_cancellable_connect (cancellable,
-						    (GCallback) cancelled_cb, task, (GDestroyNotify) g_object_unref);
+						    G_CALLBACK (cancelled_cb), g_object_ref (task), g_object_unref);
 	g_task_set_task_data (task, g_steal_pointer (&data), (GDestroyNotify) block_data_free);
 
 	/* Do the initial check. */
@@ -275,9 +275,11 @@ cancelled_cb (GCancellable *cancellable,
 }
 
 static void
-block_check_cb (GTask        *task,
+block_check_cb (GTask        *task_unowned,
                 const GError *invalidated_error)
 {
+	g_autoptr(GTask) task = g_object_ref (task_unowned);
+
 	BlockData *data = g_task_get_task_data (task);
 	GCancellable *cancellable = g_task_get_cancellable (task);
 	gboolean download_now = FALSE;


### PR DESCRIPTION
In `block_scheduler_schedule_cb`, a `GCancellable::cancelled` signal handler was connected to a tasks's cancellable, with a pointer to the task itself as data. However, this was done without incrementing the reference count for the task, resulting in an error due to the task being prematurely freed when `g_cancellable_disconnect` was called.

In addition to handling that case, we will change `block_check_cb` to increment the task's reference count while it is in use.

https://phabricator.endlessm.com/T35306